### PR TITLE
fix(macos): install tailscale only for shunk031 via homebrew

### DIFF
--- a/home/dot_config/sheldon/plugin_sources/client/macos.toml
+++ b/home/dot_config/sheldon/plugin_sources/client/macos.toml
@@ -31,11 +31,3 @@ function _macos_browser() {
 }
 zsh-defer _macos_browser
 '''
-
-[plugins.macos-command]
-inline = '''
-function _macos_command() {
-    alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
-}
-zsh-defer _macos_command
-'''

--- a/install/macos/common/mac_app_store.sh
+++ b/install/macos/common/mac_app_store.sh
@@ -41,18 +41,12 @@ function install_xcode() {
     run_mas_install "${app_id}"
 }
 
-function install_tailscale() {
-    local app_id="1475387142"
-    run_mas_install "${app_id}"
-}
-
 function main() {
     install_mas
 
     if ! "${CI:-false}"; then
         install_bandwidth_plus
         install_line
-        install_tailscale
         # install_1password7
         # install_xcode
     fi

--- a/install/macos/common/misc.sh
+++ b/install/macos/common/misc.sh
@@ -37,7 +37,7 @@ readonly CASK_PACKAGES=(
     1password
 )
 
-# Additional brew packages that I want to install on my personal computer but not on my work computer
+# Additional brew packages installed only for user shunk031.
 readonly ADDITIONAL_BREW_PACKAGES=(
     tailscale
 )
@@ -90,7 +90,7 @@ function install_brew_cask_packages() {
 }
 
 function install_additional_brew_packages() {
-    # Only install additional brew packages for user shunk031
+    # Restrict personal packages to the primary user account.
     if [[ "$(whoami)" != "shunk031" ]]; then
         return 0
     fi

--- a/tests/install/macos/common/mac_app_store.bats
+++ b/tests/install/macos/common/mac_app_store.bats
@@ -18,3 +18,30 @@ function setup() {
     # run 'mas list | grep Bandwidth'
     # [ "${status}" -eq 0 ]
 }
+
+@test "[macos] mac app store installs configured apps without tailscale" {
+    local calls_path="${BATS_TEST_TMPDIR}/mas_calls.txt"
+    : > "${calls_path}"
+
+    run env CALLS_PATH="${calls_path}" CI=false bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        install_mas() {
+            :
+        }
+
+        mas() {
+            echo "$*" >> "${CALLS_PATH}"
+        }
+
+        main
+    '
+
+    [ "${status}" -eq 0 ]
+
+    run cat "${calls_path}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"install 490461369"* ]]
+    [[ "${output}" == *"install 539883307"* ]]
+    [[ "${output}" != *"1475387142"* ]]
+}

--- a/tests/install/macos/common/misc.bats
+++ b/tests/install/macos/common/misc.bats
@@ -36,3 +36,58 @@ function setup() {
     # Currently, we do not run this test on CI
     # because of the time it takes to install the cask packages.
 }
+
+@test "[macos] install_additional_brew_packages installs tailscale only for shunk031" {
+    local calls_path="${BATS_TEST_TMPDIR}/additional_brew_calls.txt"
+    : > "${calls_path}"
+
+    run env CALLS_PATH="${calls_path}" CI=false bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        whoami() {
+            echo "shunk031"
+        }
+
+        is_brew_package_installed() {
+            return 1
+        }
+
+        brew() {
+            echo "$*" >> "${CALLS_PATH}"
+        }
+
+        install_additional_brew_packages
+    '
+
+    [ "${status}" -eq 0 ]
+
+    run cat "${calls_path}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "install --force tailscale" ]
+}
+
+@test "[macos] install_additional_brew_packages skips tailscale for other users" {
+    local calls_path="${BATS_TEST_TMPDIR}/additional_brew_calls_other_user.txt"
+    : > "${calls_path}"
+
+    run env CALLS_PATH="${calls_path}" CI=false bash -c '
+        source "'"${SCRIPT_PATH}"'"
+
+        whoami() {
+            echo "s.kitada"
+        }
+
+        is_brew_package_installed() {
+            return 1
+        }
+
+        brew() {
+            echo "$*" >> "${CALLS_PATH}"
+        }
+
+        install_additional_brew_packages
+    '
+
+    [ "${status}" -eq 0 ]
+    [ ! -s "${calls_path}" ]
+}


### PR DESCRIPTION
## Summary
- remove the Mac App Store Tailscale install path so macOS setup uses Homebrew as the only Tailscale source
- keep Tailscale restricted to the `shunk031` user in `install/macos/common/misc.sh`
- remove the stale Tailscale app-bundle alias and add tests that pin the MAS and user-gated Homebrew behavior

## Testing
- `bash -n install/macos/common/mac_app_store.sh`
- `bash -n install/macos/common/misc.sh`
- `env CI=false bash -c 'source ./install/macos/common/mac_app_store.sh; install_mas(){ :; }; mas(){ echo "$*"; }; main'`
- `env CI=false bash -c 'source ./install/macos/common/misc.sh; whoami(){ echo shunk031; }; is_brew_package_installed(){ return 1; }; brew(){ echo "$*"; }; install_additional_brew_packages'`
- `env CI=false bash -c 'source ./install/macos/common/misc.sh; whoami(){ echo s.kitada; }; is_brew_package_installed(){ return 1; }; brew(){ echo "$*"; }; install_additional_brew_packages'`
- local `bats` was not run per repository policy
