### PR TITLE
fix(tmux): update copy mode keybindings

### DIFF
--- a/home/dot_tmux.conf.d/system/client.conf
+++ b/home/dot_tmux.conf.d/system/client.conf
@@ -2,11 +2,9 @@
 set-option -g prefix C-z
 
 # Keybindings
-## Use Emacs-style keybindings in copy mode
-bind -r ^[ copy-mode
-bind -r ^] paste-buffer
-unbind -T copy-mode M-w
-unbind -T copy-mode C-w
+## Copy mode
+bind-key -T copy-mode C-Space send-keys -X begin-selection
+bind-key -T copy-mode M-w send-keys -X copy-selection-and-cancel
 
 # Status line
 ## Line colors


### PR DESCRIPTION
## Summary
- switch the copy mode section to explicit copy-mode table bindings
- start a selection with C-Space in copy mode
- copy the selection and leave copy mode with M-w

## Testing
- tmux -L codex-tmux-client-check -f /dev/null start-server \; source-file -n /tmp/chezmoi-tmux-copy-mode/home/dot_tmux.conf.d/system/client.conf \; kill-server