### PR TITLE
feat(config): split .agents/worklog by tool (claude vs codex)

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -1,7 +1,7 @@
 {
   "model": "opusplan",
   "alwaysThinkingEnabled": true,
-  "plansDirectory": "./plans",
+  "plansDirectory": "./.agents/worklog/claude",
   "permissions": {
     "deny": [
       "Bash(sudo:*)",

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -14,18 +14,18 @@
 - プロジェクト構成はプログラミング言語ごとに異なりますが、作業を開始する際、存在しない場合のみ以下の構成でセットアップしてください。
   - 作業中は plan と todo を常に更新し続けてください。
   - これらの plan/todo/learn ファイルはコミットしないでください。
-  - `.agents/worklog/plan/`: プロジェクトの計画や設計に関するドキュメントを格納するディレクトリ
+  - `.agents/worklog/codex/plan/`: プロジェクトの計画や設計に関するドキュメントを格納するディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_plan.md` のような形式でファイルを作成してください
     - 実装する前に計画を立て、必要であればユーザへの質問を行って計画用のドキュメントを更新してください。
-  - `.agents/worklog/todo/`: タスク管理用のディレクトリ
+  - `.agents/worklog/codex/todo/`: タスク管理用のディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_todo.md` のような形式でファイルを作成してください
-    - `.agents/worklog/plan/` ディレクトリのドキュメントをもとに、実装するタスクを洗い出して記述してください。
+    - `.agents/worklog/codex/plan/` ディレクトリのドキュメントをもとに、実装するタスクを洗い出して記述してください。
     - タスクは完了したら完了済みのセクションに移動してください。todo 全体が完了したら、ファイル名を `$(date +%Y%m%d_%H%M%S)_done.md` のように変更してください。
-    - タスクの完了に伴って計画が変更された場合は、`.agents/worklog/plan/` ディレクトリのドキュメントを更新してください。
-  - `.agents/worklog/learn/`: 学習用のドキュメントを格納するディレクトリ
+    - タスクの完了に伴って計画が変更された場合は、`.agents/worklog/codex/plan/` ディレクトリのドキュメントを更新してください。
+  - `.agents/worklog/codex/learn/`: 学習用のドキュメントを格納するディレクトリ
     - `$(date +%Y%m%d_%H%M%S)_learn.md` のような形式でファイルを作成してください
     - プロジェクトの実装に必要な知識や技術を学習した際に、学習内容をこのディレクトリに記録してください。
-    - 学習内容はプロジェクトの実装に活かせるように、必要に応じて `.agents/worklog/plan/` ディレクトリのドキュメントを更新してください。
+    - 学習内容はプロジェクトの実装に活かせるように、必要に応じて `.agents/worklog/codex/plan/` ディレクトリのドキュメントを更新してください。
     - learn は「次回の意思決定を速くする情報」が得られたときに更新してください。
     - learn には「何を学んだか」「どこに反映すべきか」を必ず書いてください。
     - learn を更新したら、必要に応じて plan の `Assumptions` / `Design` / `Tests` を更新してください。
@@ -36,8 +36,8 @@
 
 ### plan/todo/learn の frontmatter ルール
 
-- `.agents/worklog/plan/*.md` `.agents/worklog/todo/*.md` `.agents/worklog/learn/*.md` の先頭に YAML frontmatter を必須とします。
-- 並列実行を前提に、`active` 制約は「リポジトリ全体で1件」ではなく「`owner` ごとに1件」とします。
+- `.agents/worklog/codex/plan/*.md` `.agents/worklog/codex/todo/*.md` `.agents/worklog/codex/learn/*.md` の先頭に YAML frontmatter を必須とします。
+- 並列実行を前提に、`active` 制約は「リポジトリ全体で 1 件」ではなく「`owner` ごとに 1 件」とします。
 
 #### 共通必須キー
 
@@ -69,7 +69,7 @@
 #### 運用ルール
 
 - 新規 `todo` 作成時は `owner` を必ず設定してください。
-- 各 `owner` は同時に `active` な `todo` を1件までにしてください。
+- 各 `owner` は同時に `active` な `todo` を 1 件までにしてください。
 - `# TODO` が空になったら `status: done` に更新し、`*_done.md` へリネームしてください。
 - `learn` は「再利用可能」かつ「検証済み (`validated: true`)」のときのみ作成してください。
 - `learn` 更新時は `apply_to` に反映先（plan/tests）を明記してください。


### PR DESCRIPTION
## Summary

- Update `plansDirectory` in `home/dot_claude/settings.json` from `./plans` to `./.agents/worklog/claude`
- Update all `.agents/worklog/{plan,todo,learn}/` paths in `home/dot_config/codex/AGENTS.md` to `.agents/worklog/codex/{plan,todo,learn}/`
- Migrate existing plan files from `plans/` to `.agents/worklog/claude/` (local only, gitignored)
- Migrate existing codex worklog from `.agents/worklog/{plan,todo,learn}/` to `.agents/worklog/codex/` (local only, gitignored)

## Test plan

- [ ] Verify `home/dot_claude/settings.json` has `plansDirectory` pointing to `.agents/worklog/claude`
- [ ] Verify `home/dot_config/codex/AGENTS.md` references all paths under `.agents/worklog/codex/`
- [ ] Confirm `.gitignore` entry `.agents/worklog/` still covers both tool subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)