### PR TITLE
chore(ci): drop temporary master cutover support

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,9 +1,8 @@
 name: MacOS
 
 on:
-  # Keep both branches during the staged default-branch migration.
   push:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
@@ -13,7 +12,7 @@ on:
       - "tests/install/macos/**"
 
   pull_request:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
@@ -72,7 +71,7 @@ jobs:
 
       - name: Set flag for auto-push in the benchmark action
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && { [ "${{ github.ref }}" = "refs/heads/master" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; }; then
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "auto_push=true" >> $GITHUB_ENV
           else
             echo "auto_push=false" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,16 +1,15 @@
 name: Unit test
 
 on:
-  # Required checks must always report a final status during the staged
-  # `master` -> `main` cutover.
+  # Required checks must always report a final status for PRs into `main`.
   # Do not add workflow-level path filters here: GitHub can leave skipped
   # required checks in a pending state and block merges.
   # Keep this workflow unconditional and decide inside jobs whether the full
   # test matrix is necessary for the current diff.
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   changes:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -1,9 +1,8 @@
 name: Ubuntu
 
 on:
-  # Keep both branches during the staged default-branch migration.
   push:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"
@@ -13,7 +12,7 @@ on:
       - "tests/install/ubuntu/**"
 
   pull_request:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"


### PR DESCRIPTION
## Summary
- remove temporary `master`/`main` dual-branch workflow filters now that `main` is the default branch
- restore required workflow triggers to `main` only
- limit benchmark auto-push back to `refs/heads/main`

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/macos.yaml .github/workflows/ubuntu.yaml .github/workflows/test.yaml].each { |f| YAML.load_file(f) }'`

Refs #433
