### PR TITLE
feat(skills): add shdoc shell docs skill

### DIFF
--- a/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shdoc-shell-docs
-description: Write and review shellscript documentation with shdoc annotations. Use when Codex creates, edits, or reviews `.sh` files or shell executables and should add, repair, or normalize `@file`, `@brief`, `@description`, `@arg`, `@option`, and `@example` comments to match `vendor/shdoc`.
+description: Write and review shellscript documentation with shdoc annotations. Use when Codex creates, edits, or reviews `.sh` files or shell executables and should add, repair, or normalize `@file`, `@brief`, `@description`, `@arg`, `@option`, and `@example` comments to match shdoc conventions.
 ---
 
 # Shdoc Shell Docs
@@ -12,7 +12,7 @@ Use this skill to make shellscript comments parseable by `shdoc` without bloatin
 ## Workflow
 
 1. Inspect the target shell file before writing comments.
-2. Treat `vendor/shdoc/README.md` as the canonical annotation reference when it exists.
+2. Treat the upstream `shdoc` README as the canonical annotation reference.
 3. Use `scripts/generate-docs.sh` as the repo-local style example when working in this repository.
 4. Add or repair file-level annotations near the top of the file:
    - Prefer `@file` for the script identifier.
@@ -37,4 +37,4 @@ Use this skill to make shellscript comments parseable by `shdoc` without bloatin
 ## References
 
 - Read `references/shdoc-rules.md` for the minimal tag set and concise examples.
-- Fall back to `vendor/shdoc/README.md` when you need the full annotation vocabulary.
+- Fall back to the upstream `shdoc` README when you need the full annotation vocabulary.

--- a/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: shdoc-shell-docs
+description: Write and review shellscript documentation with shdoc annotations. Use when Codex creates, edits, or reviews `.sh` files or shell executables and should add, repair, or normalize `@file`, `@brief`, `@description`, `@arg`, `@option`, and `@example` comments to match `vendor/shdoc`.
+---
+
+# Shdoc Shell Docs
+
+## Overview
+
+Use this skill to make shellscript comments parseable by `shdoc` without bloating simple code with boilerplate. Inspect the file first, then document the script and the non-trivial functions that benefit from generated reference docs.
+
+## Workflow
+
+1. Inspect the target shell file before writing comments.
+2. Treat `vendor/shdoc/README.md` as the canonical annotation reference when it exists.
+3. Use `scripts/generate-docs.sh` as the repo-local style example when working in this repository.
+4. Add or repair file-level annotations near the top of the file:
+   - Prefer `@file` for the script identifier.
+   - Add `@brief` for a single-sentence summary.
+   - Add multiline `@description` only when the script needs more context.
+5. Add function-level annotations only where they help:
+   - Start with `@description`.
+   - Add `@arg` for positional parameters.
+   - Add `@option` for flags and option-value pairs.
+   - Add `@example` when the call shape is not obvious.
+   - Add `@stdout`, `@stderr`, `@exitcode`, or `@see` only when they clarify observable behavior.
+6. Rewrite existing free-form comments into valid `shdoc` annotations instead of keeping two parallel comment styles.
+
+## Review Checklist
+
+- Confirm the docs match the implementation instead of guessing arguments or options.
+- Keep annotations immediately above the file header or function they describe.
+- Prefer behavior and operator-facing intent over internal implementation notes.
+- Skip boilerplate comments for trivial private helpers unless the user asks for exhaustive coverage.
+- Keep multiline annotation blocks compact and easy to render as Markdown.
+
+## References
+
+- Read `references/shdoc-rules.md` for the minimal tag set and concise examples.
+- Fall back to `vendor/shdoc/README.md` when you need the full annotation vocabulary.

--- a/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/SKILL.md
@@ -12,7 +12,7 @@ Use this skill to make shellscript comments parseable by `shdoc` without bloatin
 ## Workflow
 
 1. Inspect the target shell file before writing comments.
-2. Treat the upstream `shdoc` README as the canonical annotation reference.
+2. Read `references/shdoc-rules.md` before editing comments.
 3. Use `scripts/generate-docs.sh` as the repo-local style example when working in this repository.
 4. Add or repair file-level annotations near the top of the file:
    - Prefer `@file` for the script identifier.
@@ -36,5 +36,4 @@ Use this skill to make shellscript comments parseable by `shdoc` without bloatin
 
 ## References
 
-- Read `references/shdoc-rules.md` for the minimal tag set and concise examples.
-- Fall back to the upstream `shdoc` README when you need the full annotation vocabulary.
+- Read `references/shdoc-rules.md` for the minimal tag set, concise examples, and external reference policy.

--- a/home/dot_agents/skills/shdoc-shell-docs/agents/openai.yaml
+++ b/home/dot_agents/skills/shdoc-shell-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Shdoc Shell Docs"
+  short_description: "Write and review shdoc docs for shell scripts"
+  default_prompt: "Use $shdoc-shell-docs to add or review vendor/shdoc annotations for a shell script."

--- a/home/dot_agents/skills/shdoc-shell-docs/agents/openai.yaml
+++ b/home/dot_agents/skills/shdoc-shell-docs/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Shdoc Shell Docs"
   short_description: "Write and review shdoc docs for shell scripts"
-  default_prompt: "Use $shdoc-shell-docs to add or review vendor/shdoc annotations for a shell script."
+  default_prompt: "Use $shdoc-shell-docs to add or review shdoc annotations for a shell script."

--- a/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
@@ -4,7 +4,7 @@ Use this reference when the target file needs `shdoc`-compatible comments.
 
 ## Canonical Sources
 
-- Treat the upstream `shdoc` README as the source of truth for supported tags and formatting.
+- Use the official `shdoc` README as the source of truth for supported tags and formatting.
 - Use `scripts/generate-docs.sh` as the local style baseline in this repository.
 - Prefer `@file` over `@name` here because the repo example already uses `@file`.
 

--- a/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
@@ -1,0 +1,76 @@
+# Shdoc Rules
+
+Use this reference when the target file needs `shdoc`-compatible comments.
+
+## Canonical Sources
+
+- Treat `vendor/shdoc/README.md` as the source of truth for supported tags and formatting.
+- Use `scripts/generate-docs.sh` as the local style baseline in this repository.
+- Prefer `@file` over `@name` here because the repo example already uses `@file`.
+
+## Minimal File Header
+
+Use file-level annotations near the top of the script when the file is a meaningful entrypoint or library.
+
+```bash
+#!/usr/bin/env bash
+
+# @file scripts/example.sh
+# @brief Explain the script purpose in one line.
+# @description
+#   Add extra context only when the overall workflow needs it.
+```
+
+Guidelines:
+
+- Keep `@brief` to one sentence.
+- Use multiline `@description` for scope, side effects, or generated-doc context.
+- Omit the long description when the brief is enough.
+
+## Function Annotation Pattern
+
+Document non-trivial functions directly above the definition.
+
+```bash
+# @description Build the output path for a source file.
+# @arg $1 path Source file path relative to the repository root.
+function output_path_for_source() {
+    local source_path="$1"
+}
+```
+
+Add more tags only when they describe observable behavior:
+
+- `@arg`: positional parameters such as `$1`
+- `@option`: supported flags or option-value pairs
+- `@example`: invocation examples that clarify usage
+- `@stdout` and `@stderr`: meaningful output contracts
+- `@exitcode`: non-obvious return codes
+- `@see`: related functions or docs
+
+## Option and Example Pattern
+
+```bash
+# @description Lint one shell script for missing annotations.
+# @option -n | --dry-run Print findings without modifying files.
+# @arg $1 path Target shell script.
+# @example
+#   lint_shdoc --dry-run scripts/generate-docs.sh
+function lint_shdoc() {
+    local target="$1"
+}
+```
+
+## Repo-Specific Cues
+
+- A standalone `#` spacer line above a documented function is acceptable when it improves readability.
+- Phrase descriptions around what the function or script does for the caller.
+- Match argument names to the implementation, for example `path`, `string`, or `group`.
+- Preserve accurate existing wording when possible and normalize the format first.
+
+## Common Mistakes
+
+- Do not invent flags, parameters, or exit codes that the function does not implement.
+- Do not duplicate the same prose in both raw comments and `shdoc` tags.
+- Do not add documentation noise to tiny helpers whose name and body are already obvious.
+- Do not describe hidden implementation details when callers only need behavior.

--- a/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
+++ b/home/dot_agents/skills/shdoc-shell-docs/references/shdoc-rules.md
@@ -4,7 +4,7 @@ Use this reference when the target file needs `shdoc`-compatible comments.
 
 ## Canonical Sources
 
-- Treat `vendor/shdoc/README.md` as the source of truth for supported tags and formatting.
+- Treat the upstream `shdoc` README as the source of truth for supported tags and formatting.
 - Use `scripts/generate-docs.sh` as the local style baseline in this repository.
 - Prefer `@file` over `@name` here because the repo example already uses `@file`.
 


### PR DESCRIPTION
## Summary
- add a new `shdoc-shell-docs` skill under `home/dot_agents/skills`
- teach Codex when to add or normalize `shdoc` annotations while editing shell scripts
- keep the external README reference explicit in one place while preserving repo-local style guidance

## Testing
- validate `home/dot_agents/skills/shdoc-shell-docs` with `quick_validate.py` via `uv run --with pyyaml`