### PR TITLE
docs(readme): note Pages requirements for setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ See [.chezmoiroot - chezmoi](https://www.chezmoi.io/reference/special-files-and-
 
 To set up the dotfiles run the appropriate snippet in the terminal.
 
+<details>
+<summary>About the hosted <code>setup.sh</code> snippet</summary>
+
+The `curl` and `wget` snippets below download `setup.sh` from GitHub Pages.
+To keep `http://shunk031.me/dotfiles/setup.sh` and `https://shunk031.me/dotfiles/setup.sh` working, `Settings > Pages` must publish from the branch that contains `setup.sh` and use `/(root)` as the source folder.
+Selecting `/docs` would stop serving the repository-root `setup.sh`.
+</details>
+
 ### 💻 `MacOS` [![MacOS](https://github.com/shunk031/dotfiles/actions/workflows/macos.yaml/badge.svg)](https://github.com/shunk031/dotfiles/actions/workflows/macos.yaml)
 
 - Configuration snippet of the Apple Silicon MacOS environment for client macnine:


### PR DESCRIPTION
## Summary
- add a collapsed note in the setup section explaining that the hosted `setup.sh` snippet is served from GitHub Pages
- document that `Settings > Pages` must publish from the branch that contains `setup.sh` and use `/(root)` as the source folder
- clarify that selecting `/docs` would stop serving the repository-root `setup.sh` snippet

## Testing
- `git diff --check -- README.md`
- reviewed the README diff for the inserted `<details>` block