### PR TITLE
feat(macos): tap cmux cask repository before install

### DIFF
--- a/install/macos/common/misc.sh
+++ b/install/macos/common/misc.sh
@@ -19,8 +19,13 @@ readonly BREW_PACKAGES=(
     watchexec
 )
 
+readonly BREW_TAPS=(
+    manaflow-ai/cmux
+)
+
 readonly CASK_PACKAGES=(
     adobe-acrobat-reader
+    cmux
     cyberduck
     google-chrome
     google-drive
@@ -53,6 +58,40 @@ function is_brew_package_installed() {
     local package="$1"
 
     brew list "${package}" &> /dev/null
+}
+
+#
+# @description Check whether a brew tap is already configured.
+# @arg $1 string Tap name.
+#
+function is_brew_tap_installed() {
+    local tap="$1"
+
+    brew tap | grep --fixed-strings --line-regexp --quiet "${tap}"
+}
+
+#
+# @description Install every missing tap from `BREW_TAPS` unless running in CI.
+#
+function install_brew_taps() {
+    if "${CI:-false}"; then
+        return 0
+    fi
+
+    local missing_taps=()
+    local tap
+
+    for tap in "${BREW_TAPS[@]}"; do
+        if ! is_brew_tap_installed "${tap}"; then
+            missing_taps+=("${tap}")
+        fi
+    done
+
+    if [[ ${#missing_taps[@]} -gt 0 ]]; then
+        for tap in "${missing_taps[@]}"; do
+            brew tap "${tap}"
+        done
+    fi
 }
 
 #
@@ -159,6 +198,7 @@ function setup_google_chrome() {
 # @description Install the configured optional macOS packages and casks.
 #
 function main() {
+    install_brew_taps
     install_brew_packages
     install_brew_cask_packages
     install_additional_brew_packages

--- a/tests/install/macos/common/misc.bats
+++ b/tests/install/macos/common/misc.bats
@@ -37,6 +37,21 @@ function setup() {
     # because of the time it takes to install the cask packages.
 }
 
+@test "[macos] misc includes cmux tap" {
+    run bash -lc 'source "'"${SCRIPT_PATH}"'"; [ "${#BREW_TAPS[@]}" -eq 1 ] && [ "${BREW_TAPS[0]}" = "manaflow-ai/cmux" ]'
+    [ "${status}" -eq 0 ]
+}
+
+@test "[macos] misc defines tap helpers" {
+    run bash -lc 'source "'"${SCRIPT_PATH}"'"; [ "$(type -t is_brew_tap_installed)" = "function" ] && [ "$(type -t install_brew_taps)" = "function" ]'
+    [ "${status}" -eq 0 ]
+}
+
+@test "[macos] install_brew_taps skips in ci" {
+    run bash -lc 'source "'"${SCRIPT_PATH}"'"; CI=true install_brew_taps'
+    [ "${status}" -eq 0 ]
+}
+
 @test "[macos] install_additional_brew_packages installs tailscale only for shunk031" {
     local calls_path="${BATS_TEST_TMPDIR}/additional_brew_calls.txt"
     : > "${calls_path}"


### PR DESCRIPTION
## Summary
- add `BREW_TAPS` and tap helper functions to `install/macos/common/misc.sh`
- install the `manaflow-ai/cmux` tap before cask installation so `cmux` can be installed reliably
- keep the existing tailscale tests and add lightweight coverage for tap configuration and CI skip behavior

## Test
- `bash -n install/macos/common/misc.sh`
- `bash -lc 'source ./install/macos/common/misc.sh; [ "${#BREW_TAPS[@]}" -eq 1 ] && [ "${BREW_TAPS[0]}" = "manaflow-ai/cmux" ]'`
- `bash -lc 'source ./install/macos/common/misc.sh; [ "$(type -t is_brew_tap_installed)" = "function" ] && [ "$(type -t install_brew_taps)" = "function" ]'`
- `bash -lc 'source ./install/macos/common/misc.sh; CI=true install_brew_taps'`