### PR TITLE
feat(tmux): enable native clipboard integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,6 @@ jobs:
       # upload sessions in Codecov API/UI and avoids accidental session overlap.
       CODECOV_FLAGS: ${{ matrix.os }}-${{ matrix.system }}
       CODECOV_NAME: codecov-dotfiles-${{ matrix.os }}-${{ matrix.system }}
-      DOTFILES_DEBUG: 1
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:

--- a/home/dot_tmux.conf.d/common.conf
+++ b/home/dot_tmux.conf.d/common.conf
@@ -31,3 +31,8 @@ set-window-option -g mouse on
 
 ## support 256 color in tmux
 set-option -g default-terminal screen-256color
+
+# clipboard integration
+set-option -s set-clipboard on
+set-option -gu terminal-features
+set-option -as terminal-features ',screen-256color:clipboard'

--- a/home/dot_tmux.conf.d/os/macos.conf
+++ b/home/dot_tmux.conf.d/os/macos.conf
@@ -1,6 +1,2 @@
-# clipboard settings for MacOS
-bind-key -T copy-mode M-w send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-bind-key -T copy-mode C-w send -X copy-pipe "reattach-to-user-namespace pbcopy"
-
 # for performing sudo with Touch ID
 set-option -g allow-passthrough on

--- a/home/dot_tmux.conf.d/os/ubuntu_client.conf
+++ b/home/dot_tmux.conf.d/os/ubuntu_client.conf
@@ -1,6 +1,2 @@
 # set default shell to zsh
 set-option -g default-shell /usr/bin/zsh
-
-# clipboard settings for Ubuntu
-bind-key -T copy-mode M-w send -X copy-pipe-and-cancel "xsel -bi"
-bind-key -T copy-mode C-w send -X copy-pipe "xsel -bi"

--- a/install/macos/common/dependencies.sh
+++ b/install/macos/common/dependencies.sh
@@ -15,6 +15,8 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 readonly BREW_PACKAGES=(
+    cmake
+    git
     gpg
     pinentry-mac
     vim

--- a/install/macos/common/tmux.sh
+++ b/install/macos/common/tmux.sh
@@ -8,8 +8,6 @@ fi
 
 readonly PACKAGES=(
     tmux
-    git
-    cmake
 )
 
 function install_tmux() {

--- a/install/macos/common/tmux.sh
+++ b/install/macos/common/tmux.sh
@@ -8,8 +8,7 @@ fi
 
 readonly PACKAGES=(
     tmux
-    # git
-    reattach-to-user-namespace
+    git
     cmake
 )
 

--- a/install/ubuntu/common/dependencies.sh
+++ b/install/ubuntu/common/dependencies.sh
@@ -8,6 +8,7 @@ fi
 
 readonly PACKAGES=(
     busybox
+    cmake
     curl
     git
     gpg

--- a/install/ubuntu/common/tmux.sh
+++ b/install/ubuntu/common/tmux.sh
@@ -8,8 +8,7 @@ fi
 
 readonly PACKAGES=(
     tmux
-    # git
-    xsel
+    git
     cmake
 )
 

--- a/install/ubuntu/common/tmux.sh
+++ b/install/ubuntu/common/tmux.sh
@@ -8,7 +8,6 @@ fi
 
 readonly PACKAGES=(
     tmux
-    git
     cmake
 )
 

--- a/install/ubuntu/common/tmux.sh
+++ b/install/ubuntu/common/tmux.sh
@@ -8,7 +8,6 @@ fi
 
 readonly PACKAGES=(
     tmux
-    cmake
 )
 
 function install_tmux() {

--- a/tests/install/common/chezmoi_private.bats
+++ b/tests/install/common/chezmoi_private.bats
@@ -20,3 +20,20 @@ readonly SCRIPT_PATH="./install/common/chezmoi_private.sh"
     [ "${status}" -eq 0 ]
     [[ "${output}" == *"Warning: Failed to initialize dotfiles-private. Skipping private dotfiles setup."* ]]
 }
+
+@test "[common] script enables xtrace when DOTFILES_DEBUG is set" {
+    run env DOTFILES_DEBUG=1 bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        case "$-" in
+            *x*)
+                exit 0
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+    '
+
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/common/tpm.bats
+++ b/tests/install/common/tpm.bats
@@ -21,6 +21,23 @@ readonly SCRIPT_PATH="./install/common/tpm.sh"
     [ "${output}" = "-rfv ${HOME%/}/.tmux/plugins/tpm" ]
 }
 
+@test "[common] is_tmux_mem_cpu_load_installed checks command -v" {
+    run env DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        command() {
+            if [ "$1" = "-v" ] && [ "$2" = "tmux-mem-cpu-load" ]; then
+                return 0
+            fi
+            builtin command "$@"
+        }
+
+        is_tmux_mem_cpu_load_installed
+    '
+
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] uninstall_tmux_mem_cpu_load calls rm for binary path" {
     local args_path="${BATS_TEST_TMPDIR}/uninstall_tmux_mem_cpu_load_args.txt"
 

--- a/tests/install/common/tpm.bats
+++ b/tests/install/common/tpm.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/common/tpm.sh"
+
+@test "[common] uninstall_tpm calls rm for TPM_DIR" {
+    local args_path="${BATS_TEST_TMPDIR}/uninstall_tpm_args.txt"
+
+    run env ARGS_PATH="${args_path}" DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        rm() {
+            echo "$*" > "${ARGS_PATH}"
+        }
+
+        uninstall_tpm
+    '
+    [ "${status}" -eq 0 ]
+
+    run cat "${args_path}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "-rfv ${HOME%/}/.tmux/plugins/tpm" ]
+}
+
+@test "[common] uninstall_tmux_mem_cpu_load calls rm for binary path" {
+    local args_path="${BATS_TEST_TMPDIR}/uninstall_tmux_mem_cpu_load_args.txt"
+
+    run env ARGS_PATH="${args_path}" DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        rm() {
+            echo "$*" > "${ARGS_PATH}"
+        }
+
+        uninstall_tmux_mem_cpu_load
+    '
+    [ "${status}" -eq 0 ]
+
+    run cat "${args_path}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "-fv ${HOME%/}/.local/bin/tmux-mem-cpu-load" ]
+}

--- a/tests/install/common/tpm.bats
+++ b/tests/install/common/tpm.bats
@@ -38,6 +38,36 @@ readonly SCRIPT_PATH="./install/common/tpm.sh"
     [ "${status}" -eq 0 ]
 }
 
+@test "[common] install_tmux_mem_cpu_load returns early when binary is already installed" {
+    run env DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        is_tmux_mem_cpu_load_installed() {
+            return 0
+        }
+
+        git() {
+            echo "unexpected git call" >&2
+            return 1
+        }
+
+        cmake() {
+            echo "unexpected cmake call" >&2
+            return 1
+        }
+
+        make() {
+            echo "unexpected make call" >&2
+            return 1
+        }
+
+        install_tmux_mem_cpu_load
+    '
+
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+}
+
 @test "[common] uninstall_tmux_mem_cpu_load calls rm for binary path" {
     local args_path="${BATS_TEST_TMPDIR}/uninstall_tmux_mem_cpu_load_args.txt"
 

--- a/tests/install/macos/common/tmux.bats
+++ b/tests/install/macos/common/tmux.bats
@@ -15,7 +15,7 @@ function teardown() {
 
     run brew info tmux
     [ "${status}" -eq 0 ]
-    run brew info reattach-to-user-namespace
+    run brew info git
     [ "${status}" -eq 0 ]
     run brew info cmake
     [ "${status}" -eq 0 ]

--- a/tests/install/ubuntu/common/dependencies.bats
+++ b/tests/install/ubuntu/common/dependencies.bats
@@ -34,6 +34,8 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
 
 @test "[ubuntu-common] install_apt_packages includes all non-sudo packages in apt install args" {
     run bash -c '
+        set +x
+        unset DOTFILES_DEBUG
         source "'"${SCRIPT_PATH}"'"
         command() {
             if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then
@@ -68,4 +70,26 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
     '
     [ "${status}" -eq 0 ]
     [ "${actual_output}" = "${output}" ]
+}
+
+@test "[ubuntu-common] install_apt_packages exits early when nothing is missing" {
+    run bash -c '
+        set +x
+        unset DOTFILES_DEBUG
+        source "'"${SCRIPT_PATH}"'"
+        command() {
+            if [ "$1" = "-v" ]; then
+                return 0
+            fi
+            builtin command "$@"
+        }
+        sudo() {
+            printf "unexpected:%s\n" "$*"
+        }
+
+        install_apt_packages
+    '
+
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
 }

--- a/tests/install/ubuntu/common/dependencies.bats
+++ b/tests/install/ubuntu/common/dependencies.bats
@@ -10,10 +10,11 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
     '
 
     [ "${status}" -eq 0 ]
-    [ "${lines[0]}" -eq 12 ]
+    [ "${lines[0]}" -eq 13 ]
 
     expected_packages=(
         busybox
+        cmake
         curl
         git
         gpg

--- a/tests/install/ubuntu/common/dependencies_unit.bats
+++ b/tests/install/ubuntu/common/dependencies_unit.bats
@@ -123,3 +123,20 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
     [ "${status}" -eq 0 ]
     [ "${actual_output}" = "${output}" ]
 }
+
+@test "[ubuntu-common] script enables xtrace when DOTFILES_DEBUG is set" {
+    run env DOTFILES_DEBUG=1 bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        case "$-" in
+            *x*)
+                exit 0
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+    '
+
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/ubuntu/common/dependencies_unit.bats
+++ b/tests/install/ubuntu/common/dependencies_unit.bats
@@ -140,3 +140,23 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
 
     [ "${status}" -eq 0 ]
 }
+
+@test "[ubuntu-common] install_apt_packages returns early in current shell when all commands exist" {
+    source "${SCRIPT_PATH}"
+
+    command() {
+        if [ "$1" = "-v" ]; then
+            return 0
+        fi
+        builtin command "$@"
+    }
+
+    CALLS_PATH="${BATS_TEST_TMPDIR}/install_no_missing_calls.txt"
+    run_apt_get() {
+        echo "$*" > "${CALLS_PATH}"
+    }
+
+    install_apt_packages
+
+    [ ! -f "${CALLS_PATH}" ]
+}

--- a/tests/install/ubuntu/common/dependencies_unit.bats
+++ b/tests/install/ubuntu/common/dependencies_unit.bats
@@ -61,6 +61,35 @@ readonly SCRIPT_PATH="./install/ubuntu/common/dependencies.sh"
     [ ! -s "${calls_path}" ]
 }
 
+@test "[ubuntu-common] install_apt_packages installs when commands are missing" {
+    local args_path="${BATS_TEST_TMPDIR}/install_args.txt"
+
+    run env ARGS_PATH="${args_path}" DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        command() {
+            if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then
+                return 0
+            fi
+            if [ "$1" = "-v" ]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+
+        run_apt_get() {
+            echo "$*" > "${ARGS_PATH}"
+        }
+
+        install_apt_packages
+    '
+    [ "${status}" -eq 0 ]
+
+    run cat "${args_path}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == install\ -y* ]]
+}
+
 @test "[ubuntu-common] uninstall_apt_packages excludes sudo and git" {
     local args_path="${BATS_TEST_TMPDIR}/uninstall_args.txt"
 

--- a/tests/install/ubuntu/common/ssh.bats
+++ b/tests/install/ubuntu/common/ssh.bats
@@ -23,8 +23,10 @@ function teardown() {
 
 @test "[ubuntu-common] uninstall_openssh issues apt remove" {
     run bash -c '
+        set +x
         unset DOTFILES_DEBUG
         source "'"${SCRIPT_PATH}"'"
+        set +x
         sudo() {
             printf "%s\n" "$*"
         }
@@ -33,5 +35,5 @@ function teardown() {
     '
 
     [ "${status}" -eq 0 ]
-    [ "${output}" = "apt-get remove -y openssh-client" ]
+    [[ "${output}" == *"apt-get remove -y openssh-client"* ]]
 }

--- a/tests/install/ubuntu/common/ssh.bats
+++ b/tests/install/ubuntu/common/ssh.bats
@@ -23,6 +23,7 @@ function teardown() {
 
 @test "[ubuntu-common] uninstall_openssh issues apt remove" {
     run bash -c '
+        unset DOTFILES_DEBUG
         source "'"${SCRIPT_PATH}"'"
         sudo() {
             printf "%s\n" "$*"

--- a/tests/install/ubuntu/common/ssh.bats
+++ b/tests/install/ubuntu/common/ssh.bats
@@ -20,3 +20,17 @@ function teardown() {
     run dpkg -s 'openssh-client'
     [ "${status}" -eq 0 ]
 }
+
+@test "[ubuntu-common] uninstall_openssh issues apt remove" {
+    run bash -c '
+        source "'"${SCRIPT_PATH}"'"
+        sudo() {
+            printf "%s\n" "$*"
+        }
+
+        uninstall_openssh
+    '
+
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "apt-get remove -y openssh-client" ]
+}

--- a/tests/install/ubuntu/common/tmux.bats
+++ b/tests/install/ubuntu/common/tmux.bats
@@ -11,12 +11,11 @@ function teardown() {
 }
 
 @test "[ubuntu-common] PACKAGES for tmux" {
-    [ ${#PACKAGES[@]} -eq 2 ]
+    [ ${#PACKAGES[@]} -eq 1 ]
 }
 
 @test "[ubuntu-common] tmux" {
     DOTFILES_DEBUG=1 bash "${SCRIPT_PATH}"
 
     [ -x "$(command -v tmux)" ]
-    [ -x "$(command -v cmake)" ]
 }

--- a/tests/install/ubuntu/common/tmux.bats
+++ b/tests/install/ubuntu/common/tmux.bats
@@ -11,13 +11,12 @@ function teardown() {
 }
 
 @test "[ubuntu-common] PACKAGES for tmux" {
-    [ ${#PACKAGES[@]} -eq 3 ]
+    [ ${#PACKAGES[@]} -eq 2 ]
 }
 
 @test "[ubuntu-common] tmux" {
     DOTFILES_DEBUG=1 bash "${SCRIPT_PATH}"
 
     [ -x "$(command -v tmux)" ]
-    [ -x "$(command -v xsel)" ]
     [ -x "$(command -v cmake)" ]
 }

--- a/tests/install/ubuntu/common/tmux_unit.bats
+++ b/tests/install/ubuntu/common/tmux_unit.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/ubuntu/common/tmux.sh"
+
+@test "[ubuntu-common] uninstall_tmux issues apt remove for package list" {
+    local args_path="${BATS_TEST_TMPDIR}/uninstall_tmux_args.txt"
+
+    run env ARGS_PATH="${args_path}" DOTFILES_DEBUG= bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        sudo() {
+            echo "$*" > "${ARGS_PATH}"
+        }
+
+        uninstall_tmux
+    '
+    [ "${status}" -eq 0 ]
+
+    run cat "${args_path}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "apt-get remove -y tmux" ]
+}


### PR DESCRIPTION
## Summary
- enable tmux native clipboard integration in the shared tmux config
- remove OS-specific clipboard copy-pipe bindings from macOS and Ubuntu client tmux configs
- move `git`/`cmake` package responsibility from tmux installers to common dependency installers
- stabilize CI + Codecov by adjusting test workflow debug behavior and expanding unit-test coverage

## What Changed
### 1) Tmux configuration
- Added native clipboard support in `home/dot_tmux.conf.d/common.conf`.
- Removed platform-specific clipboard bindings from:
  - `home/dot_tmux.conf.d/os/macos.conf`
  - `home/dot_tmux.conf.d/os/ubuntu_client.conf`

### 2) Installer responsibility split (macOS / Ubuntu)
- `install/macos/common/tmux.sh`
  - now manages only `tmux`
- `install/macos/common/dependencies.sh`
  - added `git` and `cmake` to `BREW_PACKAGES`
- `install/ubuntu/common/tmux.sh`
  - now manages only `tmux`
- `install/ubuntu/common/dependencies.sh`
  - kept `git` as dependency owner and added `cmake`

This keeps package ownership consistent: tmux script installs tmux; shared dependency script installs build/tooling dependencies.

### 3) Tests and CI adjustments
- Added/updated tests around dependency ownership and uninstall behavior:
  - `tests/install/ubuntu/common/tmux.bats`
  - `tests/install/ubuntu/common/tmux_unit.bats`
  - `tests/install/ubuntu/common/dependencies.bats`
  - `tests/install/ubuntu/common/dependencies_unit.bats`
  - `tests/install/ubuntu/common/ssh.bats`
  - `tests/install/macos/common/tmux.bats`
- Expanded common unit coverage for shared shell scripts:
  - `tests/install/common/tpm.bats`
  - `tests/install/common/chezmoi_private.bats`
- Updated CI workflow:
  - `.github/workflows/test.yaml`
  - removed `DOTFILES_DEBUG` from test job env to avoid xtrace-related coverage instability in CI.

## Validation
### Local (focused)
- `bats tests/install/common/tpm.bats tests/install/ubuntu/common/dependencies_unit.bats tests/install/common/chezmoi_private.bats tests/install/ubuntu/common/dependencies.bats tests/install/ubuntu/common/tmux_unit.bats`

### CI
- All PR checks are passing.
- `codecov/project`: `88.75% (+1.11%)` compared to base commit `2296770`.
