### PR TITLE
chore(repo): prepare default-branch migration to main

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,8 +1,9 @@
 name: MacOS
 
 on:
+  # Keep both branches during the staged default-branch migration.
   push:
-    branches: [master]
+    branches: [master, main]
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
@@ -12,7 +13,7 @@ on:
       - "tests/install/macos/**"
 
   pull_request:
-    branches: [master]
+    branches: [master, main]
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
@@ -71,7 +72,7 @@ jobs:
 
       - name: Set flag for auto-push in the benchmark action
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          if [ "${{ github.event_name }}" = "push" ] && { [ "${{ github.ref }}" = "refs/heads/master" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; }; then
             echo "auto_push=true" >> $GITHUB_ENV
           else
             echo "auto_push=false" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,15 +1,16 @@
 name: Unit test
 
 on:
-  # Required checks must always report a final status for PRs into `master`.
-  # Do not add workflow-level path or branch filters here: GitHub can leave
-  # skipped required checks in a pending state and block merges.
+  # Required checks must always report a final status during the staged
+  # `master` -> `main` cutover.
+  # Do not add workflow-level path filters here: GitHub can leave skipped
+  # required checks in a pending state and block merges.
   # Keep this workflow unconditional and decide inside jobs whether the full
   # test matrix is necessary for the current diff.
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
-    branches: [master]
+    branches: [master, main]
 
 jobs:
   changes:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -1,8 +1,9 @@
 name: Ubuntu
 
 on:
+  # Keep both branches during the staged default-branch migration.
   push:
-    branches: [master]
+    branches: [master, main]
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"
@@ -12,7 +13,7 @@ on:
       - "tests/install/ubuntu/**"
 
   pull_request:
-    branches: [master]
+    branches: [master, main]
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 This [dotfiles](https://github.com/shunk031/dotfiles) repository is managed with [`chezmoi🏠`](https://www.chezmoi.io/), a great dotfiles manager.
 The setup scripts are aimed for [MacOS](https://www.apple.com/jp/macos), [Ubuntu Desktop](https://ubuntu.com/desktop), and [Ubuntu Server](https://ubuntu.com/server). The first two (MacOS/Ubuntu Desktop) include settings for `client` machines and the latter one (Ubuntu Server) for `server` machines.
 
-The actual dotfiles exist under the [`home`](https://github.com/shunk031/dotfiles/tree/master/home) directory specified in the [`.chezmoiroot`](https://github.com/shunk031/dotfiles/blob/master/.chezmoiroot).
+The actual dotfiles exist under the [`home`](https://github.com/shunk031/dotfiles/tree/main/home) directory specified in the [`.chezmoiroot`](https://github.com/shunk031/dotfiles/blob/main/.chezmoiroot).
 See [.chezmoiroot - chezmoi](https://www.chezmoi.io/reference/special-files-and-directories/chezmoiroot/) more detail on the setting.
 
 The following are the tools and coding assistants I mainly use in this setup.
@@ -82,7 +82,7 @@ The desired application can be installed as follows (e.g., docker installation o
 bash install/macos/common/docker.sh
 ```
 
-Each installation script can be found under the [`./install`](https://github.com/shunk031/dotfiles/tree/master/install) directory.
+Each installation script can be found under the [`./install`](https://github.com/shunk031/dotfiles/tree/main/install) directory.
 
 ## 🛠️ Update & Test 🧪
 
@@ -91,13 +91,13 @@ To verify that the updated scripts work correctly, run the scripts on the actual
 
 ### 💡 Develop the Setup Scripts
 
-The setup scripts are stored as shellscripts in an appropriate location under the [`./install`](https://github.com/shunk031/dotfiles/tree/master/install) directory.
-After verifying that the shellscript works, store the [chezmoi template](https://www.chezmoi.io/user-guide/templating/)-based file, which is based on the shellscript, in an appropriate location under the [`./home/.chezmoiscripts`](https://github.com/shunk031/dotfiles/tree/master/home/.chezmoiscripts) directory.
+The setup scripts are stored as shellscripts in an appropriate location under the [`./install`](https://github.com/shunk031/dotfiles/tree/main/install) directory.
+After verifying that the shellscript works, store the [chezmoi template](https://www.chezmoi.io/user-guide/templating/)-based file, which is based on the shellscript, in an appropriate location under the [`./home/.chezmoiscripts`](https://github.com/shunk031/dotfiles/tree/main/home/.chezmoiscripts) directory.
 
 Below is the correspondence between shellscript and template for docker installation on MacOS.
 
-- The shellscript for docker: [`install/macos/common/docker.sh`](https://github.com/shunk031/dotfiles/blob/master/install/macos/common/docker.sh)
-- The chezmoi template for docker: [`home/.chezmoiscripts/macos/run_once_10-install-docker.sh.tmpl`](https://github.com/shunk031/dotfiles/blob/master/home/.chezmoiscripts/macos/run_once_10-install-docker.sh.tmpl)
+- The shellscript for docker: [`install/macos/common/docker.sh`](https://github.com/shunk031/dotfiles/blob/main/install/macos/common/docker.sh)
+- The chezmoi template for docker: [`home/.chezmoiscripts/macos/run_once_10-install-docker.sh.tmpl`](https://github.com/shunk031/dotfiles/blob/main/home/.chezmoiscripts/macos/run_once_10-install-docker.sh.tmpl)
 
 ### 💾 Test on the Local Machine
 
@@ -132,13 +132,13 @@ shunk031@5f93d270cb51:~$ chezmoi init --apply
 ### 🦇 Unit Test with [Bats](https://github.com/bats-core/bats-core) [![Unit test](https://github.com/shunk031/dotfiles/actions/workflows/test.yaml/badge.svg)](https://github.com/shunk031/dotfiles/actions/workflows/test.yaml)
 
 Test the shellscript for setup with [Bash Automated Testing System (bats)](https://github.com/bats-core/bats-core).
-The scripts for the unit test can be found under [`./tests`](https://github.com/shunk031/dotfiles/tree/master/tests/install) directory.
+The scripts for the unit test can be found under [`./tests`](https://github.com/shunk031/dotfiles/tree/main/tests/install) directory.
 
-### 📦 Continuously monitor code coverage with Codecov [![codecov](https://codecov.io/gh/shunk031/dotfiles/branch/master/graph/badge.svg?token=4VUJWKGAR7)](https://codecov.io/gh/shunk031/dotfiles)
+### 📦 Continuously monitor code coverage with Codecov [![codecov](https://codecov.io/gh/shunk031/dotfiles/graph/badge.svg?token=4VUJWKGAR7)](https://codecov.io/gh/shunk031/dotfiles)
 
-The code coverage of the [`./install`](https://github.com/shunk031/dotfiles/tree/master/install) scripts are continuously monitored at [app.codecov.io/gh/shunk031/dotfiles](https://app.codecov.io/gh/shunk031/dotfiles). The following Icicle graph represents the code coverage of the scripts:
+The code coverage of the [`./install`](https://github.com/shunk031/dotfiles/tree/main/install) scripts are continuously monitored at [app.codecov.io/gh/shunk031/dotfiles](https://app.codecov.io/gh/shunk031/dotfiles). The following Icicle graph represents the code coverage of the scripts:
 
-[![](https://codecov.io/gh/shunk031/dotfiles/branch/master/graphs/icicle.svg?token=4VUJWKGAR7)](https://app.codecov.io/gh/shunk031/dotfiles)
+[![](https://codecov.io/gh/shunk031/dotfiles/graphs/icicle.svg?token=4VUJWKGAR7)](https://app.codecov.io/gh/shunk031/dotfiles)
 
 ## 📊 Measure the startup speed of the dotfiles
 
@@ -148,16 +148,16 @@ The startup speed of zsh on MacOS with this dotfile is continuously measured at 
 
 ### Minimum setup for server machine without chezmoi
 
-- Download [`.tmux.conf.d/system/server.conf`](https://github.com/shunk031/dotfiles/blob/master/home/dot_tmux.conf.d/system/server.conf) and deploy as `~/.tmux.conf`
+- Download [`.tmux.conf.d/system/server.conf`](https://github.com/shunk031/dotfiles/blob/main/home/dot_tmux.conf.d/system/server.conf) and deploy as `~/.tmux.conf`
 
 ```shell
-wget -O ~/.tmux.conf https://raw.githubusercontent.com/shunk031/dotfiles/master/home/dot_tmux.conf.d/system/server.conf
+wget -O ~/.tmux.conf https://raw.githubusercontent.com/shunk031/dotfiles/main/home/dot_tmux.conf.d/system/server.conf
 ```
 
-- Download [`.vimrc`](https://github.com/shunk031/dotfiles/blob/master/home/dot_vimrc) and deploy to `~/.vimrc`
+- Download [`.vimrc`](https://github.com/shunk031/dotfiles/blob/main/home/dot_vimrc) and deploy to `~/.vimrc`
 
 ```shell
-wget -O ~/.vimrc https://raw.githubusercontent.com/shunk031/dotfiles/master/home/dot_vimrc
+wget -O ~/.vimrc https://raw.githubusercontent.com/shunk031/dotfiles/main/home/dot_vimrc
 ```
 
 ## 📈 Stats
@@ -175,4 +175,4 @@ Inspiration and code was taken from many sources, including:
 
 ## 📝 License
 
-The code is available under the [MIT license](https://github.com/shunk031/dotfiles/blob/master/LICENSE).
+The code is available under the [MIT license](https://github.com/shunk031/dotfiles/blob/main/LICENSE).

--- a/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
+++ b/home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
@@ -3,14 +3,14 @@
 # @file home/dot_local/bin/exact_common/executable_chezmoi-notify-cache
 # @brief Sync the shared chezmoi update notification cache used by p10k and Starship.
 # @description
-#   Fetches the tracked upstream ref, recomputes `HEAD..origin/master` on
+#   Fetches the tracked upstream ref, recomputes `HEAD..origin/main` on
 #   demand or only when cached results are stale, then updates the shared
 #   notification cache consumed by both prompts.
 
 set -uo pipefail
 
 readonly CHECK_INTERVAL=3600
-readonly UPSTREAM_REF="origin/master"
+readonly UPSTREAM_REF="origin/main"
 
 # @description Return the cache root honoring `XDG_CACHE_HOME`.
 function cache_root() {

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ declare -r DOTFILES_LOGO='
 '
 
 declare -r DOTFILES_REPO_URL="https://github.com/shunk031/dotfiles"
-declare -r BRANCH_NAME="${BRANCH_NAME:-master}"
+declare -r BRANCH_NAME="${BRANCH_NAME:-main}"
 
 function is_ci() {
     "${CI:-false}"

--- a/tests/install/common/chezmoi_notify_cache.bats
+++ b/tests/install/common/chezmoi_notify_cache.bats
@@ -49,7 +49,7 @@ function notify_last_check_file() {
 }
 
 function expected_refresh_calls() {
-    printf "git -- fetch -q\ngit -- rev-list --count HEAD..origin/master"
+    printf "git -- fetch -q\ngit -- rev-list --count HEAD..origin/main"
 }
 
 @test "[common] refresh clears caches when the dotfiles repo is already up to date" {


### PR DESCRIPTION
## Summary
- update repository-owned `master` links and setup defaults to `main`
- temporarily allow `master` and `main` in workflow branch filters for the staged cutover
- switch the chezmoi notify cache helper and its test to `origin/main`

## Testing
- `git diff --check`
- `bash -n setup.sh`
- `bash -n home/dot_local/bin/exact_common/executable_chezmoi-notify-cache`
- `ruby -e 'require "yaml"; %w[.github/workflows/macos.yaml .github/workflows/ubuntu.yaml .github/workflows/test.yaml].each { |f| YAML.load_file(f) }'`
- `curl -I -L https://raw.githubusercontent.com/shunk031/dotfiles/main/home/dot_vimrc`
- `curl -I -L https://codecov.io/gh/shunk031/dotfiles/graphs/icicle.svg?token=4VUJWKGAR7`
- Local `bats` execution was skipped per repository policy.

Refs #433
