### PR TITLE
fix: refresh chezmoi notification caches after apply

### DIFF
--- a/home/.chezmoiscripts/common/run_after_99-refresh-chezmoi-notify-cache.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_99-refresh-chezmoi-notify-cache.sh.tmpl
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ -x "${HOME}/.local/bin/common/chezmoi-notify-cache" ]; then
+    "${HOME}/.local/bin/common/chezmoi-notify-cache" refresh
+fi

--- a/home/dot_config/powerlevel10k/p10k.zsh
+++ b/home/dot_config/powerlevel10k/p10k.zsh
@@ -1646,45 +1646,22 @@
   }
 
   function prompt_chezmoi_update() {
-    local check_interval=3600 # check every hour
-    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/p10k-chezmoi"
-    local status_file="$cache_dir/status"
-    local last_check_file="$cache_dir/last_check"
-
-    [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir"
+    local helper_path="${HOME}/.local/bin/common/chezmoi-notify-cache"
+    local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/p10k-chezmoi/status"
 
     # --- Icon/emoji definitions ---
     local icon=$'\uf015'      # Home ()
     local arrow=$'\u21e3'     # Down Arrow (⇣)
     local sync_alt=$'\uf2f1'  # Sync ()
 
-    # --- 1. Background update check ---
-    local current_time=$(date +%s)
-    local last_check=0
-    [[ -f "$last_check_file" ]] && last_check=$(cat "$last_check_file")
-
-    if (( current_time - last_check > check_interval )); then
-      echo "$current_time" >! "$last_check_file"
-      (
-        if command -v chezmoi >/dev/null 2>&1; then
-          chezmoi git -- fetch -q
-
-          # Get the count of new changes on the remote master branch.
-          local count=$(chezmoi git -- rev-list --count HEAD..origin/master 2>/dev/null)
-          
-          if [[ "$count" -gt 0 ]]; then
-            echo "$count" >! "$status_file"
-          else
-            rm -f "$status_file"
-          fi
-        fi
-      ) &!
+    if [[ -x "${helper_path}" ]]; then
+      ("${helper_path}" refresh-if-stale > /dev/null 2>&1) &!
     fi
 
-    # --- 2. Display processing ---
+    # --- Display processing ---
     if [[ -f "$status_file" ]]; then
       local count=$(cat "$status_file")
-      
+
       # Color: Red (196)
       # Display: [Home] dotfiles [Sync] ⇣[Count]
       p10k segment -f 196 -i "${arrow}${count}" -t "${icon} dotfiles ${sync_alt}"

--- a/home/dot_config/zsh/plugins/chezmoi-notify/chezmoi-notify.plugin.zsh
+++ b/home/dot_config/zsh/plugins/chezmoi-notify/chezmoi-notify.plugin.zsh
@@ -5,35 +5,10 @@
 # -----------------------------------------------------------------------------
 
 function _check_chezmoi_update_async() {
-    local check_interval=3600 # Check every hour (3600 seconds)
-    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi"
-    local status_file="$cache_dir/count"
-    local last_check_file="$cache_dir/last_check"
+    local helper_path="${HOME}/.local/bin/common/chezmoi-notify-cache"
 
-    [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir"
-
-    local current_time=$(date +%s)
-    local last_check=0
-    [[ -f "$last_check_file" ]] && last_check=$(cat "$last_check_file")
-
-    if ((current_time - last_check > check_interval)); then
-        echo "$current_time" >| "$last_check_file"
-
-        # Run the following block in the background
-        (
-            if command -v chezmoi > /dev/null 2>&1; then
-                chezmoi git -- fetch -q
-
-                # Count the differences with the remote master branch
-                local count=$(chezmoi git -- rev-list --count HEAD..origin/master 2> /dev/null)
-
-                if [[ "$count" -gt 0 ]]; then
-                    echo "$count" >| "$status_file"
-                else
-                    rm -f "$status_file"
-                fi
-            fi
-        ) &|
+    if [[ -x "${helper_path}" ]]; then
+        ("${helper_path}" refresh-if-stale > /dev/null 2>&1) &!
     fi
 }
 

--- a/home/dot_config/zsh/plugins/chezmoi-notify/chezmoi-notify.plugin.zsh
+++ b/home/dot_config/zsh/plugins/chezmoi-notify/chezmoi-notify.plugin.zsh
@@ -8,7 +8,7 @@ function _check_chezmoi_update_async() {
     local helper_path="${HOME}/.local/bin/common/chezmoi-notify-cache"
 
     if [[ -x "${helper_path}" ]]; then
-        ("${helper_path}" refresh-if-stale > /dev/null 2>&1) &!
+        ("${helper_path}" refresh-if-stale > /dev/null 2>&1) &|
     fi
 }
 

--- a/home/dot_local/bin/common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/common/executable_chezmoi-notify-cache
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# @file home/dot_local/bin/common/executable_chezmoi-notify-cache
+# @brief Sync the chezmoi update notification caches used by p10k and Starship.
+# @description
+#   Recomputes `HEAD..origin/master` on demand or only when cached results are
+#   stale, then updates both shell-specific cache directories together.
+
+set -uo pipefail
+
+readonly CHECK_INTERVAL=3600
+readonly UPSTREAM_REF="origin/master"
+
+# @description Return the cache root honoring `XDG_CACHE_HOME`.
+function cache_root() {
+    printf "%s\n" "${XDG_CACHE_HOME:-$HOME/.cache}"
+}
+
+# @description Return the Powerlevel10k cache directory path.
+function p10k_cache_dir() {
+    printf "%s\n" "$(cache_root)/p10k-chezmoi"
+}
+
+# @description Return the Starship cache directory path.
+function starship_cache_dir() {
+    printf "%s\n" "$(cache_root)/starship-chezmoi"
+}
+
+# @description Return the current Unix timestamp.
+function current_time() {
+    date +%s
+}
+
+# @description Determine whether a `last_check` file is missing, invalid, or expired.
+# @arg $1 path Path to a `last_check` file.
+# @arg $2 integer Current Unix timestamp.
+function cache_is_stale() {
+    local last_check_file="$1"
+    local now="$2"
+    local last_check
+
+    if [[ ! -f "${last_check_file}" ]]; then
+        return 0
+    fi
+
+    last_check="$(< "${last_check_file}")"
+
+    if [[ ! "${last_check}" =~ ^[0-9]+$ ]]; then
+        return 0
+    fi
+
+    ((now - last_check >= CHECK_INTERVAL))
+}
+
+# @description Update both `last_check` files with the same timestamp.
+# @arg $1 integer Current Unix timestamp.
+function write_last_check_files() {
+    local now="$1"
+    local p10k_dir
+    local starship_dir
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+
+    mkdir -p "${p10k_dir}" "${starship_dir}" || return 0
+    printf "%s\n" "${now}" >| "${p10k_dir}/last_check"
+    printf "%s\n" "${now}" >| "${starship_dir}/last_check"
+    return 0
+}
+
+# @description Recompute the update count and synchronize both notification caches.
+function refresh() {
+    local count
+    local now
+    local p10k_dir
+    local starship_dir
+
+    if ! command -v chezmoi > /dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! count="$(chezmoi git -- rev-list --count "HEAD..${UPSTREAM_REF}" 2> /dev/null)"; then
+        return 0
+    fi
+
+    if [[ ! "${count}" =~ ^[0-9]+$ ]]; then
+        return 0
+    fi
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    now="$(current_time)"
+
+    mkdir -p "${p10k_dir}" "${starship_dir}" || return 0
+
+    if ((count == 0)); then
+        rm -f "${p10k_dir}/status" "${starship_dir}/count"
+    else
+        printf "%s\n" "${count}" >| "${p10k_dir}/status"
+        printf "%s\n" "${count}" >| "${starship_dir}/count"
+    fi
+
+    write_last_check_files "${now}"
+    return 0
+}
+
+# @description Refresh both notification caches only when either cache is stale.
+function refresh_if_stale() {
+    local now
+    local p10k_last_check_file
+    local starship_last_check_file
+
+    now="$(current_time)"
+    p10k_last_check_file="$(p10k_cache_dir)/last_check"
+    starship_last_check_file="$(starship_cache_dir)/last_check"
+
+    if cache_is_stale "${p10k_last_check_file}" "${now}" ||
+        cache_is_stale "${starship_last_check_file}" "${now}"; then
+        refresh
+    fi
+
+    return 0
+}
+
+# @description Dispatch the helper subcommands.
+# @arg $1 string Either `refresh` or `refresh-if-stale`.
+function main() {
+    local command="${1:-}"
+
+    case "${command}" in
+    refresh)
+        refresh
+        ;;
+    refresh-if-stale)
+        refresh_if_stale
+        ;;
+    *)
+        printf "usage: %s {refresh|refresh-if-stale}\n" "${0##*/}" >&2
+        return 1
+        ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./home/dot_local/bin/common/executable_chezmoi-notify-cache"
+readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_99-refresh-chezmoi-notify-cache.sh.tmpl"
+
+function setup() {
+    export HOME="${BATS_TEST_TMPDIR}/home"
+    export TEST_BIN_DIR="${BATS_TEST_TMPDIR}/bin"
+    export CHEZMOI_CALLS_PATH="${BATS_TEST_TMPDIR}/chezmoi_calls.txt"
+    export PATH="${TEST_BIN_DIR}:$(getconf PATH)"
+
+    mkdir -p "${HOME}" "${TEST_BIN_DIR}"
+    rm -f "${CHEZMOI_CALLS_PATH}"
+    unset XDG_CACHE_HOME
+    unset CHEZMOI_REV_LIST_COUNT
+    unset CHEZMOI_SHOULD_FAIL
+}
+
+function write_chezmoi_stub() {
+    cat > "${TEST_BIN_DIR}/chezmoi" << 'EOF'
+#!/usr/bin/env bash
+
+if [ -n "${CHEZMOI_CALLS_PATH:-}" ]; then
+    printf "%s\n" "$*" >> "${CHEZMOI_CALLS_PATH}"
+fi
+
+if [ "${CHEZMOI_SHOULD_FAIL:-0}" = "1" ]; then
+    exit 1
+fi
+
+printf "%s\n" "${CHEZMOI_REV_LIST_COUNT:-0}"
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/chezmoi"
+}
+
+function p10k_cache_dir() {
+    printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
+}
+
+function starship_cache_dir() {
+    printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
+}
+
+@test "[common] refresh clears caches when the dotfiles repo is already up to date" {
+    write_chezmoi_stub
+    export CHEZMOI_REV_LIST_COUNT=0
+
+    local p10k_dir
+    local starship_dir
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "9\n" > "${p10k_dir}/status"
+    printf "9\n" > "${starship_dir}/count"
+
+    run bash "${SCRIPT_PATH}" refresh
+    [ "${status}" -eq 0 ]
+    [ ! -e "${p10k_dir}/status" ]
+    [ ! -e "${starship_dir}/count" ]
+    [ -s "${p10k_dir}/last_check" ]
+    [ -s "${starship_dir}/last_check" ]
+
+    local p10k_last_check
+    local starship_last_check
+    p10k_last_check="$(< "${p10k_dir}/last_check")"
+    starship_last_check="$(< "${starship_dir}/last_check")"
+    [[ "${p10k_last_check}" =~ ^[0-9]+$ ]]
+    [[ "${starship_last_check}" =~ ^[0-9]+$ ]]
+    [ "${p10k_last_check}" = "${starship_last_check}" ]
+    [ "${p10k_last_check}" -gt 1 ]
+    [ "${starship_last_check}" -gt 1 ]
+}
+
+@test "[common] refresh writes the same count into both caches under XDG_CACHE_HOME" {
+    write_chezmoi_stub
+    export CHEZMOI_REV_LIST_COUNT=3
+    export XDG_CACHE_HOME="${BATS_TEST_TMPDIR}/xdg-cache"
+
+    local p10k_dir
+    local starship_dir
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+
+    run bash "${SCRIPT_PATH}" refresh
+    [ "${status}" -eq 0 ]
+    [ -s "${p10k_dir}/status" ]
+    [ -s "${starship_dir}/count" ]
+
+    local p10k_count
+    local starship_count
+    p10k_count="$(< "${p10k_dir}/status")"
+    starship_count="$(< "${starship_dir}/count")"
+    [ "${p10k_count}" = "3" ]
+    [ "${starship_count}" = "3" ]
+    [ -s "${p10k_dir}/last_check" ]
+    [ -s "${starship_dir}/last_check" ]
+    [ "$(< "${CHEZMOI_CALLS_PATH}")" = "git -- rev-list --count HEAD..origin/master" ]
+}
+
+@test "[common] refresh leaves existing caches untouched when chezmoi rev-list fails" {
+    write_chezmoi_stub
+    export CHEZMOI_SHOULD_FAIL=1
+
+    local p10k_dir
+    local starship_dir
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "7\n" > "${p10k_dir}/status"
+    printf "7\n" > "${starship_dir}/count"
+    printf "42\n" > "${p10k_dir}/last_check"
+    printf "42\n" > "${starship_dir}/last_check"
+
+    run bash "${SCRIPT_PATH}" refresh
+    [ "${status}" -eq 0 ]
+    [ "$(< "${p10k_dir}/status")" = "7" ]
+    [ "$(< "${starship_dir}/count")" = "7" ]
+    [ "$(< "${p10k_dir}/last_check")" = "42" ]
+    [ "$(< "${starship_dir}/last_check")" = "42" ]
+}
+
+@test "[common] refresh-if-stale skips recomputation while both caches are fresh" {
+    write_chezmoi_stub
+    export CHEZMOI_REV_LIST_COUNT=5
+
+    local p10k_dir
+    local starship_dir
+    local now
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    now="$(date +%s)"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "%s\n" "${now}" > "${p10k_dir}/last_check"
+    printf "%s\n" "${now}" > "${starship_dir}/last_check"
+
+    run bash "${SCRIPT_PATH}" refresh-if-stale
+    [ "${status}" -eq 0 ]
+    [ ! -e "${CHEZMOI_CALLS_PATH}" ]
+    [ ! -e "${p10k_dir}/status" ]
+    [ ! -e "${starship_dir}/count" ]
+}
+
+@test "[common] refresh-if-stale recomputes when either last_check file is missing" {
+    write_chezmoi_stub
+    export CHEZMOI_REV_LIST_COUNT=4
+
+    local p10k_dir
+    local starship_dir
+    local now
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    now="$(date +%s)"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "%s\n" "${now}" > "${starship_dir}/last_check"
+
+    run bash "${SCRIPT_PATH}" refresh-if-stale
+    [ "${status}" -eq 0 ]
+    [ "$(< "${p10k_dir}/status")" = "4" ]
+    [ "$(< "${starship_dir}/count")" = "4" ]
+    [ -s "${CHEZMOI_CALLS_PATH}" ]
+}
+
+@test "[common] refresh-if-stale recomputes when either last_check file is expired" {
+    write_chezmoi_stub
+    export CHEZMOI_REV_LIST_COUNT=6
+
+    local p10k_dir
+    local starship_dir
+    local now
+    local expired
+
+    p10k_dir="$(p10k_cache_dir)"
+    starship_dir="$(starship_cache_dir)"
+    now="$(date +%s)"
+    expired="$((now - 4000))"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "%s\n" "${expired}" > "${p10k_dir}/last_check"
+    printf "%s\n" "${now}" > "${starship_dir}/last_check"
+
+    run bash "${SCRIPT_PATH}" refresh-if-stale
+    [ "${status}" -eq 0 ]
+    [ "$(< "${p10k_dir}/status")" = "6" ]
+    [ "$(< "${starship_dir}/count")" = "6" ]
+    [ -s "${CHEZMOI_CALLS_PATH}" ]
+}
+
+@test "[common] run_after template invokes the helper with an absolute refresh command" {
+    [ -f "${RUN_AFTER_TEMPLATE}" ]
+
+    run grep -F '"${HOME}/.local/bin/common/chezmoi-notify-cache" refresh' "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- add a shared helper to recompute the chezmoi update count and sync the p10k and Starship caches
- run that helper after `chezmoi apply` and reuse it from the prompt/plugin stale-refresh paths
- add Bats coverage for cache refresh behavior, stale checks, and the run-after script wiring

## Testing
- `shfmt --indent 4 --space-redirects --diff home/dot_local/bin/common/executable_chezmoi-notify-cache home/.chezmoiscripts/common/run_after_99-refresh-chezmoi-notify-cache.sh.tmpl tests/install/common/chezmoi_notify_cache.bats`
- `shfmt --indent 4 --space-redirects --diff home/dot_config/zsh/plugins/chezmoi-notify/chezmoi-notify.plugin.zsh`
- not run: `bats` locally (repository policy)
