### PR TITLE
ci: always report required unit test checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,12 +46,14 @@ jobs:
 
           echo "diff_range=${diff_range}" >> "${GITHUB_OUTPUT}"
 
-          # An env var would also work here, but keeping the pattern inline is
-          # simpler while this rule is only used in one place. It only controls
-          # whether the expensive unit-test steps should run; it does not decide
-          # whether the required workflow itself reports a status. If more
-          # workflows need the same rule later, extract a shared script instead
-          # of hiding the pattern in env.
+          # One option would be to predefine CI-relevant path groups such as
+          # `.github/workflows/`, `home/`, `install/`, and `tests/` in an env-
+          # var-like form to make the rule reusable. For this workflow, keeping
+          # the pattern inline is still easier to read because the rule is only
+          # used once and only decides whether the expensive unit-test steps
+          # should run. It does not decide whether the required workflow itself
+          # reports a status. If more workflows need the same rule later,
+          # extract a shared script instead of hiding the pattern in env.
           if git diff --name-only "${diff_range}" | grep -Eq '^(\.github/workflows/|home/|install/|tests/)'; then
             echo "should_test=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Keep the diff calculation here so the required workflow can always
+          # start and report a final status before we decide whether to run the
+          # heavier test steps.
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "${BASE_REF}"
             diff_range="origin/${BASE_REF}...${HEAD_SHA}"
@@ -43,6 +46,11 @@ jobs:
 
           echo "diff_range=${diff_range}" >> "${GITHUB_OUTPUT}"
 
+          # Keep this pattern inline for readability. It only controls whether
+          # the expensive unit-test steps should run; it does not decide whether
+          # the required workflow itself reports a status. If more workflows
+          # need the same rule later, extract a shared script instead of hiding
+          # the pattern in env.
           if git diff --name-only "${diff_range}" | grep -Eq '^(\.github/workflows/|home/|install/|tests/)'; then
             echo "should_test=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,11 +46,12 @@ jobs:
 
           echo "diff_range=${diff_range}" >> "${GITHUB_OUTPUT}"
 
-          # Keep this pattern inline for readability. It only controls whether
-          # the expensive unit-test steps should run; it does not decide whether
-          # the required workflow itself reports a status. If more workflows
-          # need the same rule later, extract a shared script instead of hiding
-          # the pattern in env.
+          # An env var would also work here, but keeping the pattern inline is
+          # simpler while this rule is only used in one place. It only controls
+          # whether the expensive unit-test steps should run; it does not decide
+          # whether the required workflow itself reports a status. If more
+          # workflows need the same rule later, extract a shared script instead
+          # of hiding the pattern in env.
           if git diff --name-only "${diff_range}" | grep -Eq '^(\.github/workflows/|home/|install/|tests/)'; then
             echo "should_test=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: Unit test
 
 on:
   # Required checks must always report a final status for PRs into `master`.
+  # Do not add workflow-level path or branch filters here: GitHub can leave
+  # skipped required checks in a pending state and block merges.
   # Keep this workflow unconditional and decide inside jobs whether the full
   # test matrix is necessary for the current diff.
   push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,23 +1,56 @@
 name: Unit test
 
 on:
+  # Required checks must always report a final status for PRs into `master`.
+  # Keep this workflow unconditional and decide inside jobs whether the full
+  # test matrix is necessary for the current diff.
   push:
     branches: [master]
-    paths:
-      - ".github/workflows/**"
-      - "home/**"
-      - "install/**"
-      - "tests/**"
   pull_request:
     branches: [master]
-    paths:
-      - ".github/workflows/**"
-      - "home/**"
-      - "install/**"
-      - "tests/**"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.filter.outputs.should_test }}
+      diff_range: ${{ steps.filter.outputs.diff_range }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect unit-test-relevant changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${BASE_REF}"
+            diff_range="origin/${BASE_REF}...${HEAD_SHA}"
+          elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            diff_range="${BEFORE_SHA}...${HEAD_SHA}"
+          else
+            diff_range="${HEAD_SHA}^...${HEAD_SHA}"
+          fi
+
+          echo "diff_range=${diff_range}" >> "${GITHUB_OUTPUT}"
+
+          if git diff --name-only "${diff_range}" | grep -Eq '^(\.github/workflows/|home/|install/|tests/)'; then
+            echo "should_test=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should_test=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   test:
+    needs: changes
     # Run the same test suite on each target OS/system pair.
     # We intentionally keep macOS as `client` only because this repository
     # does not define a macOS `server` test target.
@@ -45,7 +78,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Skip full unit test run for unrelated changes
+        if: ${{ needs.changes.outputs.should_test != 'true' }}
+        run: |
+          echo "No unit-test-relevant files changed."
+          echo "Compared diff range: ${{ needs.changes.outputs.diff_range }}"
+
       - name: Install tools
+        if: ${{ needs.changes.outputs.should_test == 'true' }}
         run: |
           if [ "${OS}" == "macos-14" ]; then
             # `bashcov` on macOS must use Homebrew Bash (>=5) to avoid the
@@ -69,11 +109,13 @@ jobs:
           echo "$(ruby -r rubygems -e 'puts Gem.user_dir')/bin" >> "${GITHUB_PATH}"
 
       - name: Run `shfmt`
+        if: ${{ needs.changes.outputs.should_test == 'true' }}
         uses: reviewdog/action-shfmt@v1
         with:
           shfmt_flags: -i 4 -sr -d
 
       - name: Run unit test
+        if: ${{ needs.changes.outputs.should_test == 'true' }}
         run: |
           # Shared bashcov defaults:
           # - `--skip-uncovered`: limit report to executed files.
@@ -91,7 +133,7 @@ jobs:
             bashcov "${bashcov_args[@]}" -- ./scripts/run_unit_test.sh
 
       - name: Setup for codecov
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ needs.changes.outputs.should_test == 'true' && github.actor != 'dependabot[bot]' }}
         run: |
           # codecov-action requires these tools for uploader validation/signing
           # in this repository setup.
@@ -107,7 +149,7 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ needs.changes.outputs.should_test == 'true' && github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- remove workflow-level path filters from the required unit-test workflow
- add a lightweight `changes` job that decides whether the full matrix needs to run
- keep the existing `test` matrix check names while turning unrelated diffs into fast successful no-op jobs
- document inline why CI-relevant path groups stay inline for now instead of being predeclared in an env-var-like form
- document that required workflows should not regain workflow-level path or branch filters because skipped required checks can block merges

## Testing
- loaded `.github/workflows/test.yaml` with Ruby's YAML parser
- inspected the workflow diff to confirm only `.github/workflows/test.yaml` changed
