### PR TITLE
docs(skill): add worktree health gate to gh-first workflow

### DIFF
--- a/home/dot_agents/skills/gh-first-workflow/SKILL.md
+++ b/home/dot_agents/skills/gh-first-workflow/SKILL.md
@@ -9,6 +9,7 @@ description: Enforce gh-first GitHub investigation, pull request maintenance, an
 
 Use this workflow to keep GitHub investigation and commit output consistent with repository policy.
 For pull requests, keep the description aligned with the full current PR contents, not just the latest delta.
+Validate the target repository/worktree before running `gh` so orphaned linked worktrees or wrong repository context do not poison GitHub operations.
 
 ## Read Acknowledgement
 
@@ -16,16 +17,22 @@ For pull requests, keep the description aligned with the full current PR content
 
 ## Workflow
 
-1. Start issue/PR investigation with `gh` commands.
-2. Use `web` only when `gh` cannot provide required details.
-3. Collect URLs for every issue/PR that was inspected.
-4. When creating a PR, write the PR description as a summary of the full PR.
-5. If additional commits are pushed after PR creation, inspect the updated commits/diff with `gh` and refresh the PR description so it reflects the full current PR, not only the latest increment.
-6. Include inspected URLs in the response.
-7. Write commit messages in Conventional Commit format.
+1. Before any `gh` or `git` write operation, confirm the target repository context with `git rev-parse --show-toplevel`, `git rev-parse --git-dir`, and `git status --short --branch`.
+2. If the current directory may be a linked worktree, inspect `.git`. When it contains `gitdir: ...`, verify that the referenced path exists; if it does not, treat the directory as an orphaned worktree and stop using it for GitHub work.
+3. In multi-repo, nested-repo, or multi-worktree situations, pin every `gh`/`git` command to the intended repository by changing `workdir` or using repo-specific flags. Do not rely on an ambient parent directory.
+4. When branch, commit, or PR work would mix with unrelated local changes, prefer a fresh task-specific `git worktree` from the default branch instead of reusing the dirty worktree.
+5. Start issue/PR investigation with `gh` commands.
+6. Use `web` only when `gh` cannot provide required details.
+7. Collect URLs for every issue/PR that was inspected.
+8. When creating a PR, write the PR description as a summary of the full PR.
+9. If additional commits are pushed after PR creation, inspect the updated commits/diff with `gh` and refresh the PR description so it reflects the full current PR, not only the latest increment.
+10. Include inspected URLs in the response.
+11. Write commit messages in Conventional Commit format.
 
 ## Output Checklist
 
+- State that the repository/worktree context was validated before GitHub write operations when local git state matters.
+- If an orphaned or unhealthy worktree was detected, state that you switched to a healthy repository/worktree before continuing.
 - State that `gh` was used first.
 - State why `web` was used when fallback was necessary.
 - Include inspected issue/PR URLs.

--- a/home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md
+++ b/home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md
@@ -2,10 +2,43 @@
 
 ## Investigation Policy
 
+- Validate the target repository/worktree before GitHub write operations that depend on local git state.
 - Run GitHub issue/PR investigations with `gh` before using `web`.
 - Use `web` only when `gh` output is unavailable or insufficient.
 - Include the URL of each investigated issue/PR in the final answer.
 - Never include local absolute file paths in output. Always use repository-relative paths.
+
+## Repository/Worktree Health Gate
+
+Run these checks before branch/commit/PR work:
+
+```bash
+git rev-parse --show-toplevel
+git rev-parse --git-dir
+git status --short --branch
+```
+
+If the directory may be a linked worktree, inspect `.git` as well:
+
+```bash
+cat .git
+```
+
+Interpretation:
+
+- If `git rev-parse` or `git status` fails with `fatal: not a git repository`, do not continue with `gh` from that directory.
+- If `.git` contains `gitdir: <path>` and that path does not exist, the directory is an orphaned linked worktree.
+- When a worktree looks suspicious, confirm the current path from a healthy canonical repo:
+
+```bash
+git -C <canonical-repo> worktree list --porcelain
+```
+
+Safe response:
+
+- Switch to a healthy repository/worktree before continuing.
+- Recreate the task worktree from the canonical repo if needed.
+- In nested-repo or sibling-worktree layouts, run commands from the intended repo/worktree instead of a parent directory.
 
 ## Typical `gh` Commands
 
@@ -16,12 +49,27 @@ gh issue list --repo <owner>/<repo>
 gh pr list --repo <owner>/<repo>
 ```
 
+When local git context matters, prefer an explicit target repo/worktree:
+
+```bash
+git -C <repo> status --short --branch
+git -C <repo> rev-parse --show-toplevel
+(cd <repo> && gh pr create ...)
+```
+
 ## Fallback Pattern
 
 1. Try `gh` first.
 2. Record what was missing.
 3. Use `web` only for the missing information.
 4. Report both the result and the source URL.
+
+## Dirty Worktree Pattern
+
+1. Check whether the current worktree already contains unrelated staged, unstaged, or untracked changes.
+2. If yes, create or switch to a fresh task-specific `git worktree` from the default branch.
+3. Apply only the task-relevant changes there.
+4. Keep the PR description aligned with the full PR after every additional push.
 
 ## Conventional Commit Policy
 


### PR DESCRIPTION
## Summary
- validate the target repository/worktree before GitHub write operations that depend on local git state
- detect orphaned linked worktrees and require switching to a healthy repository/worktree before continuing
- document explicit repo/worktree targeting and fresh task-specific worktree usage when the current worktree is dirty

## Testing
- `git diff --check -- home/dot_agents/skills/gh-first-workflow/SKILL.md home/dot_agents/skills/gh-first-workflow/references/gh-git-rules.md`