### PR TITLE
Exactify public server source directory

### DIFF
--- a/home/dot_local/bin/exact_server/cache.sh
+++ b/home/dot_local/bin/exact_server/cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# @file home/dot_local/bin/server/cache.sh
+# @file home/dot_local/bin/exact_server/cache.sh
 # @brief Export Hugging Face cache locations for server environments.
 # @description
 #   Sets the dataset and model cache directories under the user's home cache

--- a/home/dot_local/bin/exact_server/cuda.sh
+++ b/home/dot_local/bin/exact_server/cuda.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-# @file home/dot_local/bin/server/cuda.sh
+# @file home/dot_local/bin/exact_server/cuda.sh
 # @brief Export CUDA paths for server shells.
 # @description
 #   Sets `CUDA_HOME`, prepends the CUDA binaries to the shell path, and extends

--- a/home/dot_local/bin/exact_server/history.sh
+++ b/home/dot_local/bin/exact_server/history.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# @file home/dot_local/bin/server/history.sh
+# @file home/dot_local/bin/exact_server/history.sh
 # @brief Share shell history across concurrent bash sessions.
 # @description
 #   Provides a `tac` fallback and appends a `PROMPT_COMMAND` hook that merges

--- a/home/dot_local/bin/exact_server/secrets.sh
+++ b/home/dot_local/bin/exact_server/secrets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# @file home/dot_local/bin/server/secrets.sh
+# @file home/dot_local/bin/exact_server/secrets.sh
 # @brief Define placeholder secret environment variables.
 # @description
 #   Exports placeholder tokens for services that are expected to be filled in on

--- a/home/dot_local/bin/exact_server/ssh_agent.sh
+++ b/home/dot_local/bin/exact_server/ssh_agent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# @file home/dot_local/bin/server/ssh_agent.sh
+# @file home/dot_local/bin/exact_server/ssh_agent.sh
 # @brief Start `ssh-agent` and load the default SSH key.
 # @description
 #   Starts a new `ssh-agent` process and adds the default ed25519 private key

--- a/home/exact_dot_bash/client/bashrc
+++ b/home/exact_dot_bash/client/bashrc
@@ -125,7 +125,7 @@ if ! shopt -oq posix; then
 fi
 
 # # for CUDA
-# # shellcheck source=../../dot_local/bin/server/cuda.sh
+# # shellcheck source=../../dot_local/bin/exact_server/cuda.sh
 # source "${HOME%/}/.local/bin/server/cuda.sh"
 
 # for prompt
@@ -133,11 +133,11 @@ fi
 source "${HOME%/}/.local/bin/server/prompt.sh"
 
 # for sharing history between panes/windiws in tmux session
-# shellcheck source=../../dot_local/bin/server/history.sh
+# shellcheck source=../../dot_local/bin/exact_server/history.sh
 source "${HOME%/}/.local/bin/server/history.sh"
 
 # # for ssh agent
-# # shellcheck source=../../dot_local/bin/server/ssh_agent.sh
+# # shellcheck source=../../dot_local/bin/exact_server/ssh_agent.sh
 # source "${HOME%/}/.local/bin/server/ssh_agent.sh"
 
 # # for golang
@@ -149,11 +149,11 @@ source "${HOME%/}/.local/bin/server/history.sh"
 source "${HOME%/}/.local/bin/server/aliases.sh"
 
 # for secrets (e.g., slack, wandb, zenodo API)
-# shellcheck source=../../dot_local/bin/server/secrets.sh
+# shellcheck source=../../dot_local/bin/exact_server/secrets.sh
 source "${HOME%/}/.local/bin/server/secrets.sh"
 
 # for cache directories
-# shellcheck source=../../dot_local/bin/server/cache.sh
+# shellcheck source=../../dot_local/bin/exact_server/cache.sh
 source "${HOME%/}/.local/bin/server/cache.sh"
 
 # for dev command


### PR DESCRIPTION
## Summary
- rename `home/dot_local/bin/server` to `home/dot_local/bin/exact_server`
- update the renamed server scripts' shdoc `@file` headers
- update `home/exact_dot_bash/client/bashrc` shellcheck source comments for the renamed source directory

## Validation
- compare the source and target file sets for `~/.local/bin/server`
- run `chezmoi source-path`, `chezmoi managed`, and `chezmoi unmanaged` for `~/.local/bin/server`
- run `chezmoi diff --force ~/.local/bin/server`
- run `chezmoi apply --dry-run --verbose ~/.local/bin/server`