### PR TITLE
feat(shell): block global npm install flows

### DIFF
--- a/home/dot_bash/client/bashrc
+++ b/home/dot_bash/client/bashrc
@@ -107,6 +107,12 @@ if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi
 
+# for npm guard
+# shellcheck source=../../dot_config/shell/npm-guard.sh
+if [ -f "${HOME%/}/.config/shell/npm-guard.sh" ]; then
+    source "${HOME%/}/.config/shell/npm-guard.sh"
+fi
+
 # enable programmable completion features (you don't need to enable
 # this, if it's already enabled in /etc/bash.bashrc and /etc/profile
 # sources /etc/bash.bashrc).

--- a/home/dot_config/sheldon/plugin_sources/common.toml
+++ b/home/dot_config/sheldon/plugin_sources/common.toml
@@ -176,6 +176,11 @@ local = '~/.config/alias'
 use = ['common.sh']
 apply = ['source']
 
+[plugins.common-shell]
+local = '~/.config/shell'
+use = ['npm-guard.sh']
+apply = ['source']
+
 # [plugins.private-alias]
 # local = '~/.config/alias'
 # use = ['private.sh']

--- a/home/dot_config/shell/npm-guard.sh
+++ b/home/dot_config/shell/npm-guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# @file home/dot_config/shell/npm-guard.sh
+# @brief Block global npm install flows and direct package management to mise.
+# @description
+#   Defines an interactive-shell wrapper around `npm` that rejects global
+#   install/update commands and points operators to `mise install "npm:<pkg>"`
+#   and `mise upgrade npm:<pkg>` instead.
+
+#
+# @description Return success when the npm arguments describe a blocked global mutation.
+#
+function npm_guard_should_block() {
+    local has_global="false"
+    local subcommand=""
+
+    while (($#)); do
+        case "$1" in
+        -g | --global | --location=global)
+            has_global="true"
+            ;;
+        --location)
+            shift
+            if (($#)) && [[ "$1" == "global" ]]; then
+                has_global="true"
+            fi
+            ;;
+        -*)
+            ;;
+        *)
+            if [[ -z "${subcommand}" ]]; then
+                subcommand="$1"
+            fi
+            ;;
+        esac
+        shift
+    done
+
+    if [[ "${has_global}" != "true" ]]; then
+        return 1
+    fi
+
+    case "${subcommand}" in
+    install | i | add | update | upgrade)
+        return 0
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+#
+# @description Print the recommended mise-based replacement for blocked npm usage.
+#
+function npm_guard_print_message() {
+    printf '%s\n' 'npm global install/update is blocked. Use mise-managed npm packages instead.' >&2
+    printf '%s\n' '  Install: mise install "npm:<package>"' >&2
+    printf '%s\n' '  Upgrade: mise upgrade npm:<package>' >&2
+}
+
+#
+# @description Wrap npm and block global install flows in interactive shells.
+#
+function npm() {
+    if [[ "$-" != *i* ]]; then
+        command npm "$@"
+        return
+    fi
+
+    if npm_guard_should_block "$@"; then
+        npm_guard_print_message
+        return 1
+    fi
+
+    command npm "$@"
+}


### PR DESCRIPTION
## Summary
- add a shared `npm` guard snippet under `home/dot_config/shell/npm-guard.sh`
- load the guard from the common Sheldon plugins and the client bashrc
- block interactive global `npm` install/update flows and direct package management to `mise`

## Testing
- `shellcheck -x home/dot_config/shell/npm-guard.sh`
- parse `home/dot_config/sheldon/plugin_sources/common.toml` with Python `tomllib`
- source `home/dot_config/shell/npm-guard.sh` in bash and zsh, then verify `npm i -g @openai/codex` is blocked while `npm uninstall -g @openai/codex`, local install detection, and `npm --version` still work
