### PR TITLE
feat(docs): add generated MkDocs docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,20 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
         with:
-          install: true
+          install: false
           cache: true
+
+      - name: Trust mise config
+        run: mise trust --yes
+
+      - name: Install shdoc plugin
+        run: |
+          if ! mise plugins ls | grep -qx shdoc; then
+            mise plugins install shdoc https://github.com/shunk031/mise-shdoc.git
+          fi
+
+      - name: Install mise tools
+        run: mise install
 
       - name: Configure git author
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/docs.yml"
+      - "Makefile"
+      - "README.md"
+      - "mkdocs.yml"
+      - "scripts/**"
+      - "install/**"
+      - "home/.chezmoiscripts/**"
+      - "home/dot_claude/hooks/**"
+      - "home/dot_config/alias/**"
+      - "home/dot_local/bin/**"
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+        with:
+          install: true
+          cache: true
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs
+        run: make deploy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,9 @@ jobs:
           if [ "${OS}" == "macos-14" ]; then
             # `bashcov` on macOS must use Homebrew Bash (>=5) to avoid the
             # system Bash 3.2 parser limitations that produced empty coverage.
-            brew install bash bats-core parallel
+            # `shdoc` is installed through a custom mise plugin that shells out
+            # to `gawk` during post-install on macOS.
+            brew install bash bats-core gawk parallel
 
           elif [ "${OS}" == "ubuntu-latest" ]; then
             # Ruby is required for bashcov/simplecov formatters.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 benchmarks/results
 coverage*
+docs/index.md
+docs/catalog.md
+docs/reference/
+site/
 
-docs/codex/
+.docs/codex/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 - After reading this `AGENTS.md`, say: `🤖 I read the AGENTS.md for shunk031/dotfiles.`
 
+## Comment Policy
+
+- When adding or updating comments for shell scripts or shell-based executables, always write them in English using shdoc-compatible format.
+
 ## Git / PR Workflow
 
 - When you are asked to create a branch, commit, or pull request and the current worktree contains unrelated staged, unstaged, or untracked changes, prefer creating a separate `git worktree` from the default branch.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ DOCKER_IMAGE_NAME=dotfiles
 DOCKER_ARCH=x86_64
 DOCKER_NUM_CPU=4
 DOKCER_RAM_GB=4
+HOST ?= 127.0.0.1
+PORT ?= 8000
+MKDOCS = uv run \
+	--with mkdocs \
+	--with mkdocs-material \
+	--with mkdocs-toc-md \
+	mkdocs
 
 #
 # Docker
@@ -44,3 +51,32 @@ reset-config:
 .PHONY: format
 format:
 	shfmt --indent 4 --space-redirects --diff .
+
+#
+# Documentation
+#
+
+.PHONY: docs
+docs:
+	@echo "==> Generating docs"
+	./scripts/generate-docs.sh
+	@echo "==> Refreshing TOC"
+	$(MKDOCS) build --clean
+	@echo "==> Building docs"
+	$(MKDOCS) build --clean --strict
+
+.PHONY: serve
+serve: docs
+	@echo "==> Serving docs"
+	$(MKDOCS) serve -a $(HOST):$(PORT)
+
+.PHONY: deploy
+deploy: docs
+	@echo "==> Deploying docs"
+	$(MKDOCS) gh-deploy --force
+
+.PHONY: clean
+clean:
+	@echo "==> Cleaning generated docs"
+	rm -rf docs/reference site
+	rm -f docs/index.md docs/catalog.md

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ bash install/macos/common/docker.sh
 
 Each installation script can be found under the [`./install`](https://github.com/shunk031/dotfiles/tree/master/install) directory.
 
+## 📚 Documentation
+
+This repository can generate a temporary MkDocs site from the shell-based setup assets.
+The generated Markdown lives under `docs/reference/`, `docs/index.md` is regenerated as a landing page, `docs/catalog.md` is regenerated as the full catalog, and internal Codex working notes live under `.docs/codex/` so they are not published.
+
+```shell
+make docs
+make serve
+make serve PORT=8001
+make deploy
+```
+
+- `make docs`: generate Markdown with `shdoc` (falling back to source-based pages when needed) and rebuild the site.
+- `make serve`: preview the generated site locally with MkDocs on `127.0.0.1:8000` by default.
+- `make serve PORT=8001`: preview the site on a different local port when `8000` is already in use.
+- `make deploy`: publish the current generated site to the `gh-pages` branch.
+
 ## 🛠️ Update & Test 🧪
 
 Updating and testing the dotfiles follows [chezmoi's daily operations](https://www.chezmoi.io/user-guide/daily-operations/).

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,0 +1,225 @@
+:root {
+    --landing-ink: #10233b;
+    --landing-muted: #5d6c7d;
+    --landing-border: rgba(16, 35, 59, 0.12);
+    --landing-surface: rgba(255, 255, 255, 0.9);
+    --landing-surface-strong: #f5f9ff;
+    --landing-accent: #0f766e;
+    --landing-accent-strong: #2563eb;
+    --landing-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+}
+
+.md-content .landing-hero {
+    position: relative;
+    overflow: hidden;
+    margin: 0 0 1.5rem;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    border: 1px solid var(--landing-border);
+    border-radius: 28px;
+    background:
+        radial-gradient(circle at top right, rgba(37, 99, 235, 0.18), transparent 34%),
+        radial-gradient(circle at left center, rgba(15, 118, 110, 0.12), transparent 28%),
+        linear-gradient(140deg, #fbfdff 0%, #eef6ff 55%, #f8fbff 100%);
+    box-shadow: var(--landing-shadow);
+}
+
+.md-content .landing-hero::before,
+.md-content .landing-hero::after {
+    content: "";
+    position: absolute;
+    border-radius: 999px;
+    filter: blur(6px);
+    opacity: 0.7;
+}
+
+.md-content .landing-hero::before {
+    top: -6rem;
+    right: -4rem;
+    width: 14rem;
+    height: 14rem;
+    background: radial-gradient(circle, rgba(37, 99, 235, 0.2) 0%, transparent 65%);
+}
+
+.md-content .landing-hero::after {
+    bottom: -7rem;
+    left: -5rem;
+    width: 16rem;
+    height: 16rem;
+    background: radial-gradient(circle, rgba(15, 118, 110, 0.18) 0%, transparent 60%);
+}
+
+.md-content .landing-hero > * {
+    position: relative;
+    z-index: 1;
+}
+
+.md-content .landing-hero__eyebrow {
+    margin: 0 0 0.75rem;
+    color: var(--landing-accent);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.md-content .landing-hero h1 {
+    margin: 0;
+    color: var(--landing-ink);
+    font-size: clamp(2.2rem, 6vw, 3.7rem);
+    line-height: 1.02;
+    letter-spacing: -0.04em;
+}
+
+.md-content .landing-hero p:last-of-type {
+    max-width: 48rem;
+    margin-top: 1rem;
+    color: var(--landing-muted);
+    font-size: 1.05rem;
+}
+
+.md-content .landing-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.md-content .landing-actions .md-button {
+    margin: 0;
+    border-radius: 999px;
+}
+
+.md-content .landing-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.9rem;
+    margin: 0 0 2rem;
+}
+
+.md-content .landing-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-height: 8.5rem;
+    padding: 1rem 1rem 1.1rem;
+    border: 1px solid var(--landing-border);
+    border-radius: 22px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 250, 255, 0.92) 100%);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.05);
+}
+
+.md-content .landing-stat__value {
+    color: var(--landing-ink);
+    font-size: 2.1rem;
+    font-weight: 700;
+    letter-spacing: -0.06em;
+    line-height: 1;
+}
+
+.md-content .landing-stat__label {
+    color: var(--landing-ink);
+    font-size: 0.95rem;
+    font-weight: 700;
+}
+
+.md-content .landing-stat__note {
+    color: var(--landing-muted);
+    font-size: 0.82rem;
+    line-height: 1.4;
+}
+
+.md-content .landing-grid {
+    display: grid;
+    gap: 1rem;
+    margin: 0 0 2rem;
+}
+
+.md-content .landing-grid--summary {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.md-content .landing-grid--catalog {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.md-content .landing-card {
+    height: 100%;
+    padding: 1.25rem 1.25rem 1.35rem;
+    border: 1px solid var(--landing-border);
+    border-radius: 24px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 251, 255, 0.94) 100%);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+}
+
+.md-content .landing-card > :first-child {
+    margin-top: 0;
+}
+
+.md-content .landing-card > :last-child {
+    margin-bottom: 0;
+}
+
+.md-content .landing-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.7rem;
+    color: var(--landing-ink);
+    font-size: 1.2rem;
+    letter-spacing: -0.02em;
+}
+
+.md-content .landing-card p,
+.md-content .landing-card li,
+.md-content .landing-card em {
+    color: var(--landing-muted);
+}
+
+.md-content .landing-card ul {
+    margin: 0.85rem 0 0;
+    padding-left: 1.1rem;
+}
+
+.md-content .landing-card li + li {
+    margin-top: 0.45rem;
+}
+
+.md-content .landing-card a {
+    font-weight: 600;
+}
+
+.md-content .landing-kicker {
+    margin: 0 0 0.65rem;
+    color: var(--landing-accent-strong);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.md-content .landing-card--command {
+    background:
+        radial-gradient(circle at top right, rgba(37, 99, 235, 0.14), transparent 30%),
+        linear-gradient(180deg, rgba(250, 253, 255, 0.99) 0%, rgba(244, 249, 255, 0.96) 100%);
+}
+
+.md-content .landing-card--command pre {
+    margin-top: 1rem;
+    border-radius: 18px;
+}
+
+@media screen and (max-width: 44.984375em) {
+    .md-content .landing-hero {
+        border-radius: 24px;
+        padding: 1.35rem 1.1rem 1.6rem;
+    }
+
+    .md-content .landing-card,
+    .md-content .landing-stat {
+        border-radius: 18px;
+    }
+
+    .md-content .landing-stat {
+        min-height: auto;
+    }
+}

--- a/home/dot_claude/hooks/executable_enforce-uv.sh
+++ b/home/dot_claude/hooks/executable_enforce-uv.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# enforce-uv.sh
-# uvを使用するように強制するフック
-# ref. Claude Codeの指示忘れ問題を解決！HooksでPython環境をpip禁止＆uv統一にする https://zenn.dev/gotalab/articles/2fe8d7a15409c8
+# @file home/dot_claude/hooks/executable_enforce-uv.sh
+# @brief Block direct Python and pip commands in favor of `uv`.
+# @description
+#   Claude hook that inspects shell commands and returns a JSON decision that
+#   blocks direct `pip` or `python` usage, guiding the caller toward `uv`.
 
 # ===== 関数定義 =====
 
-# pip installコマンドの処理
+# @description Emit the `uv` replacement message for `pip install`.
+# @arg $1 string Parsed `pip` subcommand beginning with `install`.
 function handle_pip_install() {
     local pip_cmd="$1"
     local packages=$(echo "$pip_cmd" | sed 's/install//' | sed 's/--[^ ]*//g' | xargs)
@@ -71,7 +74,8 @@ function handle_pip_install() {
     exit 0
 }
 
-# pip uninstallコマンドの処理
+# @description Emit the `uv remove` replacement message for `pip uninstall`.
+# @arg $1 string Parsed `pip` subcommand beginning with `uninstall`.
 function handle_pip_uninstall() {
     local pip_cmd="$1"
     local packages=$(echo "$pip_cmd" | sed 's/uninstall//' | sed 's/-y//g' | xargs)
@@ -88,7 +92,7 @@ function handle_pip_uninstall() {
     exit 0
 }
 
-# pip list/freezeコマンドの処理
+# @description Explain the `uv` alternatives for `pip list` and `pip freeze`.
 function handle_pip_list() {
     cat <<- 'EOF'
 	{
@@ -106,7 +110,8 @@ function handle_pip_list() {
     exit 0
 }
 
-# その他のpipコマンドの処理
+# @description Fall back to a generic `uv` recommendation for other pip commands.
+# @arg $1 string Parsed `pip` subcommand.
 function handle_pip_other() {
     local pip_cmd="$1"
     cat <<- EOF
@@ -122,7 +127,8 @@ function handle_pip_other() {
     exit 0
 }
 
-# python -m pipコマンドの処理
+# @description Handle `python -m pip ...` by mapping it to the right `uv` advice.
+# @arg $1 string Parsed module arguments after `python -m pip`.
 function handle_python_m_pip() {
     local pip_cmd="$1"
 
@@ -169,7 +175,8 @@ function handle_python_m_pip() {
     exit 0
 }
 
-# python -m moduleコマンドの処理
+# @description Rewrite `python -m module` invocations to `uv run`.
+# @arg $1 string Module invocation after `python -m`.
 function handle_python_m_module() {
     local module="$1"
     cat <<- EOF
@@ -185,7 +192,8 @@ function handle_python_m_module() {
     exit 0
 }
 
-# 基本的なPython実行の処理
+# @description Rewrite direct Python execution to `uv run`.
+# @arg $1 string Original Python arguments.
 function handle_python_run() {
     local args="$1"
     cat <<- EOF
@@ -201,7 +209,7 @@ function handle_python_run() {
     exit 0
 }
 
-# ===== メイン処理 =====
+# @description Read hook input JSON, classify the command, and emit a decision.
 function main() {
     local input=$(cat)
 
@@ -270,5 +278,4 @@ function main() {
     echo '{"decision": "approve"}'
 }
 
-# スクリプト実行
 main

--- a/home/dot_config/alias/client.sh
+++ b/home/dot_config/alias/client.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Client-specific alias definitions and examples.
+# This file currently keeps optional aliases commented out until they are needed.
+
 # Alias for gcloud CLI in docker container
 # alias gcloud='docker run --rm -it -v "${HOME%/}"/.config/gcloud:/root/.config/gcloud gcr.io/google.com/cloudsdktool/cloud-sdk gcloud'
 

--- a/home/dot_config/alias/common.sh
+++ b/home/dot_config/alias/common.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Shared shell aliases used across machines.
+# These aliases wrap common repository and local workflow commands.
+
 # Use eza for ls command
 alias ls="eza --long --group --header --binary --time-style=long-iso --icons"
 

--- a/home/dot_config/alias/server.sh
+++ b/home/dot_config/alias/server.sh
@@ -1,1 +1,4 @@
 #!/usr/bin/env bash
+
+# Server-specific alias definitions.
+# This file is reserved for server-only aliases and is currently empty.

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -9,18 +9,18 @@
 - プロジェクト構成はプログラミング言語ごとに異なりますが、作業を開始する際、存在しない場合のみ以下の構成でセットアップしてください。
   - 作業中は plan と todo を常に更新し続けてください。
   - これらの plan/todo/learn ファイルはコミットしないでください。
-  - `docs/codex/plan/`: プロジェクトの計画や設計に関するドキュメントを格納するディレクトリ
+  - `.docs/codex/plan/`: プロジェクトの計画や設計に関するドキュメントを格納するディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_plan.md` のような形式でファイルを作成してください
     - 実装する前に計画を立て、必要であればユーザへの質問を行って計画用のドキュメントを更新してください。
-  - `docs/codex/todo/`: タスク管理用のディレクトリ
+  - `.docs/codex/todo/`: タスク管理用のディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_todo.md` のような形式でファイルを作成してください
-    - `docs/codex/plan/` ディレクトリのドキュメントをもとに、実装するタスクを洗い出して記述してください。
+    - `.docs/codex/plan/` ディレクトリのドキュメントをもとに、実装するタスクを洗い出して記述してください。
     - タスクは完了したら完了済みのセクションに移動してください。todo 全体が完了したら、ファイル名を `$(date +%Y%m%d_%H%M%S)_done.md` のように変更してください。
-    - タスクの完了に伴って計画が変更された場合は、`docs/codex/plan/` ディレクトリのドキュメントを更新してください。
-  - `docs/codex/learn/`: 学習用のドキュメントを格納するディレクトリ
+    - タスクの完了に伴って計画が変更された場合は、`.docs/codex/plan/` ディレクトリのドキュメントを更新してください。
+  - `.docs/codex/learn/`: 学習用のドキュメントを格納するディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_learn.md` のような形式でファイルを作成してください
     - プロジェクトの実装に必要な知識や技術を学習した際に、学習内容をこのディレクトリに記録してください。
-    - 学習内容はプロジェクトの実装に活かせるように、必要に応じて `docs/codex/plan/` ディレクトリのドキュメントを更新してください。
+    - 学習内容はプロジェクトの実装に活かせるように、必要に応じて `.docs/codex/plan/` ディレクトリのドキュメントを更新してください。
     - learn は「次回の意思決定を速くする情報」が得られたときに更新してください。
     - learn には「何を学んだか」「どこに反映すべきか」を必ず書いてください。
     - learn を更新したら、必要に応じて plan の `Assumptions` / `Design` / `Tests` を更新してください。
@@ -31,7 +31,7 @@
 
 ### plan/todo/learn の frontmatter ルール
 
-- `docs/codex/plan/*.md` `docs/codex/todo/*.md` `docs/codex/learn/*.md` の先頭に YAML frontmatter を必須とします。
+- `.docs/codex/plan/*.md` `.docs/codex/todo/*.md` `.docs/codex/learn/*.md` の先頭に YAML frontmatter を必須とします。
 - 並列実行を前提に、`active` 制約は「リポジトリ全体で1件」ではなく「`owner` ごとに1件」とします。
 
 #### 共通必須キー
@@ -71,7 +71,7 @@
 
 #### 既存ファイルの最小移行ルール
 
-- 既存の `docs/codex/todo/*_todo.md` / `docs/codex/todo/*_done.md` は、次回編集時に frontmatter を追加してください。
+- 既存の `.docs/codex/todo/*_todo.md` / `.docs/codex/todo/*_done.md` は、次回編集時に frontmatter を追加してください。
 - 既存ファイルで `owner` が不明な場合は一時的に `owner: unknown` を設定してください。
 - 既存 `*_done.md` は `status: done` を設定してください。
 - 既存 `*_todo.md` で `# TODO` が空の場合は `status: done` に更新し、`*_done.md` へリネームしてください。

--- a/home/dot_local/bin/client/executable_connect-hosei-vpn
+++ b/home/dot_local/bin/client/executable_connect-hosei-vpn
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/client/executable_connect-hosei-vpn
+# @brief Connect to the Hosei University VPN.
+# @description
+#   Reads the stored AnyConnect credentials from the configured JSON file and
+#   connects to the Hosei VPN host through the Cisco AnyConnect CLI.
+
 readonly HOSEI_VPN_CREDENTIAL_JSON="${HOSEI_VPN_CREDENTIAL_JSON:-${HOME%/}/.config/anyconnect/hosei_credential.json}"
 readonly HOSEI_VPN_HOST="vpn.hosei.ac.jp"
 
+# @description Read the VPN username from the credential JSON file.
 function get-username() {
     jq < "${HOSEI_VPN_CREDENTIAL_JSON}" -r ".username"
 }
 
+# @description Read the VPN password from the credential JSON file.
 function get-password() {
     jq < "${HOSEI_VPN_CREDENTIAL_JSON}" -r ".password"
 }
 
+# @description Connect to the Hosei VPN using the stored credentials.
 function connect-hosei-vpn() {
     username=$(get-username)
     password=$(get-password)

--- a/home/dot_local/bin/client/executable_disconnect-vpn
+++ b/home/dot_local/bin/client/executable_disconnect-vpn
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/client/executable_disconnect-vpn
+# @brief Disconnect the active Cisco AnyConnect VPN session.
+# @description
+#   Calls the Cisco AnyConnect CLI to disconnect the current VPN session.
+
+# @description Disconnect the active VPN session through Cisco AnyConnect.
 function disconnect-vpn() {
     /opt/cisco/anyconnect/bin/vpn disconnect
 }

--- a/home/dot_local/bin/client/executable_login-ghcr
+++ b/home/dot_local/bin/client/executable_login-ghcr
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/client/executable_login-ghcr
+# @brief Log Docker into GitHub Container Registry.
+# @description
+#   Fetches the GHCR username and personal access token from 1Password and
+#   authenticates Docker against `ghcr.io`.
+
+# @description Log into GHCR using credentials stored in 1Password.
 function login-ghcr() {
     local cr_pat username
     cr_pat=$(op item get github.com --fields label=cr-pat)

--- a/home/dot_local/bin/common/executable_cdgwq
+++ b/home/dot_local/bin/common/executable_cdgwq
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_cdgwq
+# @brief Change into a repository path selected from `gwq`.
+# @description
+#   Uses `gwq list --json` and `fzf` to select a known repository path, then
+#   changes the current shell into that directory.
+
+# @description Fuzzy-select a `gwq` workspace path and `cd` into it.
 function cdgwq() {
     # git 内かどうかをチェック
     if ! git rev-parse --is-inside-work-tree &> /dev/null; then

--- a/home/dot_local/bin/common/executable_cdw
+++ b/home/dot_local/bin/common/executable_cdw
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_cdw
+# @brief Change into the most recent `gwq` workspace.
+# @description
+#   Selects the newest path returned by `gwq list --json` and changes the
+#   current shell into that repository.
+
+# @description Jump to the newest `gwq` workspace path.
 function cdw() {
     # git 内かどうかをチェック
     if ! git rev-parse --is-inside-work-tree &> /dev/null; then

--- a/home/dot_local/bin/common/executable_chezmoi-cd
+++ b/home/dot_local/bin/common/executable_chezmoi-cd
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_chezmoi-cd
+# @brief Change into the active chezmoi source directory.
+# @description
+#   Resolves `chezmoi source-path` and changes the current shell into that
+#   repository checkout.
+
+# @description Change into the current chezmoi source path.
 chezmoi-cd() {
     cd "$(chezmoi source-path)" || return
 }

--- a/home/dot_local/bin/common/executable_dev
+++ b/home/dot_local/bin/common/executable_dev
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_dev
+# @brief Change into a repository selected from `ghq`.
+# @description
+#   Lets the user choose a repository path from `ghq`, changes into it, and
+#   renames the current tmux session to match the selected repository.
+
+# @description Fuzzy-select a repository path from `ghq`.
 function ghq-path() {
     local selected_path
     selected_path=$(ghq list --full-path | fzf) || return 1
@@ -7,6 +14,7 @@ function ghq-path() {
     printf '%s\n' "$selected_path"
 }
 
+# @description Change into a selected `ghq` repository and rename tmux session.
 function dev() {
     local moveto
     moveto=$(ghq-path) || return 0

--- a/home/dot_local/bin/common/executable_fgc
+++ b/home/dot_local/bin/common/executable_fgc
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_fgc
+# @brief Fuzzy-pick and checkout a local Git branch.
+# @description
+#   Lists local branches, selects one with `fzf`, and checks it out.
+
+# @description Checkout a branch selected from the local branch list.
 function fgc() {
     git checkout "$(git for-each-ref refs/heads/ --format='%(refname:short)' | fzf)"
 }

--- a/home/dot_local/bin/common/executable_git-delete-merged-branches
+++ b/home/dot_local/bin/common/executable_git-delete-merged-branches
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_git-delete-merged-branches
+# @brief Delete local branches already merged through squash-and-merge.
+# @description
+#   Detects the repository default branch, compares local branches against it,
+#   and removes branches whose tree has already been integrated upstream.
+
+# @description Check whether the current directory is inside a Git repository.
 function is_inside_git_repository() {
     git rev-parse --is-inside-work-tree > /dev/null 2>&1
 }
 
+# @description Detect the default branch name from the `origin` remote.
 function get_default_branch() {
     local default_branch
 
@@ -12,6 +20,7 @@ function get_default_branch() {
     echo -n "${default_branch}"
 }
 
+# @description Delete local branches whose content is already on the default branch.
 function git-delete-merged-branches() {
     # delete all git branches which have been "squash and merge" via GitHub
     # ref. https://stackoverflow.com/questions/43489303/how-can-i-delete-all-git-branches-which-have-been-squash-and-merge-via-github

--- a/home/dot_local/bin/common/executable_setup-gh
+++ b/home/dot_local/bin/common/executable_setup-gh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_setup-gh
+# @brief Authenticate `gh` and upload the local SSH key.
+# @description
+#   Logs into GitHub through the GitHub CLI and registers the local public SSH
+#   key on the authenticated account.
+
 set -Eeuo pipefail
 
+# @description Authenticate GitHub CLI against github.com over HTTPS.
 function login_to_github() {
     gh auth login -h github.com -p https
 }
 
+# @description Upload the local public SSH key through GitHub CLI.
 function add_ssh_key_to_github() {
     gh auth refresh -h github.com -s admin:public_key
     gh ssh-key add "${HOME%/}/.ssh/id_ed25519.pub"
 }
 
+# @description Run the GitHub authentication and SSH key setup flow.
 function main() {
     login_to_github
     add_ssh_key_to_github

--- a/home/dot_local/bin/common/executable_setup-python-env
+++ b/home/dot_local/bin/common/executable_setup-python-env
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_setup-python-env
+# @brief Bootstrap a Poetry-based Python development environment.
+# @description
+#   Upgrades core Python packaging tools with pip, initializes a Poetry
+#   project, and adds common development dependencies.
+
+# @description Upgrade pip, wheel, setuptools, and Poetry.
 function install_with_pip() {
     pip install -U pip wheel setuptools poetry
 }
 
+# @description Initialize Poetry and add common development dependencies.
 function setup_poetry() {
     poetry init -n
     poetry add --group dev ruff black mypy pytest
 }
 
+# @description Run the Python environment bootstrap flow.
 function setup-python-env() {
     install_with_pip
     setup_poetry

--- a/home/dot_local/bin/common/executable_uv-format
+++ b/home/dot_local/bin/common/executable_uv-format
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/common/executable_uv-format
+# @brief Format Python code with Ruff through `uvx`.
+# @description
+#   Runs Ruff formatting first and then fixes import ordering and selected
+#   issues through Ruff's check mode.
+
+# @description Run Ruff formatting and autofix passes through `uvx`.
 function uv_format() {
     uvx ruff format
     uvx ruff check --fix --extend-select I

--- a/home/dot_local/bin/server/cache.sh
+++ b/home/dot_local/bin/server/cache.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/server/cache.sh
+# @brief Export Hugging Face cache locations for server environments.
+# @description
+#   Sets the dataset and model cache directories under the user's home cache
+#   directory for Hugging Face tooling.
+
 # for huggingface datasets
 export HF_DATASETS_CACHE="${HOME%/}/.cache/huggingface/datasets"
 export TRANSFORMERS_CACHE="${HOME%/}/.cache/huggingface/hub"

--- a/home/dot_local/bin/server/cuda.sh
+++ b/home/dot_local/bin/server/cuda.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env zsh
 
+# @file home/dot_local/bin/server/cuda.sh
+# @brief Export CUDA paths for server shells.
+# @description
+#   Sets `CUDA_HOME`, prepends the CUDA binaries to the shell path, and extends
+#   `LD_LIBRARY_PATH` for CUDA libraries.
+
 export CUDA_HOME="/usr/local/cuda"
 
 typeset -gU path

--- a/home/dot_local/bin/server/history.sh
+++ b/home/dot_local/bin/server/history.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/server/history.sh
+# @brief Share shell history across concurrent bash sessions.
+# @description
+#   Provides a `tac` fallback and appends a `PROMPT_COMMAND` hook that merges
+#   duplicate-filtered bash history back into the main history file.
+
+# @description Reverse lines from stdin or files using `sed`.
 function tac {
     exec sed '1!G;h;$!d' ${@+"$@"}
 }
 
+# @description Merge the current bash session history back into `~/.bash_history`.
 function share_history {
     history -a
     tac ~/.bash_history | awk '!a[$0]++' | tac > ~/.bash_history.tmp

--- a/home/dot_local/bin/server/secrets.sh
+++ b/home/dot_local/bin/server/secrets.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/server/secrets.sh
+# @brief Define placeholder secret environment variables.
+# @description
+#   Exports placeholder tokens for services that are expected to be filled in on
+#   the target server environment.
+
 # for slack api
 export SLACK_TOKEN=""
 

--- a/home/dot_local/bin/server/ssh_agent.sh
+++ b/home/dot_local/bin/server/ssh_agent.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# @file home/dot_local/bin/server/ssh_agent.sh
+# @brief Start `ssh-agent` and load the default SSH key.
+# @description
+#   Starts a new `ssh-agent` process and adds the default ed25519 private key
+#   for the current user.
+
 eval "$(ssh-agent)" > /dev/null 2>&1
 ssh-add "${HOME}/.ssh/id_ed25519" > /dev/null 2>&1

--- a/install/common/chezmoi_private.sh
+++ b/install/common/chezmoi_private.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/common/chezmoi_private.sh
+# @brief Initialize the private chezmoi repository.
+# @description
+#   Bootstraps `shunk031/dotfiles-private` using the dedicated source and
+#   config paths under the current user's home directory.
+
 set -Eeuo pipefail
 
 declare -r PRIVATE_DOTFILES_REPO_URL="https://github.com/shunk031/dotfiles-private"
@@ -10,6 +16,9 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Initialize the private dotfiles repository if it is available.
+#
 function install_chezmoi_private() {
     if chezmoi init \
         --apply \
@@ -23,11 +32,17 @@ function install_chezmoi_private() {
     echo "Warning: Failed to initialize dotfiles-private. Skipping private dotfiles setup." >&2
 }
 
+#
+# @description Remove the private chezmoi source and config paths.
+#
 function uninstall_chezmoi_private() {
     rm -rfv "${PRIVATE_DOTFILES_PATH}"
     rm -rfv "${PRIVATE_DOTFILES_CONFIG_PATH}"
 }
 
+#
+# @description Run the private chezmoi initialization flow.
+#
 function main() {
     install_chezmoi_private
 }

--- a/install/common/gh_extensions.sh
+++ b/install/common/gh_extensions.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/common/gh_extensions.sh
+# @brief Install GitHub CLI extensions used by the dotfiles.
+# @description
+#   Activates `mise` when available, ensures GitHub authentication, and
+#   installs the configured `gh` extensions.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -12,24 +18,36 @@ readonly GH_EXTENSIONS=(
     seachicken/gh-poi
 )
 
+#
+# @description Activate `mise` so `gh` can resolve the expected toolchain.
+#
 function activate_mise() {
     if [ -x "${MISE_BIN}" ]; then
         eval "$("${MISE_BIN}" activate bash)"
     fi
 }
 
+#
+# @description Prompt for GitHub CLI authentication when no session exists.
+#
 function ensure_gh_auth() {
     if ! gh auth status &> /dev/null; then
         gh auth login -h github.com -p https
     fi
 }
 
+#
+# @description Install every extension listed in `GH_EXTENSIONS`.
+#
 function install_gh_extensions() {
     for extension in "${GH_EXTENSIONS[@]}"; do
         gh extension install "${extension}"
     done
 }
 
+#
+# @description Run the `gh` extension installation workflow.
+#
 function main() {
     activate_mise
     ensure_gh_auth

--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/common/mise.sh
+# @brief Install and bootstrap `mise`.
+# @description
+#   Downloads a pinned standalone `mise` release and runs `mise install`
+#   against the repository tool definitions.
+
 # set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -9,6 +15,9 @@ fi
 export MISE_INSTALL_PATH="${HOME}/.local/bin/mise"
 readonly DEFAULT_NPM_MIN_RELEASE_AGE_DAYS=7
 
+#
+# @description Install the pinned standalone `mise` binary and activate it.
+#
 function install_mise() {
     # https://mise.run
     local version="v2026.3.7"
@@ -21,16 +30,25 @@ function install_mise() {
     eval "$(~/.local/bin/mise activate bash)"
 }
 
+#
+# @description Install all tools declared for this repository through `mise`.
+#
 function run_mise_install() {
     # `MISE_CURRENT_VERSION` is interpreted by mise as a tool env override for `current`.
     unset MISE_CURRENT_VERSION
     mise install --before "${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d"
 }
 
+#
+# @description Remove the standalone `mise` binary from the local bin dir.
+#
 function uninstall_mise() {
     rm "${MISE_INSTALL_PATH}"
 }
 
+#
+# @description Install `mise` and the configured tools.
+#
 function main() {
     install_mise
     run_mise_install

--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -14,6 +14,8 @@ fi
 
 export MISE_INSTALL_PATH="${HOME}/.local/bin/mise"
 readonly DEFAULT_NPM_MIN_RELEASE_AGE_DAYS=7
+readonly SHDOC_PLUGIN_NAME="shdoc"
+readonly SHDOC_PLUGIN_REPOSITORY="https://github.com/shunk031/mise-shdoc.git"
 
 #
 # @description Install the pinned standalone `mise` binary and activate it.
@@ -31,11 +33,31 @@ function install_mise() {
 }
 
 #
+# @description Trust the local `mise.toml` before plugin or tool installation.
+#
+function trust_mise_config() {
+    mise trust --yes
+}
+
+#
+# @description Install the custom `shdoc` plugin when it is not available yet.
+#
+function ensure_shdoc_plugin_installed() {
+    if mise plugins ls | grep -qx "${SHDOC_PLUGIN_NAME}"; then
+        return
+    fi
+
+    mise plugins install "${SHDOC_PLUGIN_NAME}" "${SHDOC_PLUGIN_REPOSITORY}"
+}
+
+#
 # @description Install all tools declared for this repository through `mise`.
 #
 function run_mise_install() {
     # `MISE_CURRENT_VERSION` is interpreted by mise as a tool env override for `current`.
     unset MISE_CURRENT_VERSION
+    trust_mise_config
+    ensure_shdoc_plugin_installed
     mise install --before "${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d"
 }
 

--- a/install/common/sheldon.sh
+++ b/install/common/sheldon.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# @file install/common/sheldon.sh
+# @brief Install the Sheldon shell plugin manager.
+# @description
+#   Downloads the latest `sheldon` binary into the user's local bin directory.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -8,6 +13,9 @@ fi
 
 readonly BIN_DIR="${HOME}/.local/bin"
 
+#
+# @description Download and install `sheldon` into `BIN_DIR`.
+#
 function install_sheldon() {
     mkdir -p "${BIN_DIR}"
 
@@ -15,10 +23,16 @@ function install_sheldon() {
         bash -s -- --repo rossmacarthur/sheldon --to "${BIN_DIR}" --force
 }
 
+#
+# @description Remove the installed `sheldon` binary.
+#
 function uninstall_sheldon() {
     rm "${BIN_DIR}/sheldon"
 }
 
+#
+# @description Run the Sheldon installation flow.
+#
 function main() {
     install_sheldon
 }

--- a/install/common/tpm.sh
+++ b/install/common/tpm.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/common/tpm.sh
+# @brief Install tmux plugin tooling.
+# @description
+#   Clones TPM, installs tmux plugins, and builds `tmux-mem-cpu-load` into the
+#   user's local prefix.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -9,10 +15,17 @@ fi
 readonly TMUX_PLUGINS_DIR="${HOME%/}/.tmux/plugins"
 readonly TPM_DIR="${TMUX_PLUGINS_DIR}/tpm"
 
+#
+# @description Check whether `tmux-mem-cpu-load` is already installed.
+#
 function is_tmux_mem_cpu_load_installed() {
     command -v "tmux-mem-cpu-load" &> /dev/null
 }
 
+#
+# @description Clone the TPM repository when it is not present.
+# @arg $1 path Target directory for the TPM checkout.
+#
 function clone_tpm() {
     local dir="$1"
     local url="https://github.com/tmux-plugins/tpm"
@@ -22,6 +35,10 @@ function clone_tpm() {
     fi
 }
 
+#
+# @description Run TPM's plugin installer in a nounset-safe subshell.
+# @arg $1 path TPM installation directory.
+#
 function install_tpm_plugins() {
     local dir="$1"
     local cmd="${dir%/}/scripts/install_plugins.sh"
@@ -36,6 +53,9 @@ function install_tpm_plugins() {
     )
 }
 
+#
+# @description Install TPM and fetch tmux plugins.
+#
 function install_tpm() {
     export TMUX_PLUGIN_MANAGER_PATH="${TMUX_PLUGINS_DIR}"
 
@@ -45,6 +65,9 @@ function install_tpm() {
     fi
 }
 
+#
+# @description Build and install `tmux-mem-cpu-load` from source.
+#
 function install_tmux_mem_cpu_load() {
     if [ ! "${DOTFILES_DEBUG:-}" ] && is_tmux_mem_cpu_load_installed; then
         return 0 # early return
@@ -62,14 +85,23 @@ function install_tmux_mem_cpu_load() {
     make install
 }
 
+#
+# @description Remove the TPM checkout.
+#
 function uninstall_tpm() {
     rm -rfv "${TPM_DIR}"
 }
 
+#
+# @description Remove the installed `tmux-mem-cpu-load` binary.
+#
 function uninstall_tmux_mem_cpu_load() {
     rm -fv "${HOME%/}/.local/bin/tmux-mem-cpu-load"
 }
 
+#
+# @description Install TPM and `tmux-mem-cpu-load`.
+#
 function main() {
     install_tpm
     install_tmux_mem_cpu_load

--- a/install/macos/arm64/prepare_arm64_system.sh
+++ b/install/macos/arm64/prepare_arm64_system.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
+# @file install/macos/arm64/prepare_arm64_system.sh
+# @brief Prepare Apple Silicon hosts for the dotfiles setup.
+# @description
+#   Installs Rosetta on arm64 macOS machines when it is not already present.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Install Rosetta if the system has not installed it yet.
+#
 function install_rosetta() {
     local rosetta_path="/Library/Apple/usr/share/rosetta/rosetta"
     if ! [[ -f "${rosetta_path}" ]]; then
@@ -13,6 +21,9 @@ function install_rosetta() {
     fi
 }
 
+#
+# @description Run Apple Silicon system preparation steps.
+#
 function main() {
     install_rosetta
 }

--- a/install/macos/arm64/run.sh
+++ b/install/macos/arm64/run.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# @file install/macos/arm64/run.sh
+# @brief Print the arm64 installer entrypoint path.
+# @description
+#   Emits the relative arm64 installer path consumed by the surrounding setup
+#   flow.
+
 set -Eeuo pipefail
 
+#
+# @description Print the arm64 installer path.
+#
 function main() {
     echo "../install/macos/arm64/run.sh"
 }

--- a/install/macos/common/brew.sh
+++ b/install/macos/common/brew.sh
@@ -1,25 +1,43 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/brew.sh
+# @brief Install Homebrew and apply repository defaults.
+# @description
+#   Ensures Homebrew is installed on macOS and disables analytics for the local
+#   user.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Check whether Homebrew is already available on `PATH`.
+#
 function is_homebrew_exists() {
     command -v brew &> /dev/null
 }
 
+#
+# @description Install Homebrew when it is not present.
+#
 function install_homebrew() {
     if ! is_homebrew_exists; then
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
 }
 
+#
+# @description Disable Homebrew analytics for the current user.
+#
 function opt_out_of_analytics() {
     brew analytics off
 }
 
+#
+# @description Install Homebrew and apply repository defaults.
+#
 function main() {
     install_homebrew
     opt_out_of_analytics

--- a/install/macos/common/command_line_tool.sh
+++ b/install/macos/common/command_line_tool.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/command_line_tool.sh
+# @brief Install Xcode Command Line Tools.
+# @description
+#   Triggers the Apple command line tools installer and waits for the user to
+#   confirm the installation has completed.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Install Xcode Command Line Tools when `git` is not available.
+#
 function install_command_line_tool() {
     local git_cmd_path="/Library/Developer/CommandLineTools/usr/bin/git"
 
@@ -27,6 +36,9 @@ function install_command_line_tool() {
     fi
 }
 
+#
+# @description Run the command line tools installation flow.
+#
 function main() {
     install_command_line_tool
 }

--- a/install/macos/common/defaults.sh
+++ b/install/macos/common/defaults.sh
@@ -1,17 +1,29 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/defaults.sh
+# @brief Apply the preferred macOS defaults for this dotfiles setup.
+# @description
+#   Configures UI, input, Dock, Finder, screenshot, and application defaults,
+#   then restarts affected applications where needed.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Configure small Control Center and UI preferences.
+#
 function defaults_ui() {
     # Display battery percentage
     # ref. https://github.com/todd-dsm/mac-ops/issues/39#issuecomment-962459353
     defaults write ~/Library/Preferences/ByHost/com.apple.controlcenter.plist BatteryShowPercentage -bool true
 }
 
+#
+# @description Configure keyboard repeat and modifier key preferences.
+#
 function defaults_keyboard() {
     # Set a blazingly fast keyboard repeat rate
     defaults write NSGlobalDomain KeyRepeat -int 2
@@ -24,6 +36,9 @@ function defaults_keyboard() {
         '{"UserKeyMapping": [{"HIDKeyboardModifierMappingSrc": 0x700000039, "HIDKeyboardModifierMappingDst": 0x7000000e0 }] }'
 }
 
+#
+# @description Configure trackpad speed, tap-to-click, and drag behavior.
+#
 function defaults_trackpad() {
 
     defaults write -g com.apple.trackpad.scaling 2
@@ -39,10 +54,16 @@ function defaults_trackpad() {
     defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerDrag -bool true
 }
 
+#
+# @description Expose Bluetooth in the macOS Control Center.
+#
 function defaults_controlcenter() {
     defaults write com.apple.controlcenter "NSStatusItem Visible Bluetooth" -bool true
 }
 
+#
+# @description Customize Dock behavior and its pinned applications.
+#
 function defaults_dock() {
     # Automatically hide and show the Dock
     defaults write com.apple.dock autohide -bool true
@@ -94,6 +115,9 @@ function defaults_dock() {
         "$(dock_item "$(get_system_app_path)")"
 }
 
+#
+# @description Configure input sources and keyboard shortcuts for IME switching.
+#
 function defaults_input_sources() {
     # Enable `Automatically switch to a document's input source'`
     defaults write com.apple.HIToolbox AppleGlobalTextInputProperties -dict TextInputGlobalPropertyPerContextInput -bool true
@@ -138,6 +162,9 @@ function defaults_input_sources() {
         </dict>"
 }
 
+#
+# @description Configure Finder defaults and file visibility preferences.
+#
 function defaults_finder() {
 
     # Set Home directory as the default location for new Finder windows
@@ -167,6 +194,9 @@ function defaults_finder() {
     defaults write com.apple.finder FXRemoveOldTrashItems -bool true
 }
 
+#
+# @description Configure screenshot naming and storage behavior.
+#
 function defaults_screencapture() {
     # Save screenshots to ${HOME}/Pictures/
     defaults write com.apple.screencapture location -string "${HOME}/Pictures/"
@@ -176,11 +206,17 @@ function defaults_screencapture() {
     defaults write com.apple.screencapture show-thumbnail -bool false
 }
 
+#
+# @description Disable Siri and dictation defaults.
+#
 function defaults_assistant() {
     defaults write com.apple.assistant.support "Assistant Enabled" -bool false
     defaults write com.apple.HIToolbox AppleDictationAutoEnable -bool false
 }
 
+#
+# @description Apply iTerm2-specific defaults expected by this setup.
+#
 function defaults_iterm2() {
 
     #
@@ -197,6 +233,9 @@ function defaults_iterm2() {
     defaults write com.googlecode.iterm2 NoSyncTipsDisabled -bool true
 }
 
+#
+# @description Restart applications affected by the defaults changes.
+#
 function kill_affected_applications() {
     local apps=(
         "Activity Monitor"
@@ -218,6 +257,9 @@ function kill_affected_applications() {
     done
 }
 
+#
+# @description Re-open Rectangle after defaults have been applied.
+#
 function open_rectangle() {
     local app_path="/Applications/Rectangle.app/"
     if [ -e "${app_path}" ]; then
@@ -225,10 +267,16 @@ function open_rectangle() {
     fi
 }
 
+#
+# @description Re-open applications that should be restored after setup.
+#
 function open_killed_applications() {
     open_rectangle
 }
 
+#
+# @description Apply all macOS defaults managed by this script.
+#
 function main() {
 
     defaults_ui

--- a/install/macos/common/dependencies.sh
+++ b/install/macos/common/dependencies.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-#
-# dependencies.sh
-#
-# Installs the essential command-line packages required for the dotfiles to function properly.
-# This script is limited to core dependencies.
-# For optional utilities, GUI apps, or user-specific tools, see install/macos/common/misc.sh.
-#
+# @file install/macos/common/dependencies.sh
+# @brief Install essential Homebrew packages for macOS.
+# @description
+#   Installs the core command-line packages required by the dotfiles.
+#   Optional utilities and GUI applications live in
+#   `install/macos/common/misc.sh`.
 
 set -Eeuo pipefail
 
@@ -23,12 +22,19 @@ readonly BREW_PACKAGES=(
     zsh
 )
 
+#
+# @description Check whether a Homebrew package is already installed.
+# @arg $1 string Homebrew package name.
+#
 function is_brew_package_installed() {
     local package="$1"
 
     brew list "${package}" &> /dev/null
 }
 
+#
+# @description Install every missing package from `BREW_PACKAGES`.
+#
 function install_brew_packages() {
     local missing_packages=()
 
@@ -47,6 +53,9 @@ function install_brew_packages() {
     fi
 }
 
+#
+# @description Install the required Homebrew dependencies.
+#
 function main() {
     install_brew_packages
 }

--- a/install/macos/common/dependencies.sh
+++ b/install/macos/common/dependencies.sh
@@ -16,6 +16,7 @@ fi
 readonly BREW_PACKAGES=(
     cmake
     git
+    gawk
     gpg
     pinentry-mac
     vim

--- a/install/macos/common/docker.sh
+++ b/install/macos/common/docker.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/docker.sh
+# @brief Install Docker Desktop on macOS.
+# @description
+#   Installs or removes the Docker Desktop cask through Homebrew.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Install the Docker Desktop Homebrew cask.
+#
 function install_docker() {
     brew install --cask docker
 }
 
+#
+# @description Remove the Docker Desktop Homebrew cask.
+#
 function uninstall_docker() {
     brew uninstall --cask docker --force
 }
 
+#
+# @description Run the Docker Desktop installation flow.
+#
 function main() {
     install_docker
 }

--- a/install/macos/common/iterm2.sh
+++ b/install/macos/common/iterm2.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/iterm2.sh
+# @brief Install iTerm2 and manage its dynamic profile setup.
+# @description
+#   Installs the iTerm2 cask and provides helpers for initializing or removing
+#   the repository-managed dynamic profile.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -9,21 +15,33 @@ fi
 readonly ITERM2_CONFIG_NAME="hotkey_window.json"
 readonly ITERM2_CONFIG_DIR="${HOME%/}/Library/Application Support/iTerm2/DynamicProfiles"
 
+#
+# @description Install the iTerm2 Homebrew cask.
+#
 function install_item2() {
     brew install --cask iterm2
 }
 
+#
+# @description Uninstall iTerm2 and remove the managed dynamic profile file.
+#
 function uninstall_iterm2() {
     brew uninstall --cask iterm2
     rm -fv "${ITERM2_CONFIG_DIR}/${ITERM2_CONFIG_NAME}"
 }
 
+#
+# @description Open iTerm2 until the application can be launched.
+#
 function initialize_iterm2() {
     while ! open -g "/Applications/iTerm.app"; do
         sleep 2
     done
 }
 
+#
+# @description Run the iTerm2 installation flow.
+#
 function main() {
     install_item2
 }

--- a/install/macos/common/mac_app_store.sh
+++ b/install/macos/common/mac_app_store.sh
@@ -1,46 +1,77 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/mac_app_store.sh
+# @brief Install selected Mac App Store applications.
+# @description
+#   Ensures the `mas` CLI exists and installs the configured Mac App Store apps
+#   when the script is not running in CI.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Check whether the `mas` CLI is available.
+#
 function is_mas_installed() {
     common -v mas &> /dev/null
 }
 
+#
+# @description Install the `mas` CLI through Homebrew when needed.
+#
 function install_mas() {
     if ! is_mas_installed; then
         brew install mas
     fi
 }
 
+#
+# @description Install a Mac App Store application by its numeric identifier.
+# @arg $1 string Mac App Store application identifier.
+#
 function run_mas_install() {
     local app_id="$1"
     mas install "${app_id}"
 }
 
+#
+# @description Install Bandwidth+ from the Mac App Store.
+#
 function install_bandwidth_plus() {
     local app_id="490461369"
     run_mas_install "${app_id}"
 }
 
+#
+# @description Install LINE from the Mac App Store.
+#
 function install_line() {
     local app_id="539883307"
     run_mas_install "${app_id}"
 }
 
+#
+# @description Install 1Password 7 from the Mac App Store.
+#
 function install_1password7() {
     local app_id="1333542190"
     run_mas_install "${app_id}"
 }
 
+#
+# @description Install Xcode from the Mac App Store.
+#
 function install_xcode() {
     local app_id="497799835"
     run_mas_install "${app_id}"
 }
 
+#
+# @description Install the configured Mac App Store applications.
+#
 function main() {
     install_mas
 

--- a/install/macos/common/misc.sh
+++ b/install/macos/common/misc.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-#
-# misc.sh
-#
-# Installs optional utilities and GUI applications for daily use.
-# This script covers non-essential tools and user- or machine-specific extras.
-# For the minimal required dependencies, see install/macos/common/dependencies.sh.
-#
+# @file install/macos/common/misc.sh
+# @brief Install optional macOS utilities and GUI applications.
+# @description
+#   Installs non-essential brew packages, casks, and user-specific extras for
+#   daily development use.
 
 set -Eeuo pipefail
 
@@ -47,12 +45,19 @@ readonly ADDITIONAL_CASK_PACKAGES=(
     zoom
 )
 
+#
+# @description Check whether a brew package or cask is already installed.
+# @arg $1 string Package or cask name.
+#
 function is_brew_package_installed() {
     local package="$1"
 
     brew list "${package}" &> /dev/null
 }
 
+#
+# @description Install every missing package from `BREW_PACKAGES`.
+#
 function install_brew_packages() {
     local missing_packages=()
 
@@ -71,6 +76,9 @@ function install_brew_packages() {
     fi
 }
 
+#
+# @description Install every missing cask from `CASK_PACKAGES`.
+#
 function install_brew_cask_packages() {
     local missing_packages=()
 
@@ -89,6 +97,9 @@ function install_brew_cask_packages() {
     fi
 }
 
+#
+# @description Install additional brew packages for the primary user only.
+#
 function install_additional_brew_packages() {
     # Restrict personal packages to the primary user account.
     if [[ "$(whoami)" != "shunk031" ]]; then
@@ -112,6 +123,9 @@ function install_additional_brew_packages() {
     fi
 }
 
+#
+# @description Install additional casks that may fail independently.
+#
 function install_additional_cask_packages() {
     local missing_packages=()
 
@@ -134,10 +148,16 @@ function install_additional_cask_packages() {
     fi
 }
 
+#
+# @description Open Google Chrome and prompt it to become the default browser.
+#
 function setup_google_chrome() {
     open "/Applications/Google Chrome.app" --args --make-default-browser
 }
 
+#
+# @description Install the configured optional macOS packages and casks.
+#
 function main() {
     install_brew_packages
     install_brew_cask_packages

--- a/install/macos/common/tmux.sh
+++ b/install/macos/common/tmux.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/macos/common/tmux.sh
+# @brief Install tmux on macOS.
+# @description
+#   Installs or removes `tmux`, with a GitHub Actions-specific workaround for
+#   brew dependency resolution.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -10,6 +16,9 @@ readonly PACKAGES=(
     tmux
 )
 
+#
+# @description Install `tmux` while tolerating the CI CMake pinning issue.
+#
 function install_tmux() {
     # On GitHub Actions macOS instances, reinstalling CMake fails.
     # Implement the following workaround to avoid this issue.
@@ -19,10 +28,16 @@ function install_tmux() {
     done
 }
 
+#
+# @description Remove the installed `tmux` package.
+#
 function uninstall_tmux() {
     brew uninstall "${PACKAGES[@]}"
 }
 
+#
+# @description Run the tmux installation flow.
+#
 function main() {
     install_tmux
 }

--- a/install/ubuntu/client/docker.sh
+++ b/install/ubuntu/client/docker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/client/docker.sh
+# @brief Install Docker Engine on Ubuntu client machines.
+# @description
+#   Removes legacy Docker packages, configures Docker's apt repository, and
+#   installs the current Docker Engine packages.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -13,6 +19,9 @@ readonly PACKAGES=(
     docker-compose-plugin
 )
 
+#
+# @description Remove legacy Docker packages that conflict with Docker Engine.
+#
 function uninstall_old_docker() {
     local packages=(
         "docker"
@@ -28,6 +37,9 @@ function uninstall_old_docker() {
     done
 }
 
+#
+# @description Configure Docker's official apt repository and signing key.
+#
 function setup_repository() {
 
     # Update the apt package index and install packages to allow apt to use a repository over HTTPS:
@@ -48,6 +60,9 @@ function setup_repository() {
         $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 }
 
+#
+# @description Install Docker Engine and the configured companion packages.
+#
 function install_docker_engine() {
     # Update the apt package index:
     sudo apt-get update
@@ -57,10 +72,16 @@ function install_docker_engine() {
 
 }
 
+#
+# @description Remove the configured Docker Engine packages.
+#
 function uninstall_docker_engine() {
     sudo apt-get remove -y "${PACKAGES[@]}"
 }
 
+#
+# @description Install Docker Engine from Docker's official Ubuntu repository.
+#
 function main() {
     uninstall_old_docker
     setup_repository

--- a/install/ubuntu/client/misc.sh
+++ b/install/ubuntu/client/misc.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/client/misc.sh
+# @brief Install optional Ubuntu client applications.
+# @description
+#   Installs or removes a small set of GUI applications used on Ubuntu client
+#   machines.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -11,14 +17,23 @@ readonly PACKAGES=(
     gparted
 )
 
+#
+# @description Install the optional Ubuntu client packages.
+#
 function install_misc() {
     sudo apt-get install -y "${PACKAGES[@]}"
 }
 
+#
+# @description Remove the optional Ubuntu client packages.
+#
 function uninstall_misc() {
     sudo apt-get remove -y "${PACKAGES[@]}"
 }
 
+#
+# @description Run the optional Ubuntu client package installation flow.
+#
 function main() {
     install_misc
 }

--- a/install/ubuntu/common/dependencies.sh
+++ b/install/ubuntu/common/dependencies.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/common/dependencies.sh
+# @brief Install essential Ubuntu packages for the dotfiles.
+# @description
+#   Ensures the base command-line toolchain required by the repository is
+#   present, including `sudo` when starting from a minimal container.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -22,6 +28,9 @@ readonly PACKAGES=(
     zsh
 )
 
+#
+# @description Run `apt-get`, installing `sudo` first when required.
+#
 function run_apt_get() {
     if ! command -v sudo > /dev/null 2>&1; then
         apt-get update
@@ -31,6 +40,9 @@ function run_apt_get() {
     sudo --preserve-env=http_proxy,https_proxy,no_proxy apt-get "$@"
 }
 
+#
+# @description Install every missing package from `PACKAGES`.
+#
 function install_apt_packages() {
     local missing_packages=()
     local package
@@ -48,6 +60,9 @@ function install_apt_packages() {
     run_apt_get install -y "${missing_packages[@]}"
 }
 
+#
+# @description Remove packages that are safe to uninstall from `PACKAGES`.
+#
 function uninstall_apt_packages() {
     local removable_packages=()
     local package
@@ -65,6 +80,9 @@ function uninstall_apt_packages() {
     run_apt_get remove -y "${removable_packages[@]}"
 }
 
+#
+# @description Install the required Ubuntu dependencies.
+#
 function main() {
     install_apt_packages
 }

--- a/install/ubuntu/common/ssh.sh
+++ b/install/ubuntu/common/ssh.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/common/ssh.sh
+# @brief Install the OpenSSH client on Ubuntu.
+# @description
+#   Installs or removes the Ubuntu OpenSSH client package while preserving
+#   proxy-related environment variables.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -10,14 +16,23 @@ readonly PACKAGES=(
     openssh-client
 )
 
+#
+# @description Install the OpenSSH client package.
+#
 function install_openssh() {
     sudo --preserve-env=http_proxy,https_proxy,no_proxy apt-get install -y "${PACKAGES[@]}"
 }
 
+#
+# @description Remove the OpenSSH client package.
+#
 function uninstall_openssh() {
     sudo apt-get remove -y "${PACKAGES[@]}"
 }
 
+#
+# @description Run the OpenSSH client installation flow.
+#
 function main() {
     install_openssh
 }

--- a/install/ubuntu/common/tmux.sh
+++ b/install/ubuntu/common/tmux.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/common/tmux.sh
+# @brief Install tmux on Ubuntu.
+# @description
+#   Installs or removes the Ubuntu `tmux` package while preserving proxy
+#   environment variables.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -10,14 +16,23 @@ readonly PACKAGES=(
     tmux
 )
 
+#
+# @description Install the Ubuntu `tmux` package.
+#
 function install_tmux() {
     sudo --preserve-env=http_proxy,https_proxy,no_proxy apt-get install -y "${PACKAGES[@]}"
 }
 
+#
+# @description Remove the Ubuntu `tmux` package.
+#
 function uninstall_tmux() {
     sudo apt-get remove -y "${PACKAGES[@]}"
 }
 
+#
+# @description Run the Ubuntu tmux installation flow.
+#
 function main() {
     install_tmux
 }

--- a/install/ubuntu/server/misc.sh
+++ b/install/ubuntu/server/misc.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/server/misc.sh
+# @brief Install optional Ubuntu server packages.
+# @description
+#   Installs GPU-related utilities when available and always installs
+#   OpenCV-related system packages needed by the server environment.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Detect whether an NVIDIA GPU is available on the host.
+#
 function is_available_gpu() {
     if command -v nvidia-smi &> /dev/null; then
         return 0
@@ -14,11 +23,17 @@ function is_available_gpu() {
     fi
 }
 
+#
+# @description Install GPU monitoring utilities for NVIDIA-equipped hosts.
+#
 function install_gpu_related_packages() {
     sudo --preserve-env=http_proxy,https_proxy,no_proxy apt-get install --no-install-recommends -y \
         nvtop
 }
 
+#
+# @description Install packages commonly required by OpenCV-based workloads.
+#
 function install_opencv_related_packages() {
     # To avoid the following error when running OpenCV-based applications:
     # ImportError: libGL.so.1: cannot open shared object file: No such file or directory
@@ -27,6 +42,9 @@ function install_opencv_related_packages() {
         ncat
 }
 
+#
+# @description Install optional Ubuntu server packages for the current host.
+#
 function main() {
     if is_available_gpu; then
         install_gpu_related_packages

--- a/install/ubuntu/server/setup_locale.sh
+++ b/install/ubuntu/server/setup_locale.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/server/setup_locale.sh
+# @brief Ensure the preferred locale exists on Ubuntu servers.
+# @description
+#   Generates `en_US.UTF-8` when it is missing and updates the system locale
+#   configuration.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -8,6 +14,9 @@ fi
 
 readonly TARGET="en_US.UTF-8"
 
+#
+# @description Generate the target locale when the server does not have it yet.
+#
 function main() {
     # `locale -a` often outputs in lowercase, so we convert to lowercase for comparison
     TARGET_LOWER=$(echo "$TARGET" | tr '[:upper:]' '[:lower:]')

--- a/install/ubuntu/server/setup_timezone.sh
+++ b/install/ubuntu/server/setup_timezone.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/server/setup_timezone.sh
+# @brief Configure the server timezone.
+# @description
+#   Points the system timezone at `Asia/Tokyo` and installs `tzdata`
+#   non-interactively.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Apply the repository's preferred timezone configuration.
+#
 function main() {
     export TZ="Asia/Tokyo"
     sudo ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime

--- a/install/ubuntu/server/ssh_server.sh
+++ b/install/ubuntu/server/ssh_server.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/server/ssh_server.sh
+# @brief Install and configure an Ubuntu SSH server.
+# @description
+#   Installs `openssh-server`, relaxes the container-oriented SSH settings used
+#   by this repository, and starts the SSH service when running inside Docker.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -8,6 +14,9 @@ fi
 
 declare -r SSH_PORT="${DOTFILES_SERVER_SSH_PORT:-22}"
 
+#
+# @description Install the Ubuntu OpenSSH server package and its prerequisites.
+#
 function install_openssh_server() {
     # install openssh-server and vim
     sudo --preserve-env=http_proxy,https_proxy,no_proxy apt-get install --no-install-recommends -y \
@@ -15,6 +24,9 @@ function install_openssh_server() {
         openssh-server
 }
 
+#
+# @description Merge proxy-related variables into `AcceptEnv` in `sshd_config`.
+#
 function configure_accept_env() {
     local current add merged
 
@@ -32,6 +44,9 @@ function configure_accept_env() {
     echo "AcceptEnv $merged" | sudo tee -a /etc/ssh/sshd_config
 }
 
+#
+# @description Configure `sshd` for the repository's container-oriented setup.
+#
 function setup_sshd() {
     sudo mkdir -p /var/run/sshd
     mkdir -p ${HOME}/.ssh
@@ -51,11 +66,17 @@ function setup_sshd() {
     touch ${HOME}/.ssh/authorized_keys
 }
 
+#
+# @description Start the SSH service after configuration has been validated.
+#
 function run_sshd() {
     # run sshd
     sudo /usr/sbin/service ssh start
 }
 
+#
+# @description Install, configure, and start the Ubuntu SSH server.
+#
 function main() {
     install_openssh_server
     setup_sshd

--- a/install/ubuntu/server/starship.sh
+++ b/install/ubuntu/server/starship.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# @file install/ubuntu/server/starship.sh
+# @brief Install the Starship prompt on Ubuntu servers.
+# @description
+#   Downloads the upstream Starship installer and places the binary in the
+#   user's local bin directory.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
@@ -8,6 +14,9 @@ fi
 
 readonly BIN_DIR="${HOME}/.local/bin"
 
+#
+# @description Download and install the Starship binary.
+#
 function install_starship() {
     # equivalent to `https://starship.rs/install.sh`
     local url="https://raw.githubusercontent.com/starship/starship/master/install/install.sh"
@@ -21,10 +30,16 @@ function install_starship() {
         --bin-dir "${BIN_DIR}"
 }
 
+#
+# @description Remove the locally installed Starship binary directory.
+#
 function uninstall_starship() {
     rm -rf "${BIN_DIR}"
 }
 
+#
+# @description Run the Starship installation flow.
+#
 function main() {
     install_starship
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+shdoc = "head"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,28 @@
+site_name: Dotfiles Docs
+site_description: Generated reference for shell-based dotfiles automation.
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.top
+    - content.code.copy
+
+plugins:
+  - search
+  - toc-md:
+      output_path: catalog.md
+      ignore_page_pattern: 'index.*\.md$|catalog.*\.md$'
+
+extra_css:
+  - assets/stylesheets/extra.css
+
+markdown_extensions:
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -15,16 +15,32 @@ readonly LANDING_PAGE="${DOCS_DIR}/index.md"
 readonly CATALOG_PAGE="${DOCS_DIR}/catalog.md"
 readonly TEMPLATE_MAPPING_PAGE="${REFERENCE_DIR}/chezmoi-templates.md"
 readonly LANDING_PREVIEW_LIMIT=6
+readonly SHDOC_PLUGIN_NAME="shdoc"
+readonly SHDOC_PLUGIN_REPOSITORY="https://github.com/shunk031/mise-shdoc.git"
 
 #
 # @description Regenerate every public docs page under `docs/`.
 #
 function main() {
+    ensure_shdoc_plugin_installed
     clean_generated_docs
     generate_reference_pages
     generate_template_mapping_page
     generate_catalog_placeholder
     generate_landing_page
+}
+
+#
+# @description Trust the local `mise.toml` and install the custom `shdoc` plugin.
+#
+function ensure_shdoc_plugin_installed() {
+    mise trust --yes
+
+    if mise plugins ls | grep -qx "${SHDOC_PLUGIN_NAME}"; then
+        return
+    fi
+
+    mise plugins install "${SHDOC_PLUGIN_NAME}" "${SHDOC_PLUGIN_REPOSITORY}"
 }
 
 #

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -636,7 +636,7 @@ function print_landing_stat() {
 # @description Print the quick-start card shown on the landing page.
 #
 function print_quickstart_card() {
-    cat <<'EOF'
+    cat << 'EOF'
 <div class="landing-card landing-card--command" markdown="1">
 
 <p class="landing-kicker">Quick Start</p>
@@ -659,7 +659,7 @@ EOF
 # @description Print the pipeline summary card shown on the landing page.
 #
 function print_pipeline_card() {
-    cat <<'EOF'
+    cat << 'EOF'
 <div class="landing-card" markdown="1">
 
 <p class="landing-kicker">Pipeline</p>
@@ -686,7 +686,7 @@ function print_catalog_card() {
     local source_count="$1"
     local template_count="$2"
 
-    cat <<EOF
+    cat << EOF
 <div class="landing-card" markdown="1">
 
 <p class="landing-kicker">Coverage</p>

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,872 @@
+#!/usr/bin/env bash
+
+# @file scripts/generate-docs.sh
+# @brief Generate the MkDocs input for shell-based repository assets.
+# @description
+#   Collects tracked shell sources, renders Markdown reference pages, creates a
+#   curated landing page, and writes a chezmoi template mapping page under
+#   `docs/`.
+
+set -Eeuo pipefail
+
+readonly DOCS_DIR="docs"
+readonly REFERENCE_DIR="${DOCS_DIR}/reference"
+readonly LANDING_PAGE="${DOCS_DIR}/index.md"
+readonly CATALOG_PAGE="${DOCS_DIR}/catalog.md"
+readonly TEMPLATE_MAPPING_PAGE="${REFERENCE_DIR}/chezmoi-templates.md"
+readonly LANDING_PREVIEW_LIMIT=6
+
+#
+# @description Regenerate every public docs page under `docs/`.
+#
+function main() {
+    clean_generated_docs
+    generate_reference_pages
+    generate_template_mapping_page
+    generate_catalog_placeholder
+    generate_landing_page
+}
+
+#
+# @description Remove stale generated docs before a new generation pass.
+#
+function clean_generated_docs() {
+    rm -rf "${REFERENCE_DIR}"
+    rm -f "${LANDING_PAGE}" "${CATALOG_PAGE}"
+    mkdir -p "${REFERENCE_DIR}"
+}
+
+#
+# @description List tracked shell source files that should become public docs.
+#
+function collect_source_files() {
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        git ls-files -- \
+            ":(glob)install/**/*.sh" \
+            ":(glob)scripts/**/*.sh" \
+            ":(glob)home/dot_local/bin/**" \
+            ":(glob)home/dot_claude/hooks/**" \
+            ":(glob)home/dot_config/alias/*.sh"
+        return
+    fi
+
+    if [[ -d "install" ]]; then
+        find "install" -type f -name "*.sh"
+    fi
+
+    if [[ -d "scripts" ]]; then
+        find "scripts" -type f -name "*.sh"
+    fi
+
+    if [[ -d "home/dot_local/bin" ]]; then
+        find "home/dot_local/bin" -type f
+    fi
+
+    if [[ -d "home/dot_claude/hooks" ]]; then
+        find "home/dot_claude/hooks" -type f
+    fi
+
+    if [[ -d "home/dot_config/alias" ]]; then
+        find "home/dot_config/alias" -type f -name "*.sh"
+    fi
+}
+
+#
+# @description List tracked chezmoi wrapper templates for mapping generation.
+#
+function collect_template_files() {
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        git ls-files -- ":(glob)home/.chezmoiscripts/**/*.tmpl" | LC_ALL=C sort
+        return
+    fi
+
+    if [[ -d "home/.chezmoiscripts" ]]; then
+        find "home/.chezmoiscripts" -type f -name "*.tmpl" | LC_ALL=C sort
+    fi
+}
+
+#
+# @description Convert a source file path into its generated Markdown path.
+# @arg $1 path Source file path relative to the repository root.
+#
+function output_path_for_source() {
+    local source_path="$1"
+    local output_path="${REFERENCE_DIR}/${source_path}"
+
+    if [[ "${output_path}" == *.sh ]]; then
+        output_path="${output_path%.sh}.md"
+    else
+        output_path="${output_path}.md"
+    fi
+
+    printf "%s\n" "${output_path}"
+}
+
+#
+# @description Classify a source file into a stable landing-page group.
+# @arg $1 path Source file path relative to the repository root.
+#
+function source_group_for_path() {
+    local source_path="$1"
+
+    case "${source_path}" in
+    install/*)
+        printf "install\n"
+        ;;
+    scripts/*)
+        printf "scripts\n"
+        ;;
+    home/dot_local/bin/*)
+        printf "commands\n"
+        ;;
+    home/dot_claude/hooks/*)
+        printf "hooks\n"
+        ;;
+    home/dot_config/alias/*)
+        printf "aliases\n"
+        ;;
+    *)
+        printf "other\n"
+        ;;
+    esac
+}
+
+#
+# @description Classify a source file for generated page metadata.
+# @arg $1 path Source file path relative to the repository root.
+#
+function source_category_for_path() {
+    local group
+
+    group="$(source_group_for_path "$1")"
+
+    case "${group}" in
+    install)
+        printf "install script\n"
+        ;;
+    scripts)
+        printf "repository script\n"
+        ;;
+    commands)
+        printf "shell executable\n"
+        ;;
+    hooks)
+        printf "Claude hook\n"
+        ;;
+    aliases)
+        printf "shell aliases\n"
+        ;;
+    *)
+        printf "shell source\n"
+        ;;
+    esac
+}
+
+#
+# @description Return the human-readable title for a landing-page group.
+# @arg $1 string Stable group slug.
+#
+function source_group_title() {
+    local group="$1"
+
+    case "${group}" in
+    install)
+        printf "Install Scripts\n"
+        ;;
+    scripts)
+        printf "Repository Scripts\n"
+        ;;
+    commands)
+        printf "Local Commands\n"
+        ;;
+    hooks)
+        printf "Claude Hooks\n"
+        ;;
+    aliases)
+        printf "Alias Bundles\n"
+        ;;
+    *)
+        printf "Other Sources\n"
+        ;;
+    esac
+}
+
+#
+# @description Return the summary sentence for a landing-page group.
+# @arg $1 string Stable group slug.
+#
+function source_group_description() {
+    local group="$1"
+
+    case "${group}" in
+    install)
+        printf 'Bootstrap and application setup flows stored under `install/**`.\n'
+        ;;
+    scripts)
+        printf 'Repository maintenance and verification helpers under `scripts/**`.\n'
+        ;;
+    commands)
+        printf 'Executable helpers published from `home/dot_local/bin/**`.\n'
+        ;;
+    hooks)
+        printf "Claude Code hook scripts that enforce local automation policies.\n"
+        ;;
+    aliases)
+        printf "Shell alias collections for common, client, and server profiles.\n"
+        ;;
+    *)
+        printf "Additional generated shell references.\n"
+        ;;
+    esac
+}
+
+#
+# @description Extract the first meaningful leading comment from a source file.
+# @arg $1 path Source file path relative to the repository root.
+#
+function extract_summary() {
+    local source_path="$1"
+    local base_name
+
+    base_name="$(basename "${source_path}")"
+
+    awk -v base_name="${base_name}" '
+        NR == 1 && /^#!/ { next }
+        /^[[:space:]]*$/ {
+            if (capturing) {
+                print summary
+                printed = 1
+                exit
+            }
+            next
+        }
+        /^[[:space:]]*#/ {
+            line = $0
+            sub(/^[[:space:]]*#[[:space:]]?/, "", line)
+            gsub(/[[:space:]]+/, " ", line)
+            sub(/^[[:space:]]+/, "", line)
+            gsub(/[[:space:]]+$/, "", line)
+
+            if (line == "" || line == base_name || line ~ /^[-_#=*[:space:]]+$/) {
+                if (capturing) {
+                    print summary
+                    printed = 1
+                    exit
+                }
+                next
+            }
+
+            if (line ~ /^@/) {
+                if (capturing) {
+                    print summary
+                    printed = 1
+                    exit
+                }
+                next
+            }
+
+            if (capturing) {
+                summary = summary " " line
+            } else {
+                summary = line
+                capturing = 1
+            }
+            next
+        }
+        {
+            if (capturing) {
+                print summary
+                printed = 1
+            }
+            exit
+        }
+        END {
+            if (capturing && !printed) {
+                print summary
+            }
+        }
+    ' "${source_path}"
+}
+
+#
+# @description Extract a short single-line summary suitable for landing-page cards.
+# @arg $1 path Source file path relative to the repository root.
+# @arg $2 int Maximum character count before truncation.
+#
+function short_summary_for_source() {
+    local source_path="$1"
+    local max_length="$2"
+    local summary
+
+    summary="$(extract_summary "${source_path}")"
+
+    if [[ -z "${summary}" ]]; then
+        printf "\n"
+        return
+    fi
+
+    if [[ "${#summary}" -le "${max_length}" ]]; then
+        printf "%s\n" "${summary}"
+        return
+    fi
+
+    printf "%s...\n" "${summary:0:$((max_length - 3))}"
+}
+
+#
+# @description Extract documented function names from a shell source file.
+# @arg $1 path Source file path relative to the repository root.
+#
+function extract_function_names() {
+    local source_path="$1"
+
+    awk '
+        /^[[:space:]]*function[[:space:]]+[[:alpha:]_][[:alnum:]_]*[[:space:]]*\(\)[[:space:]]*\{/ {
+            name = $0
+            sub(/^[[:space:]]*function[[:space:]]+/, "", name)
+            sub(/[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*$/, "", name)
+            print name
+            next
+        }
+        /^[[:space:]]*[[:alpha:]_][[:alnum:]_]*[[:space:]]*\(\)[[:space:]]*\{/ {
+            name = $0
+            sub(/^[[:space:]]*/, "", name)
+            sub(/[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*$/, "", name)
+            print name
+        }
+    ' "${source_path}" | LC_ALL=C sort -u
+}
+
+#
+# @description Print the standard page header used by generated docs pages.
+# @arg $1 path Source file path.
+# @arg $2 string Generated category label.
+# @arg $3 string Renderer identifier.
+#
+function print_page_header() {
+    local source_path="$1"
+    local category="$2"
+    local renderer="$3"
+    local summary=""
+
+    if [[ "${renderer}" != "shdoc" ]]; then
+        summary="$(extract_summary "${source_path}")"
+    fi
+
+    printf "# %s\n\n" "${source_path}"
+
+    if [[ -n "${summary}" ]]; then
+        printf "%s\n\n" "${summary}"
+    fi
+
+    printf '## Metadata\n\n'
+    printf -- '- Source: `%s`\n' "${source_path}"
+    printf -- '- Category: %s\n' "${category}"
+    printf -- '- Renderer: `%s`\n\n' "${renderer}"
+}
+
+#
+# @description Embed the raw source file in a fenced bash code block.
+# @arg $1 path Source file path.
+#
+function print_source_block() {
+    local source_path="$1"
+
+    printf '## Source\n\n'
+    printf '```bash\n'
+    cat "${source_path}"
+    printf '\n```\n'
+}
+
+#
+# @description Render a shell source page using `shdoc` or the fallback format.
+# @arg $1 path Source file path.
+# @arg $2 string Generated category label.
+#
+function render_shell_page() {
+    local source_path="$1"
+    local category="$2"
+    local shdoc_output
+
+    if shdoc_output="$(mise exec shdoc -- shdoc < "${source_path}" 2> /dev/null)" && [[ -n "${shdoc_output//[[:space:]]/}" ]]; then
+        print_page_header "${source_path}" "${category}" "shdoc"
+        printf '## Generated Reference\n\n'
+        awk '
+            NR == 1 && /^# / { next }
+            in_index {
+                if (/^## /) {
+                    in_index = 0
+                } else {
+                    next
+                }
+            }
+            /^## Index$/ {
+                in_index = 1
+                next
+            }
+            { print }
+        ' <<< "${shdoc_output}"
+        return
+    fi
+
+    print_page_header "${source_path}" "${category}" "shell-fallback"
+
+    local function_count=0
+
+    while IFS= read -r function_name; do
+        [[ -n "${function_name}" ]] || continue
+
+        if [[ "${function_count}" -eq 0 ]]; then
+            printf '## Functions\n\n'
+        fi
+
+        printf -- '- `%s`\n' "${function_name}"
+        function_count=$((function_count + 1))
+    done < <(extract_function_names "${source_path}")
+
+    if [[ "${function_count}" -gt 0 ]]; then
+        printf "\n"
+    fi
+
+    print_source_block "${source_path}"
+}
+
+#
+# @description Render an alias file as a list of aliases plus source code.
+# @arg $1 path Source file path.
+# @arg $2 string Generated category label.
+#
+function render_alias_page() {
+    local source_path="$1"
+    local category="$2"
+    local found_aliases=false
+
+    print_page_header "${source_path}" "${category}" "alias-fallback"
+    printf '## Aliases\n\n'
+
+    while IFS= read -r line; do
+        [[ "${line}" == alias\ * ]] || continue
+
+        local alias_definition="${line#alias }"
+        local alias_name="${alias_definition%%=*}"
+        local alias_value="${alias_definition#*=}"
+
+        printf -- '- `%s`: `%s`\n' "${alias_name}" "${alias_value}"
+        found_aliases=true
+    done < "${source_path}"
+
+    if [[ "${found_aliases}" == false ]]; then
+        printf "No aliases were detected.\n"
+    fi
+
+    printf "\n"
+    print_source_block "${source_path}"
+}
+
+#
+# @description Generate Markdown reference pages for all collected source files.
+#
+function generate_reference_pages() {
+    while IFS= read -r source_path; do
+        [[ -n "${source_path}" ]] || continue
+
+        local output_path
+        local category
+
+        output_path="$(output_path_for_source "${source_path}")"
+        category="$(source_category_for_path "${source_path}")"
+
+        mkdir -p "$(dirname "${output_path}")"
+
+        if [[ "${source_path}" == home/dot_config/alias/* ]]; then
+            render_alias_page "${source_path}" "${category}" > "${output_path}"
+        else
+            render_shell_page "${source_path}" "${category}" > "${output_path}"
+        fi
+    done < <(collect_source_files | LC_ALL=C sort)
+}
+
+#
+# @description Resolve the included `install/...` source for a chezmoi wrapper.
+# @arg $1 path Template file path.
+#
+function resolve_template_target() {
+    local template_path="$1"
+
+    sed -n 's@.*{{[[:space:]]*include[[:space:]]*"\.\./\(install/[^"]*\)"[[:space:]]*}}.*@\1@p' "${template_path}" | head -n 1
+}
+
+#
+# @description Convert a source path into a docs-relative Markdown link target.
+# @arg $1 path Source file path.
+#
+function link_for_source_page() {
+    local source_path="$1"
+    local output_path
+
+    output_path="$(output_path_for_source "${source_path}")"
+    printf "%s\n" "${output_path#${REFERENCE_DIR}/}"
+}
+
+#
+# @description Convert a source path into a landing-page Markdown link target.
+# @arg $1 path Source file path.
+#
+function docs_link_for_source_page() {
+    printf "reference/%s\n" "$(link_for_source_page "$1")"
+}
+
+#
+# @description Generate a page mapping chezmoi wrapper templates to install scripts.
+#
+function generate_template_mapping_page() {
+    local found_template=false
+
+    {
+        printf '# home/.chezmoiscripts Template Mapping\n\n'
+        printf 'This page maps `home/.chezmoiscripts/**/*.tmpl` wrappers to the source scripts they include.\n\n'
+        printf '## Mappings\n\n'
+
+        while IFS= read -r template_path; do
+            [[ -n "${template_path}" ]] || continue
+
+            local target_path
+            local target_link
+
+            target_path="$(resolve_template_target "${template_path}")"
+            if [[ -z "${target_path}" ]]; then
+                printf "Warning: skipping unmapped template %s\n" "${template_path}" >&2
+                continue
+            fi
+
+            target_link="$(link_for_source_page "${target_path}")"
+            printf -- '- `%s` -> [`%s`](%s)\n' "${template_path}" "${target_path}" "${target_link}"
+            found_template=true
+        done < <(collect_template_files)
+
+        if [[ "${found_template}" == false ]]; then
+            printf "No template wrappers were found.\n"
+        fi
+        printf "\n"
+    } > "${TEMPLATE_MAPPING_PAGE}"
+}
+
+#
+# @description Create a placeholder catalog page until `mkdocs-toc-md` rewrites it.
+#
+function generate_catalog_placeholder() {
+    {
+        printf '# Catalog\n\n'
+        printf 'This page is regenerated automatically by `mkdocs-toc-md` during `make docs`, `make serve`, or `make deploy`.\n'
+    } > "${CATALOG_PAGE}"
+}
+
+#
+# @description Count non-empty input lines from stdin.
+#
+function count_lines() {
+    awk '
+        NF { count++ }
+        END { print count + 0 }
+    '
+}
+
+#
+# @description Count all collected source files.
+#
+function count_source_files() {
+    collect_source_files | count_lines
+}
+
+#
+# @description Count source files that belong to a single landing-page group.
+# @arg $1 string Stable group slug.
+#
+function count_sources_for_group() {
+    local group="$1"
+    local count=0
+
+    while IFS= read -r source_path; do
+        [[ -n "${source_path}" ]] || continue
+
+        if [[ "$(source_group_for_path "${source_path}")" == "${group}" ]]; then
+            count=$((count + 1))
+        fi
+    done < <(collect_source_files | LC_ALL=C sort)
+
+    printf "%s\n" "${count}"
+}
+
+#
+# @description Count template wrappers that resolve to a source script.
+#
+function count_mapped_templates() {
+    local count=0
+
+    while IFS= read -r template_path; do
+        [[ -n "${template_path}" ]] || continue
+
+        if [[ -n "$(resolve_template_target "${template_path}")" ]]; then
+            count=$((count + 1))
+        fi
+    done < <(collect_template_files)
+
+    printf "%s\n" "${count}"
+}
+
+#
+# @description Print one stat card for the generated landing page.
+# @arg $1 string Large numeric value.
+# @arg $2 string Card label.
+# @arg $3 string Supplemental detail line.
+#
+function print_landing_stat() {
+    local value="$1"
+    local label="$2"
+    local note="$3"
+
+    printf '<div class="landing-stat">\n'
+    printf '  <span class="landing-stat__value">%s</span>\n' "${value}"
+    printf '  <span class="landing-stat__label">%s</span>\n' "${label}"
+    printf '  <span class="landing-stat__note">%s</span>\n' "${note}"
+    printf '</div>\n'
+}
+
+#
+# @description Print the quick-start card shown on the landing page.
+#
+function print_quickstart_card() {
+    cat <<'EOF'
+<div class="landing-card landing-card--command" markdown="1">
+
+<p class="landing-kicker">Quick Start</p>
+
+### Build, preview, deploy
+
+Run the documentation pipeline from the repository root.
+
+```console
+make docs
+make serve PORT=8001
+make deploy
+```
+
+</div>
+EOF
+}
+
+#
+# @description Print the pipeline summary card shown on the landing page.
+#
+function print_pipeline_card() {
+    cat <<'EOF'
+<div class="landing-card" markdown="1">
+
+<p class="landing-kicker">Pipeline</p>
+
+### Generated end to end
+
+The site is rebuilt from tracked shell sources every time.
+
+- `mise exec shdoc -- shdoc` renders structured script references when annotations exist
+- fallback pages still expose aliases, functions, and raw source when `shdoc` is not enough
+- `mkdocs-toc-md` writes the full navigation tree to [catalog.md](catalog.md)
+- `uv run --with` keeps the MkDocs toolchain ephemeral
+
+</div>
+EOF
+}
+
+#
+# @description Print the catalog overview card shown on the landing page.
+# @arg $1 string Total number of source reference pages.
+# @arg $2 string Number of mapped template wrappers.
+#
+function print_catalog_card() {
+    local source_count="$1"
+    local template_count="$2"
+
+    cat <<EOF
+<div class="landing-card" markdown="1">
+
+<p class="landing-kicker">Coverage</p>
+
+### Browse the full tree
+
+The homepage stays curated, while the complete generated table of contents lives on its own page.
+
+- [Open the full catalog](catalog.md)
+- **${source_count}** source reference pages are generated from tracked shell assets
+- **${template_count}** chezmoi wrappers are mapped back to their source scripts
+
+</div>
+EOF
+}
+
+#
+# @description Print the template-mapping card shown on the landing page.
+#
+function print_template_mapping_card() {
+    local mapped_count
+    local shown_count=0
+
+    mapped_count="$(count_mapped_templates)"
+
+    printf '<div class="landing-card" markdown="1">\n\n'
+    printf '<p class="landing-kicker">Chezmoi</p>\n\n'
+    printf '### Template Mapping\n\n'
+    printf 'Wrapper templates under `home/.chezmoiscripts` are linked back to the source scripts they include.\n\n'
+    printf '_%s mapped wrappers_\n\n' "${mapped_count}"
+    printf -- '- [Open template mapping](reference/chezmoi-templates.md)\n'
+
+    while IFS= read -r template_path; do
+        [[ -n "${template_path}" ]] || continue
+
+        local target_path
+
+        target_path="$(resolve_template_target "${template_path}")"
+        [[ -n "${target_path}" ]] || continue
+
+        if [[ "${shown_count}" -ge "${LANDING_PREVIEW_LIMIT}" ]]; then
+            continue
+        fi
+
+        printf -- '- `%s` -> [`%s`](%s)\n' \
+            "${template_path}" \
+            "${target_path}" \
+            "$(docs_link_for_source_page "${target_path}")"
+        shown_count=$((shown_count + 1))
+    done < <(collect_template_files)
+
+    if [[ "${mapped_count}" -gt "${shown_count}" ]]; then
+        printf '\n[%s more mappings](reference/chezmoi-templates.md)\n' "$((mapped_count - shown_count))"
+    fi
+
+    printf '\n</div>\n'
+}
+
+#
+# @description Print one category card with a preview of generated pages.
+# @arg $1 string Stable group slug.
+# @arg $2 int Number of links to preview before deferring to the catalog.
+#
+function print_category_card() {
+    local group="$1"
+    local preview_limit="$2"
+    local title
+    local description
+    local total_count
+    local shown_count=0
+
+    title="$(source_group_title "${group}")"
+    description="$(source_group_description "${group}")"
+    total_count="$(count_sources_for_group "${group}")"
+
+    if [[ "${total_count}" -eq 0 ]]; then
+        return
+    fi
+
+    printf '<div class="landing-card" markdown="1">\n\n'
+    printf '<p class="landing-kicker">%s</p>\n\n' "${title}"
+    printf '### %s\n\n' "${title}"
+    printf '%s\n\n' "${description}"
+    printf '_%s documented entries_\n\n' "${total_count}"
+
+    while IFS= read -r source_path; do
+        [[ -n "${source_path}" ]] || continue
+
+        if [[ "$(source_group_for_path "${source_path}")" != "${group}" ]]; then
+            continue
+        fi
+
+        if [[ "${shown_count}" -ge "${preview_limit}" ]]; then
+            continue
+        fi
+
+        local summary
+
+        summary="$(short_summary_for_source "${source_path}" 120)"
+
+        if [[ -n "${summary}" ]]; then
+            printf -- '- [`%s`](%s): %s\n' \
+                "${source_path}" \
+                "$(docs_link_for_source_page "${source_path}")" \
+                "${summary}"
+        else
+            printf -- '- [`%s`](%s)\n' \
+                "${source_path}" \
+                "$(docs_link_for_source_page "${source_path}")"
+        fi
+
+        shown_count=$((shown_count + 1))
+    done < <(collect_source_files | LC_ALL=C sort)
+
+    if [[ "${total_count}" -gt "${shown_count}" ]]; then
+        printf '\n[%s more entries in the full catalog](catalog.md)\n' "$((total_count - shown_count))"
+    fi
+
+    printf '\n</div>\n'
+}
+
+#
+# @description Generate the rich top-level landing page under `docs/index.md`.
+#
+function generate_landing_page() {
+    local source_count
+    local install_count
+    local script_count
+    local command_count
+    local hook_count
+    local alias_count
+    local template_count
+
+    source_count="$(count_source_files)"
+    install_count="$(count_sources_for_group "install")"
+    script_count="$(count_sources_for_group "scripts")"
+    command_count="$(count_sources_for_group "commands")"
+    hook_count="$(count_sources_for_group "hooks")"
+    alias_count="$(count_sources_for_group "aliases")"
+    template_count="$(count_mapped_templates)"
+
+    {
+        printf '<div class="landing-hero" markdown="1">\n\n'
+        printf '<p class="landing-hero__eyebrow">Generated with shdoc, MkDocs Material, toc-md, and uv</p>\n\n'
+        printf '# Dotfiles Shell Automation Docs\n\n'
+        printf 'Reference for installation flows, local commands, aliases, Claude hooks, and chezmoi wrappers maintained in this repository.\n\n'
+        printf '<div class="landing-actions" markdown="1">\n\n'
+        printf '[Browse Full Catalog](catalog.md){ .md-button .md-button--primary }\n'
+        printf '[View Template Mapping](reference/chezmoi-templates.md){ .md-button }\n'
+        printf '\n</div>\n\n'
+        printf '</div>\n\n'
+
+        printf '<div class="landing-stats">\n'
+        print_landing_stat "${source_count}" "source docs" "tracked shell assets"
+        print_landing_stat "${install_count}" "install scripts" "bootstrap and app setup"
+        print_landing_stat "${script_count}" "repo scripts" "maintenance and checks"
+        print_landing_stat "${command_count}" "local commands" "helpers under home/dot_local/bin"
+        print_landing_stat "${hook_count}" "Claude hooks" "local automation policies"
+        print_landing_stat "${alias_count}" "alias bundles" "common, client, server"
+        print_landing_stat "${template_count}" "template mappings" "chezmoi wrappers"
+        printf '</div>\n\n'
+
+        printf '## Quick Start\n\n'
+        printf '<div class="landing-grid landing-grid--summary">\n'
+        print_quickstart_card
+        print_pipeline_card
+        print_catalog_card "${source_count}" "${template_count}"
+        print_template_mapping_card
+        printf '</div>\n\n'
+
+        printf '## Browse By Area\n\n'
+        printf 'Each section links to generated reference pages. Update source comments, then rerun `make docs` to refresh the site.\n\n'
+        printf '<div class="landing-grid landing-grid--catalog">\n'
+        print_category_card "install" "${LANDING_PREVIEW_LIMIT}"
+        print_category_card "scripts" "${LANDING_PREVIEW_LIMIT}"
+        print_category_card "commands" "${LANDING_PREVIEW_LIMIT}"
+        print_category_card "hooks" "${LANDING_PREVIEW_LIMIT}"
+        print_category_card "aliases" "${LANDING_PREVIEW_LIMIT}"
+        printf '</div>\n'
+    } > "${LANDING_PAGE}"
+}
+
+main "$@"

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
+# @file scripts/run_benchmark.sh
+# @brief Measure zsh startup latency for the repository benchmark workflow.
+# @description
+#   Creates a temporary directory, records initial and average interactive zsh
+#   startup times, prints benchmark-action compatible JSON, and cleans up.
+
 set -Eeuo pipefail
 
 if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
+#
+# @description Create and print the temporary directory used for benchmark files.
+#
 function prepare_benchmark() {
     local tmp_dir
     tmp_dir="$(mktemp -d)"
@@ -13,17 +22,27 @@ function prepare_benchmark() {
     echo -n "${tmp_dir}"
 }
 
+#
+# @description Remove the benchmark result directory after reporting.
+# @arg $1 path Temporary benchmark directory.
+#
 function cleanup_result_dir() {
     local target_dir=$1
     echo "cleanup ${target_dir}" >&2
     rm -rf "${target_dir}"
 }
 
+#
+# @description Detect the current operating system in lowercase form.
+#
 function get_os() {
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     echo -n "${os}"
 }
 
+#
+# @description Select the appropriate `time` command for the current platform.
+#
 function get_time_command() {
     case "$(get_os)" in
     darwin)
@@ -35,6 +54,10 @@ function get_time_command() {
     esac
 }
 
+#
+# @description Measure the first interactive zsh startup time.
+# @arg $1 path Temporary benchmark directory.
+#
 function measure_initial_startup_time() {
     local benchmark_result_dir=$1
     local result_file="${benchmark_result_dir}/zsh-initial-startup-time.txt"
@@ -45,6 +68,10 @@ function measure_initial_startup_time() {
     "${time_cmd}" --format="%e" --output="${result_file}" zsh -i -c exit
 }
 
+#
+# @description Measure ten interactive zsh startups for an average value.
+# @arg $1 path Temporary benchmark directory.
+#
 function measure_average_startup_time() {
     local benchmark_result_dir=$1
 
@@ -58,6 +85,10 @@ function measure_average_startup_time() {
     done
 }
 
+#
+# @description Print benchmark-action compatible JSON from collected timings.
+# @arg $1 path Temporary benchmark directory.
+#
 function record_startup_time() {
     local benchmark_result_dir=$1
 
@@ -85,6 +116,9 @@ EOJ
 
 }
 
+#
+# @description Run the full benchmark workflow and print the JSON payload.
+#
 function main() {
     local tmp_dir
     tmp_dir=$(prepare_benchmark)

--- a/scripts/run_unit_test.sh
+++ b/scripts/run_unit_test.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 
+# @file scripts/run_unit_test.sh
+# @brief Run the repository's shell unit tests.
+# @description
+#   Dispatches the common Bats suite and the OS-specific Bats suite selected by
+#   the `OS` environment variable.
+
 # Keep this wrapper minimal: CI invokes this script through `bashcov`.
 # `-u` is intentionally omitted because strict nounset can propagate through
 # bashcov's SHELLOPTS/xtrace path and break third-party scripts under test.
 set -Eeo pipefail
 
+#
+# @description Run the install tests shared across all CI targets.
+#
 function run_common_test() {
     # Common install tests executed on every matrix target.
     bats -r "tests/install/common/"
 }
 
+#
+# @description Run the OS-specific Bats suite for the active CI target.
+#
 function run_os_specific_test() {
     if [ "${OS}" == "macos-14" ]; then
         # macOS-only install tests.
@@ -24,6 +36,9 @@ function run_os_specific_test() {
     fi
 }
 
+#
+# @description Run the full unit test flow used by CI.
+#
 function main() {
     run_common_test
     run_os_specific_test


### PR DESCRIPTION
## Summary
- add a generated docs pipeline driven by `make`, `uv`, `mkdocs`, `mkdocs-material`, `mkdocs-toc-md`, and `shdoc`
- add documentation-oriented comments to shell install scripts, local commands, aliases, and Claude hooks so reference pages can be generated from tracked assets
- replace the raw TOC homepage with a richer generated landing page and move the full generated table of contents to `catalog.md`
- bootstrap the custom `shdoc` mise plugin and trust local `mise.toml` before `mise install` in both the install script and docs CI flow
- install `gawk` in macOS CI/bootstrap paths so the custom `shdoc` plugin can complete its post-install step
- document in `AGENTS.md` that shell-script comment additions and updates must use English shdoc-compatible format
- add GitHub Actions deployment for the docs site and keep generated docs plus internal Codex notes out of version control

## Testing
- `git diff -- AGENTS.md`
- `shfmt --indent 4 --space-redirects --diff install/common/mise.sh scripts/generate-docs.sh`
- `bash -n install/common/mise.sh`
- `bash -n install/macos/common/dependencies.sh`
- `bash -n scripts/generate-docs.sh`
- `mise trust --yes && mise install --before 7d`
- `make docs`
- `make serve PORT=54701`
- `curl -s http://127.0.0.1:54701/ | rg -n \"landing-hero|Browse Full Catalog|assets/stylesheets/extra.css|Install Scripts\"`

## Notes
- the repository default branch is `master`
- generated docs remain ephemeral and are rebuilt during `make docs`, `make serve`, and CI deploy
- `make docs` still prints the pre-existing unmapped template warning for `home/.chezmoiscripts/common/run_once_before_01-decrypt-private-key.sh.tmpl`
- MkDocs Material emits its upstream MkDocs 2.0 warning during build
- local `bats` execution was skipped per repository policy