### PR TITLE
docs(skill): clarify gh-first PR description maintenance

### DIFF
--- a/home/dot_agents/skills/gh-first-workflow/SKILL.md
+++ b/home/dot_agents/skills/gh-first-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-first-workflow
-description: Enforce gh-first GitHub investigation and Conventional Commit output rules. Use when investigating GitHub issues or pull requests, summarizing investigation results, or preparing commit messages.
+description: Enforce gh-first GitHub investigation, pull request maintenance, and Conventional Commit output rules. Use when investigating GitHub issues or pull requests, creating or updating pull requests, summarizing investigation results, or preparing commit messages.
 ---
 
 # GH-First Workflow
@@ -8,6 +8,7 @@ description: Enforce gh-first GitHub investigation and Conventional Commit outpu
 ## Overview
 
 Use this workflow to keep GitHub investigation and commit output consistent with repository policy.
+For pull requests, keep the description aligned with the full current PR contents, not just the latest delta.
 
 ## Read Acknowledgement
 
@@ -18,14 +19,17 @@ Use this workflow to keep GitHub investigation and commit output consistent with
 1. Start issue/PR investigation with `gh` commands.
 2. Use `web` only when `gh` cannot provide required details.
 3. Collect URLs for every issue/PR that was inspected.
-4. Include inspected URLs in the response.
-5. Write commit messages in Conventional Commit format.
+4. When creating a PR, write the PR description as a summary of the full PR.
+5. If additional commits are pushed after PR creation, inspect the updated commits/diff with `gh` and refresh the PR description so it reflects the full current PR, not only the latest increment.
+6. Include inspected URLs in the response.
+7. Write commit messages in Conventional Commit format.
 
 ## Output Checklist
 
 - State that `gh` was used first.
 - State why `web` was used when fallback was necessary.
 - Include inspected issue/PR URLs.
+- When commits were added after PR creation, confirm the PR description was updated to match the full current PR.
 - Keep commit subject in Conventional Commit form: `<type>(<scope>): <summary>`.
 
 Use [gh-git-rules.md](references/gh-git-rules.md) for command examples and commit-type guidance.

--- a/home/dot_agents/skills/gh-first-workflow/agents/openai.yaml
+++ b/home/dot_agents/skills/gh-first-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "GH-First Workflow"
-  short_description: "Use gh-first issue/PR research and Conventional Commits"
-  default_prompt: "Use this when investigating GitHub issues/PRs and when writing commit messages."
+  short_description: "Use gh-first PR research, upkeep, and Conventional Commits"
+  default_prompt: "Use $gh-first-workflow to investigate a GitHub issue/PR, maintain the PR description, and write a Conventional Commit message."


### PR DESCRIPTION
## Summary
- clarify that gh-first-workflow covers creating and updating pull requests
- require refreshing the PR description after additional commits so it reflects the full current PR
- align the skill UI metadata with the PR maintenance workflow

## Testing
- not run (documentation-only change)
