### PR TITLE
docs(skills): prohibit local absolute paths in gh-first-workflow output

### DIFF
--- a/home/dot_agents/skills/gh-first-workflow/SKILL.md
+++ b/home/dot_agents/skills/gh-first-workflow/SKILL.md
@@ -31,5 +31,6 @@ For pull requests, keep the description aligned with the full current PR content
 - Include inspected issue/PR URLs.
 - When commits were added after PR creation, confirm the PR description was updated to match the full current PR.
 - Keep commit subject in Conventional Commit form: `<type>(<scope>): <summary>`.
+- Do NOT include local absolute file paths (e.g., `/Users/.../`, `/home/.../`) in any output. Use repository-relative paths instead.
 
 Use [gh-git-rules.md](references/gh-git-rules.md) for command examples and commit-type guidance.

--- a/home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md
+++ b/home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md
@@ -5,6 +5,7 @@
 - Run GitHub issue/PR investigations with `gh` before using `web`.
 - Use `web` only when `gh` output is unavailable or insufficient.
 - Include the URL of each investigated issue/PR in the final answer.
+- Never include local absolute file paths in output. Always use repository-relative paths.
 
 ## Typical `gh` Commands
 


### PR DESCRIPTION
## Summary

- Add a rule to `SKILL.md` Output Checklist: do NOT include local absolute file paths (e.g., `/Users/.../`, `/home/.../`) in any output; use repository-relative paths instead
- Add the same rule to `references/gh-git-rules.md` Investigation Policy

## Test plan

- [ ] Verify that the updated skill instructions appear correctly in `home/dot_agents/skills/gh-first-workflow/SKILL.md`
- [ ] Verify that `home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md` reflects the new rule
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)