### PR TITLE
docs: add chezmoi context for agent instruction files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md
 
+## Repository Context
+
+- This repository is managed with [`chezmoi`](https://www.chezmoi.io/) ([GitHub](https://github.com/twpayne/chezmoi)).
+- Files under `home/` are the public source state and are applied by `chezmoi` into the user's `$HOME` directory.
+- Private dotfiles are managed separately from `~/.local/share/chezmoi-private` with config at `~/.config/chezmoi-private/chezmoi.yaml`.
+- Treat the public `home/` tree and the private `chezmoi` source/config as separate management domains.
+
 ## Response Rule
 
 - After reading this `AGENTS.md`, say: `🤖 I read the AGENTS.md for shunk031/dotfiles.`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- add a Repository Context section above the Response Rule in `AGENTS.md`
- document the public `home/` mapping and the separate private `chezmoi` source/config paths
- add `CLAUDE.md` that delegates to `AGENTS.md`

## Testing
- confirmed `AGENTS.md` starts with the new Repository Context section
- confirmed `CLAUDE.md` contains only `@AGENTS.md`
