### PR TITLE
docs(codex): add user-level AGENTS response rule

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Response Rule
+
+- After reading this user-level `AGENTS.md`, say: `🤖 I read the user-level AGENTS.md (~/.codex/AGENTS.md).`
+
 ## ユーザーへの質問
 
 - ユーザが提供した情報に基づいて、最適な解決策を提案するための質問を行ってください。


### PR DESCRIPTION
## Summary
- add a user-level Response Rule to `home/dot_config/codex/AGENTS.md`
- require agents to acknowledge `~/.codex/AGENTS.md` after reading it
- keep the repo-level `AGENTS.md` rule and `home/dot_codex/symlink_AGENTS.md.tmpl` unchanged

## Testing
- confirmed `home/dot_config/codex/AGENTS.md` contains one Response Rule section with the expected acknowledgement
- confirmed `AGENTS.md` still contains the existing repo-level acknowledgement
- confirmed only `home/dot_config/codex/AGENTS.md` is changed for this PR