### PR TITLE
fix: unify chezmoi notify cache across prompts

### DIFF
--- a/home/dot_config/powerlevel10k/p10k.zsh
+++ b/home/dot_config/powerlevel10k/p10k.zsh
@@ -1647,7 +1647,7 @@
 
   function prompt_chezmoi_update() {
     local helper_path="${HOME}/.local/bin/common/chezmoi-notify-cache"
-    local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"
+    local count_file="${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-notify/count"
 
     # --- Icon/emoji definitions ---
     local icon=$'\uf015'      # Home ()
@@ -1659,8 +1659,8 @@
     fi
 
     # --- Display processing ---
-    if [[ -s "$status_file" ]]; then
-      local count=$(cat "$status_file")
+    if [[ -s "$count_file" ]]; then
+      local count=$(cat "$count_file")
 
       # Color: Red (196)
       # Display: [Home] dotfiles [Sync] ⇣[Count]

--- a/home/dot_config/powerlevel10k/p10k.zsh
+++ b/home/dot_config/powerlevel10k/p10k.zsh
@@ -1647,7 +1647,7 @@
 
   function prompt_chezmoi_update() {
     local helper_path="${HOME}/.local/bin/common/chezmoi-notify-cache"
-    local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/p10k-chezmoi/status"
+    local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"
 
     # --- Icon/emoji definitions ---
     local icon=$'\uf015'      # Home ()
@@ -1659,7 +1659,7 @@
     fi
 
     # --- Display processing ---
-    if [[ -f "$status_file" ]]; then
+    if [[ -s "$status_file" ]]; then
       local count=$(cat "$status_file")
 
       # Color: Red (196)

--- a/home/dot_config/starship.toml
+++ b/home/dot_config/starship.toml
@@ -6,8 +6,8 @@ ${custom.chezmoi}
 python_binary = 'python'
 
 [custom.chezmoi]
-command = "cat ${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"
-when = "test -s ${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"
+command = "cat ${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-notify/count"
+when = "test -s ${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-notify/count"
 symbol = " dotfiles  ⇣"
 style = "bold red"
 format = "[$symbol$output]($style) "

--- a/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # @file home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
-# @brief Sync the chezmoi update notification caches used by p10k and Starship.
+# @brief Sync the shared chezmoi update notification cache used by p10k and Starship.
 # @description
 #   Fetches the tracked upstream ref, recomputes `HEAD..origin/master` on
-#   demand or only when cached results are stale, then updates both
-#   shell-specific cache directories together.
+#   demand or only when cached results are stale, then updates the shared
+#   notification cache consumed by both prompts.
 
 set -uo pipefail
 
@@ -17,14 +17,29 @@ function cache_root() {
     printf "%s\n" "${XDG_CACHE_HOME:-$HOME/.cache}"
 }
 
-# @description Return the Powerlevel10k cache directory path.
-function p10k_cache_dir() {
+# @description Return the shared chezmoi notification cache directory path.
+function notify_cache_dir() {
+    printf "%s\n" "$(cache_root)/chezmoi-notify"
+}
+
+# @description Return the legacy Powerlevel10k cache directory path.
+function legacy_p10k_cache_dir() {
     printf "%s\n" "$(cache_root)/p10k-chezmoi"
 }
 
-# @description Return the Starship cache directory path.
-function starship_cache_dir() {
+# @description Return the legacy Starship cache directory path.
+function legacy_starship_cache_dir() {
     printf "%s\n" "$(cache_root)/starship-chezmoi"
+}
+
+# @description Return the shared count file path.
+function notify_count_file() {
+    printf "%s\n" "$(notify_cache_dir)/count"
+}
+
+# @description Return the shared last_check file path.
+function notify_last_check_file() {
+    printf "%s\n" "$(notify_cache_dir)/last_check"
 }
 
 # @description Return the current Unix timestamp.
@@ -53,28 +68,43 @@ function cache_is_stale() {
     ((now - last_check >= CHECK_INTERVAL))
 }
 
-# @description Update both `last_check` files with the same timestamp.
+# @description Update the shared `last_check` file with the current timestamp.
 # @arg $1 integer Current Unix timestamp.
-function write_last_check_files() {
+function write_last_check_file() {
     local now="$1"
-    local p10k_dir
-    local starship_dir
+    local cache_dir
+    local last_check_file
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
+    cache_dir="$(notify_cache_dir)"
+    last_check_file="$(notify_last_check_file)"
 
-    mkdir -p "${p10k_dir}" "${starship_dir}" || return 0
-    printf "%s\n" "${now}" >| "${p10k_dir}/last_check"
-    printf "%s\n" "${now}" >| "${starship_dir}/last_check"
+    mkdir -p "${cache_dir}" || return 0
+    printf "%s\n" "${now}" >| "${last_check_file}"
     return 0
 }
 
-# @description Fetch the upstream ref, recompute the update count, and synchronize both caches.
+# @description Remove obsolete prompt-specific cache files after a successful refresh.
+function remove_legacy_cache_files() {
+    local p10k_dir
+    local starship_dir
+
+    p10k_dir="$(legacy_p10k_cache_dir)"
+    starship_dir="$(legacy_starship_cache_dir)"
+
+    rm -f \
+        "${p10k_dir}/status" \
+        "${p10k_dir}/last_check" \
+        "${starship_dir}/count" \
+        "${starship_dir}/last_check"
+    return 0
+}
+
+# @description Fetch the upstream ref, recompute the update count, and update the shared cache.
 function refresh() {
     local count
     local now
-    local p10k_dir
-    local starship_dir
+    local cache_dir
+    local count_file
 
     if ! command -v chezmoi > /dev/null 2>&1; then
         return 0
@@ -92,35 +122,32 @@ function refresh() {
         return 0
     fi
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
+    cache_dir="$(notify_cache_dir)"
+    count_file="$(notify_count_file)"
     now="$(current_time)"
 
-    mkdir -p "${p10k_dir}" "${starship_dir}" || return 0
+    mkdir -p "${cache_dir}" || return 0
 
     if ((count == 0)); then
-        rm -f "${p10k_dir}/status" "${starship_dir}/count"
+        rm -f "${count_file}"
     else
-        printf "%s\n" "${count}" >| "${p10k_dir}/status"
-        printf "%s\n" "${count}" >| "${starship_dir}/count"
+        printf "%s\n" "${count}" >| "${count_file}"
     fi
 
-    write_last_check_files "${now}"
+    write_last_check_file "${now}"
+    remove_legacy_cache_files
     return 0
 }
 
-# @description Refresh both notification caches only when either cache is stale.
+# @description Refresh the shared notification cache only when it is stale.
 function refresh_if_stale() {
     local now
-    local p10k_last_check_file
-    local starship_last_check_file
+    local last_check_file
 
     now="$(current_time)"
-    p10k_last_check_file="$(p10k_cache_dir)/last_check"
-    starship_last_check_file="$(starship_cache_dir)/last_check"
+    last_check_file="$(notify_last_check_file)"
 
-    if cache_is_stale "${p10k_last_check_file}" "${now}" ||
-        cache_is_stale "${starship_last_check_file}" "${now}"; then
+    if cache_is_stale "${last_check_file}" "${now}"; then
         refresh
     fi
 

--- a/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
@@ -3,8 +3,9 @@
 # @file home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
 # @brief Sync the chezmoi update notification caches used by p10k and Starship.
 # @description
-#   Recomputes `HEAD..origin/master` on demand or only when cached results are
-#   stale, then updates both shell-specific cache directories together.
+#   Fetches the tracked upstream ref, recomputes `HEAD..origin/master` on
+#   demand or only when cached results are stale, then updates both
+#   shell-specific cache directories together.
 
 set -uo pipefail
 
@@ -68,7 +69,7 @@ function write_last_check_files() {
     return 0
 }
 
-# @description Recompute the update count and synchronize both notification caches.
+# @description Fetch the upstream ref, recompute the update count, and synchronize both caches.
 function refresh() {
     local count
     local now
@@ -76,6 +77,10 @@ function refresh() {
     local starship_dir
 
     if ! command -v chezmoi > /dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! chezmoi git -- fetch -q > /dev/null 2>&1; then
         return 0
     fi
 

--- a/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
@@ -22,16 +22,6 @@ function notify_cache_dir() {
     printf "%s\n" "$(cache_root)/chezmoi-notify"
 }
 
-# @description Return the legacy Powerlevel10k cache directory path.
-function legacy_p10k_cache_dir() {
-    printf "%s\n" "$(cache_root)/p10k-chezmoi"
-}
-
-# @description Return the legacy Starship cache directory path.
-function legacy_starship_cache_dir() {
-    printf "%s\n" "$(cache_root)/starship-chezmoi"
-}
-
 # @description Return the shared count file path.
 function notify_count_file() {
     printf "%s\n" "$(notify_cache_dir)/count"
@@ -85,17 +75,15 @@ function write_last_check_file() {
 
 # @description Remove obsolete prompt-specific cache files after a successful refresh.
 function remove_legacy_cache_files() {
-    local p10k_dir
-    local starship_dir
+    local cache_root_path
 
-    p10k_dir="$(legacy_p10k_cache_dir)"
-    starship_dir="$(legacy_starship_cache_dir)"
+    cache_root_path="$(cache_root)"
 
     rm -f \
-        "${p10k_dir}/status" \
-        "${p10k_dir}/last_check" \
-        "${starship_dir}/count" \
-        "${starship_dir}/last_check"
+        "${cache_root_path}/p10k-chezmoi/status" \
+        "${cache_root_path}/p10k-chezmoi/last_check" \
+        "${cache_root_path}/starship-chezmoi/count" \
+        "${cache_root_path}/starship-chezmoi/last_check"
     return 0
 }
 

--- a/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
@@ -73,20 +73,6 @@ function write_last_check_file() {
     return 0
 }
 
-# @description Remove obsolete prompt-specific cache files after a successful refresh.
-function remove_legacy_cache_files() {
-    local cache_root_path
-
-    cache_root_path="$(cache_root)"
-
-    rm -f \
-        "${cache_root_path}/p10k-chezmoi/status" \
-        "${cache_root_path}/p10k-chezmoi/last_check" \
-        "${cache_root_path}/starship-chezmoi/count" \
-        "${cache_root_path}/starship-chezmoi/last_check"
-    return 0
-}
-
 # @description Fetch the upstream ref, recompute the update count, and update the shared cache.
 function refresh() {
     local count
@@ -123,7 +109,6 @@ function refresh() {
     fi
 
     write_last_check_file "${now}"
-    remove_legacy_cache_files
     return 0
 }
 

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -42,6 +42,10 @@ function starship_cache_dir() {
     printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
 }
 
+function expected_refresh_calls() {
+    printf "git -- fetch -q\ngit -- rev-list --count HEAD..origin/master"
+}
+
 @test "[common] refresh clears caches when the dotfiles repo is already up to date" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=0
@@ -97,10 +101,10 @@ function starship_cache_dir() {
     [ "${starship_count}" = "3" ]
     [ -s "${p10k_dir}/last_check" ]
     [ -s "${starship_dir}/last_check" ]
-    [ "$(< "${CHEZMOI_CALLS_PATH}")" = "git -- rev-list --count HEAD..origin/master" ]
+    [ "$(< "${CHEZMOI_CALLS_PATH}")" = "$(expected_refresh_calls)" ]
 }
 
-@test "[common] refresh leaves existing caches untouched when chezmoi rev-list fails" {
+@test "[common] refresh leaves existing caches untouched when upstream fetch fails" {
     write_chezmoi_stub
     export CHEZMOI_SHOULD_FAIL=1
 
@@ -121,6 +125,7 @@ function starship_cache_dir() {
     [ "$(< "${starship_dir}/count")" = "7" ]
     [ "$(< "${p10k_dir}/last_check")" = "42" ]
     [ "$(< "${starship_dir}/last_check")" = "42" ]
+    [ "$(< "${CHEZMOI_CALLS_PATH}")" = "git -- fetch -q" ]
 }
 
 @test "[common] refresh-if-stale skips recomputation while both caches are fresh" {
@@ -163,7 +168,7 @@ function starship_cache_dir() {
     [ "${status}" -eq 0 ]
     [ "$(< "${p10k_dir}/status")" = "4" ]
     [ "$(< "${starship_dir}/count")" = "4" ]
-    [ -s "${CHEZMOI_CALLS_PATH}" ]
+    [ "$(< "${CHEZMOI_CALLS_PATH}")" = "$(expected_refresh_calls)" ]
 }
 
 @test "[common] refresh-if-stale recomputes when either last_check file is expired" {

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -57,27 +57,15 @@ function expected_refresh_calls() {
     export CHEZMOI_REV_LIST_COUNT=0
 
     local cache_dir
-    local p10k_dir
-    local starship_dir
 
     cache_dir="$(notify_cache_dir)"
-    p10k_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
-    starship_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
-    mkdir -p "${cache_dir}" "${p10k_dir}" "${starship_dir}"
+    mkdir -p "${cache_dir}"
     printf "9\n" > "$(notify_count_file)"
-    printf "9\n" > "${p10k_dir}/status"
-    printf "9\n" > "${starship_dir}/count"
-    printf "42\n" > "${p10k_dir}/last_check"
-    printf "42\n" > "${starship_dir}/last_check"
 
     run bash "${SCRIPT_PATH}" refresh
     [ "${status}" -eq 0 ]
     [ ! -e "$(notify_count_file)" ]
     [ -s "$(notify_last_check_file)" ]
-    [ ! -e "${p10k_dir}/status" ]
-    [ ! -e "${p10k_dir}/last_check" ]
-    [ ! -e "${starship_dir}/count" ]
-    [ ! -e "${starship_dir}/last_check" ]
 
     local last_check
     last_check="$(< "$(notify_last_check_file)")"
@@ -85,30 +73,15 @@ function expected_refresh_calls() {
     [ "${last_check}" -gt 1 ]
 }
 
-@test "[common] refresh writes the shared count under XDG_CACHE_HOME and removes legacy caches" {
+@test "[common] refresh writes the shared count under XDG_CACHE_HOME" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=3
     export XDG_CACHE_HOME="${BATS_TEST_TMPDIR}/xdg-cache"
-
-    local p10k_dir
-    local starship_dir
-
-    p10k_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
-    starship_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
-    printf "11\n" > "${p10k_dir}/status"
-    printf "11\n" > "${starship_dir}/count"
-    printf "11\n" > "${p10k_dir}/last_check"
-    printf "11\n" > "${starship_dir}/last_check"
 
     run bash "${SCRIPT_PATH}" refresh
     [ "${status}" -eq 0 ]
     [ -s "$(notify_count_file)" ]
     [ -s "$(notify_last_check_file)" ]
-    [ ! -e "${p10k_dir}/status" ]
-    [ ! -e "${p10k_dir}/last_check" ]
-    [ ! -e "${starship_dir}/count" ]
-    [ ! -e "${starship_dir}/last_check" ]
 
     local count
     count="$(< "$(notify_count_file)")"

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -2,6 +2,8 @@
 
 readonly SCRIPT_PATH="./home/dot_local/bin/exact_common/executable_chezmoi-notify-cache"
 readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_99-refresh-chezmoi-notify-cache.sh.tmpl"
+readonly P10K_CONFIG_PATH="./home/dot_config/powerlevel10k/p10k.zsh"
+readonly STARSHIP_CONFIG_PATH="./home/dot_config/starship.toml"
 
 function setup() {
     export HOME="${BATS_TEST_TMPDIR}/home"
@@ -199,5 +201,19 @@ function expected_refresh_calls() {
     [ -f "${RUN_AFTER_TEMPLATE}" ]
 
     run grep -F '"${HOME}/.local/bin/common/chezmoi-notify-cache" refresh' "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] p10k reads the same chezmoi cache file as starship" {
+    [ -f "${P10K_CONFIG_PATH}" ]
+    [ -f "${STARSHIP_CONFIG_PATH}" ]
+
+    run grep -F 'command = "cat ${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"' "${STARSHIP_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"' "${P10K_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'if [[ -s "$status_file" ]]; then' "${P10K_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -40,14 +40,6 @@ function notify_cache_dir() {
     printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/chezmoi-notify"
 }
 
-function legacy_p10k_cache_dir() {
-    printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
-}
-
-function legacy_starship_cache_dir() {
-    printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
-}
-
 function notify_count_file() {
     printf "%s\n" "$(notify_cache_dir)/count"
 }
@@ -69,8 +61,8 @@ function expected_refresh_calls() {
     local starship_dir
 
     cache_dir="$(notify_cache_dir)"
-    p10k_dir="$(legacy_p10k_cache_dir)"
-    starship_dir="$(legacy_starship_cache_dir)"
+    p10k_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
+    starship_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
     mkdir -p "${cache_dir}" "${p10k_dir}" "${starship_dir}"
     printf "9\n" > "$(notify_count_file)"
     printf "9\n" > "${p10k_dir}/status"
@@ -101,8 +93,8 @@ function expected_refresh_calls() {
     local p10k_dir
     local starship_dir
 
-    p10k_dir="$(legacy_p10k_cache_dir)"
-    starship_dir="$(legacy_starship_cache_dir)"
+    p10k_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
+    starship_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
     mkdir -p "${p10k_dir}" "${starship_dir}"
     printf "11\n" > "${p10k_dir}/status"
     printf "11\n" > "${starship_dir}/count"

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -36,12 +36,24 @@ EOF
     chmod +x "${TEST_BIN_DIR}/chezmoi"
 }
 
-function p10k_cache_dir() {
+function notify_cache_dir() {
+    printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/chezmoi-notify"
+}
+
+function legacy_p10k_cache_dir() {
     printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/p10k-chezmoi"
 }
 
-function starship_cache_dir() {
+function legacy_starship_cache_dir() {
     printf "%s\n" "${XDG_CACHE_HOME:-${HOME}/.cache}/starship-chezmoi"
+}
+
+function notify_count_file() {
+    printf "%s\n" "$(notify_cache_dir)/count"
+}
+
+function notify_last_check_file() {
+    printf "%s\n" "$(notify_cache_dir)/last_check"
 }
 
 function expected_refresh_calls() {
@@ -52,34 +64,36 @@ function expected_refresh_calls() {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=0
 
+    local cache_dir
     local p10k_dir
     local starship_dir
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
+    cache_dir="$(notify_cache_dir)"
+    p10k_dir="$(legacy_p10k_cache_dir)"
+    starship_dir="$(legacy_starship_cache_dir)"
+    mkdir -p "${cache_dir}" "${p10k_dir}" "${starship_dir}"
+    printf "9\n" > "$(notify_count_file)"
     printf "9\n" > "${p10k_dir}/status"
     printf "9\n" > "${starship_dir}/count"
+    printf "42\n" > "${p10k_dir}/last_check"
+    printf "42\n" > "${starship_dir}/last_check"
 
     run bash "${SCRIPT_PATH}" refresh
     [ "${status}" -eq 0 ]
+    [ ! -e "$(notify_count_file)" ]
+    [ -s "$(notify_last_check_file)" ]
     [ ! -e "${p10k_dir}/status" ]
+    [ ! -e "${p10k_dir}/last_check" ]
     [ ! -e "${starship_dir}/count" ]
-    [ -s "${p10k_dir}/last_check" ]
-    [ -s "${starship_dir}/last_check" ]
+    [ ! -e "${starship_dir}/last_check" ]
 
-    local p10k_last_check
-    local starship_last_check
-    p10k_last_check="$(< "${p10k_dir}/last_check")"
-    starship_last_check="$(< "${starship_dir}/last_check")"
-    [[ "${p10k_last_check}" =~ ^[0-9]+$ ]]
-    [[ "${starship_last_check}" =~ ^[0-9]+$ ]]
-    [ "${p10k_last_check}" = "${starship_last_check}" ]
-    [ "${p10k_last_check}" -gt 1 ]
-    [ "${starship_last_check}" -gt 1 ]
+    local last_check
+    last_check="$(< "$(notify_last_check_file)")"
+    [[ "${last_check}" =~ ^[0-9]+$ ]]
+    [ "${last_check}" -gt 1 ]
 }
 
-@test "[common] refresh writes the same count into both caches under XDG_CACHE_HOME" {
+@test "[common] refresh writes the shared count under XDG_CACHE_HOME and removes legacy caches" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=3
     export XDG_CACHE_HOME="${BATS_TEST_TMPDIR}/xdg-cache"
@@ -87,22 +101,26 @@ function expected_refresh_calls() {
     local p10k_dir
     local starship_dir
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
+    p10k_dir="$(legacy_p10k_cache_dir)"
+    starship_dir="$(legacy_starship_cache_dir)"
+    mkdir -p "${p10k_dir}" "${starship_dir}"
+    printf "11\n" > "${p10k_dir}/status"
+    printf "11\n" > "${starship_dir}/count"
+    printf "11\n" > "${p10k_dir}/last_check"
+    printf "11\n" > "${starship_dir}/last_check"
 
     run bash "${SCRIPT_PATH}" refresh
     [ "${status}" -eq 0 ]
-    [ -s "${p10k_dir}/status" ]
-    [ -s "${starship_dir}/count" ]
+    [ -s "$(notify_count_file)" ]
+    [ -s "$(notify_last_check_file)" ]
+    [ ! -e "${p10k_dir}/status" ]
+    [ ! -e "${p10k_dir}/last_check" ]
+    [ ! -e "${starship_dir}/count" ]
+    [ ! -e "${starship_dir}/last_check" ]
 
-    local p10k_count
-    local starship_count
-    p10k_count="$(< "${p10k_dir}/status")"
-    starship_count="$(< "${starship_dir}/count")"
-    [ "${p10k_count}" = "3" ]
-    [ "${starship_count}" = "3" ]
-    [ -s "${p10k_dir}/last_check" ]
-    [ -s "${starship_dir}/last_check" ]
+    local count
+    count="$(< "$(notify_count_file)")"
+    [ "${count}" = "3" ]
     [ "$(< "${CHEZMOI_CALLS_PATH}")" = "$(expected_refresh_calls)" ]
 }
 
@@ -110,90 +128,61 @@ function expected_refresh_calls() {
     write_chezmoi_stub
     export CHEZMOI_SHOULD_FAIL=1
 
-    local p10k_dir
-    local starship_dir
+    local cache_dir
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
-    printf "7\n" > "${p10k_dir}/status"
-    printf "7\n" > "${starship_dir}/count"
-    printf "42\n" > "${p10k_dir}/last_check"
-    printf "42\n" > "${starship_dir}/last_check"
+    cache_dir="$(notify_cache_dir)"
+    mkdir -p "${cache_dir}"
+    printf "7\n" > "$(notify_count_file)"
+    printf "42\n" > "$(notify_last_check_file)"
 
     run bash "${SCRIPT_PATH}" refresh
     [ "${status}" -eq 0 ]
-    [ "$(< "${p10k_dir}/status")" = "7" ]
-    [ "$(< "${starship_dir}/count")" = "7" ]
-    [ "$(< "${p10k_dir}/last_check")" = "42" ]
-    [ "$(< "${starship_dir}/last_check")" = "42" ]
+    [ "$(< "$(notify_count_file)")" = "7" ]
+    [ "$(< "$(notify_last_check_file)")" = "42" ]
     [ "$(< "${CHEZMOI_CALLS_PATH}")" = "git -- fetch -q" ]
 }
 
-@test "[common] refresh-if-stale skips recomputation while both caches are fresh" {
+@test "[common] refresh-if-stale skips recomputation while the shared cache is fresh" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=5
 
-    local p10k_dir
-    local starship_dir
     local now
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
     now="$(date +%s)"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
-    printf "%s\n" "${now}" > "${p10k_dir}/last_check"
-    printf "%s\n" "${now}" > "${starship_dir}/last_check"
+    mkdir -p "$(notify_cache_dir)"
+    printf "%s\n" "${now}" > "$(notify_last_check_file)"
 
     run bash "${SCRIPT_PATH}" refresh-if-stale
     [ "${status}" -eq 0 ]
     [ ! -e "${CHEZMOI_CALLS_PATH}" ]
-    [ ! -e "${p10k_dir}/status" ]
-    [ ! -e "${starship_dir}/count" ]
+    [ ! -e "$(notify_count_file)" ]
 }
 
-@test "[common] refresh-if-stale recomputes when either last_check file is missing" {
+@test "[common] refresh-if-stale recomputes when the shared last_check file is missing" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=4
 
-    local p10k_dir
-    local starship_dir
-    local now
-
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
-    now="$(date +%s)"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
-    printf "%s\n" "${now}" > "${starship_dir}/last_check"
-
     run bash "${SCRIPT_PATH}" refresh-if-stale
     [ "${status}" -eq 0 ]
-    [ "$(< "${p10k_dir}/status")" = "4" ]
-    [ "$(< "${starship_dir}/count")" = "4" ]
+    [ "$(< "$(notify_count_file)")" = "4" ]
     [ "$(< "${CHEZMOI_CALLS_PATH}")" = "$(expected_refresh_calls)" ]
 }
 
-@test "[common] refresh-if-stale recomputes when either last_check file is expired" {
+@test "[common] refresh-if-stale recomputes when the shared last_check file is expired" {
     write_chezmoi_stub
     export CHEZMOI_REV_LIST_COUNT=6
 
-    local p10k_dir
-    local starship_dir
     local now
     local expired
 
-    p10k_dir="$(p10k_cache_dir)"
-    starship_dir="$(starship_cache_dir)"
     now="$(date +%s)"
     expired="$((now - 4000))"
-    mkdir -p "${p10k_dir}" "${starship_dir}"
-    printf "%s\n" "${expired}" > "${p10k_dir}/last_check"
-    printf "%s\n" "${now}" > "${starship_dir}/last_check"
+    mkdir -p "$(notify_cache_dir)"
+    printf "%s\n" "${expired}" > "$(notify_last_check_file)"
 
     run bash "${SCRIPT_PATH}" refresh-if-stale
     [ "${status}" -eq 0 ]
-    [ "$(< "${p10k_dir}/status")" = "6" ]
-    [ "$(< "${starship_dir}/count")" = "6" ]
+    [ "$(< "$(notify_count_file)")" = "6" ]
     [ -s "${CHEZMOI_CALLS_PATH}" ]
 }
 
@@ -208,12 +197,12 @@ function expected_refresh_calls() {
     [ -f "${P10K_CONFIG_PATH}" ]
     [ -f "${STARSHIP_CONFIG_PATH}" ]
 
-    run grep -F 'command = "cat ${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"' "${STARSHIP_CONFIG_PATH}"
+    run grep -F 'command = "cat ${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-notify/count"' "${STARSHIP_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F 'local status_file="${XDG_CACHE_HOME:-$HOME/.cache}/starship-chezmoi/count"' "${P10K_CONFIG_PATH}"
+    run grep -F 'local count_file="${XDG_CACHE_HOME:-$HOME/.cache}/chezmoi-notify/count"' "${P10K_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F 'if [[ -s "$status_file" ]]; then' "${P10K_CONFIG_PATH}"
+    run grep -F 'if [[ -s "$count_file" ]]; then' "${P10K_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- restore the upstream `chezmoi git -- fetch -q` step before recomputing the remote-behind count for the chezmoi notification helper
- replace the prompt-specific cache layout with a neutral shared `chezmoi-notify/{count,last_check}` cache consumed directly by both Powerlevel10k and Starship
- drop the old prompt-specific cache compatibility code so the unified cache becomes the only source of truth
- extend the focused tests to lock the fetch-before-rev-list behavior and the shared cache consumer paths under the new single-cache layout

## Testing
- `shfmt --indent 4 --space-redirects -w home/dot_local/bin/exact_common/executable_chezmoi-notify-cache tests/install/common/chezmoi_notify_cache.bats`
- `bash -n home/dot_local/bin/exact_common/executable_chezmoi-notify-cache`
- `rg -n 'p10k-chezmoi|starship-chezmoi|legacy_.*cache_dir' home/dot_local/bin/exact_common/executable_chezmoi-notify-cache tests/install/common/chezmoi_notify_cache.bats home/dot_config/powerlevel10k/p10k.zsh home/dot_config/starship.toml`
- manual helper check with a fake `chezmoi` stub to confirm `fetch -q` runs before `rev-list --count` and the unified cache is written under `chezmoi-notify/{count,last_check}`
- not run: `bats` locally (repository policy)
