### PR TITLE
feat(codex): delegate worklog management to subagent

### DIFF
--- a/home/dot_codex/README.md
+++ b/home/dot_codex/README.md
@@ -1,4 +1,5 @@
 - This directory is applied as `~/.codex`.
 - Chezmoi maps `~/.codex/AGENTS.md` to the canonical source in [home/dot_config/codex/AGENTS.md](../dot_config/codex/AGENTS.md).
+- Chezmoi maps `~/.codex/agents` to the canonical source in [home/dot_config/codex/agents/](../dot_config/codex/agents/).
 - The design keeps the home-facing path stable while the real files live in one git-friendly source tree.
 - Edit the canonical source, not this adapter directory.

--- a/home/dot_codex/symlink_agents.tmpl
+++ b/home/dot_codex/symlink_agents.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/codex/agents

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -16,81 +16,17 @@
 
 - After reading this user-level `AGENTS.md`, say: `🤖 I read the user-level AGENTS.md.`
 
-### セッション開始時の learn 確認
+### Worklog Subagent
 
-- 作業を開始する前に、`.agents/worklog/codex/learn/learn_index.md` を読み、過去のセッションで得た知見やエラーの教訓を把握してください。
-- インデックスの中で今回のタスクに関連しそうな項目があれば、該当する learn ファイルの本文も読んでから作業に取り掛かってください。
-- 特にエラーや失敗に関する教訓は、同じ過ちを繰り返さないように作業中も意識してください。
+- Worklog management is handled by the custom subagent `worklog_manager`, exposed through `~/.codex/agents`.
+- For every non-trivial task, spawn `worklog_manager` once near the start of the session and reuse the same thread for the rest of the task.
+- Pass the task summary, the initial user prompt, and a `parent_owner` value such as `codex-foo`.
+- Delegate all reads and writes under `.agents/worklog/codex/**` to `worklog_manager`.
+- Do not update `.agents/worklog/codex/**` directly from the main Codex agent.
+- Use the learn summary returned by `worklog_manager` before continuing the main task.
+- If `worklog_manager` cannot read the required learn files or cannot update the worklog after it starts, fail hard and report the problem instead of falling back to direct edits.
 
 ### セッション終了時のまとめ
 
-- 会話の自然な区切りで、直ちに次のアクションが想定されない場合は、以下の形式で 1 行のまとめを出力してください。
+- 会話の自然な区切りで、直ちに次のアクションが想定されない場合は、`worklog_manager` から summary 案を受け取り、以下の形式で 1 行のまとめを出力してください。
 - `📝 まとめ: <このセッションで完了した内容を 1〜2 文で要約してください。未完了のタスクや次のアクションがあれば末尾に追記してください。>`
-
-### プロジェクトの構成について
-
-- プロジェクト構成はプログラミング言語ごとに異なりますが、作業を開始する際、存在しない場合のみ以下の構成でセットアップしてください。
-  - 作業中は plan と todo を常に更新し続けてください。
-  - これらの plan/todo/learn ファイルはコミットしないでください。
-  - `.agents/worklog/codex/plan/`: プロジェクトの計画や設計に関するドキュメントを格納するディレクトリ
-    - `$(date +%Y%m%d_%H%M%S)_plan.md` のような形式でファイルを作成してください
-    - 実装する前に計画を立て、必要であればユーザへの質問を行って計画用のドキュメントを更新してください。
-    - セッション開始時の最初のユーザープロンプトを `User Prompt` セクションに記録し、その後の要件変更や追加指示も時系列で追記してください。
-  - `.agents/worklog/codex/todo/`: タスク管理用のディレクトリ
-    - `$(date +%Y%m%d_%H%M%S)_todo.md` のような形式でファイルを作成してください
-    - `.agents/worklog/codex/plan/` ディレクトリのドキュメントをもとに、実装するタスクを洗い出して記述してください。
-    - タスクは完了したら完了済みのセクションに移動してください。todo 全体が完了したら、ファイル名を `$(date +%Y%m%d_%H%M%S)_done.md` のように変更してください。
-    - タスクの完了に伴って計画が変更された場合は、`.agents/worklog/codex/plan/` ディレクトリのドキュメントを更新してください。
-  - `.agents/worklog/codex/learn/`: 学習用のドキュメントを格納するディレクトリ
-    - `$(date +%Y%m%d_%H%M%S)_learn.md` のような形式でファイルを作成してください
-    - プロジェクトの実装に必要な知識や技術を学習した際に、学習内容をこのディレクトリに記録してください。
-    - 学習内容はプロジェクトの実装に活かせるように、必要に応じて `.agents/worklog/codex/plan/` ディレクトリのドキュメントを更新してください。
-    - learn は「次回の意思決定を速くする情報」が得られたときに更新してください。
-    - learn には「何を学んだか」「どこに反映すべきか」を必ず書いてください。
-    - learn を更新したら、必要に応じて plan の `Assumptions` / `Design` / `Tests` を更新してください。
-    - `.agents/worklog/codex/learn/learn_index.md`: learn ファイルの要約インデックス。learn ファイルを新規作成・更新・削除した際は、必ずこのインデックスも更新してください。
-    - インデックスの各エントリは 1 行で `- [タイトル](ファイル名) — 要約（150 文字以内）` の形式で記述してください。
-  - 作成するファイルには以下の最低限の見出しを含めてください。
-    - plan: `User Prompt`, `Goal`, `Scope`, `Assumptions`, `Design`, `Tests`, `Open Questions`
-    - todo: `TODO`, `Done`
-    - learn: `Date`, `Learnings`, `Plan Updates`
-
-#### plan/todo/learn の frontmatter ルール
-
-- `.agents/worklog/codex/plan/*.md` `.agents/worklog/codex/todo/*.md` `.agents/worklog/codex/learn/*.md` の先頭に YAML frontmatter を必須とします。
-- 並列実行を前提に、`active` 制約は「リポジトリ全体で 1 件」ではなく「`owner` ごとに 1 件」とします。
-
-##### 共通必須キー
-
-- `type`: `plan | todo | learn`
-- `id`: `YYYYMMDD_HHMMSS`
-- `owner`: 例 `codex-a`, `codex-b`
-- `created_at`: ISO8601
-- `updated_at`: ISO8601
-
-##### type ごとの必須キー
-
-- `todo`: `status`, `workstream`, `related_plan`
-- `plan`: `status`
-- `learn`: `validated`, `apply_to`
-
-##### status 値
-
-- `todo.status`: `active | blocked | done | superseded`
-- `plan.status`: `draft | active | done | superseded`
-- `learn.validated`: `true | false`
-
-##### 推奨キー（任意）
-
-- `depends_on`: 依存する `todo id` の配列
-- `blocked_reason`: `status=blocked` の理由
-- `evidence`: ログ/PR/実験結果のパス配列
-- `tags`: 任意タグ
-
-##### 運用ルール
-
-- 新規 `todo` 作成時は `owner` を必ず設定してください。
-- 各 `owner` は同時に `active` な `todo` を 1 件までにしてください。
-- `# TODO` が空になったら `status: done` に更新し、`*_done.md` へリネームしてください。
-- `learn` は「再利用可能」かつ「検証済み (`validated: true`)」のときのみ作成してください。
-- `learn` 更新時は `apply_to` に反映先（plan/tests）を明記してください。

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -16,17 +16,17 @@
 
 - After reading this user-level `AGENTS.md`, say: `🤖 I read the user-level AGENTS.md.`
 
-### Worklog Subagent
+### Worklog のサブエージェント
 
-- Worklog management is handled by the custom subagent `worklog_manager`, exposed through `~/.codex/agents`.
-- For every non-trivial task, spawn `worklog_manager` once near the start of the session and reuse the same thread for the rest of the task.
-- Pass the task summary, the initial user prompt, and a `parent_owner` value such as `codex-foo`.
-- Delegate all reads and writes under `.agents/worklog/codex/**` to `worklog_manager`.
-- Do not update `.agents/worklog/codex/**` directly from the main Codex agent.
-- Use the learn summary returned by `worklog_manager` before continuing the main task.
-- If `worklog_manager` cannot read the required learn files or cannot update the worklog after it starts, fail hard and report the problem instead of falling back to direct edits.
+- worklog の管理は custom subagent `worklog_manager` が担当します。`~/.codex/agents` 経由で利用できます。
+- 実装、調査、レビューなど、軽微ではないタスクでは、セッションの早い段階で `worklog_manager` を 1 回だけ spawn し、その後は同じスレッドを使い続けてください。
+- 起動時には、タスクの要約、最初のユーザープロンプト、`codex-foo` のような `parent_owner` を渡してください。
+- `.agents/worklog/codex/**` 配下の読み書きは、すべて `worklog_manager` に委譲してください。
+- main Codex agent から `.agents/worklog/codex/**` を直接更新しないでください。
+- 本体の作業を進める前に、`worklog_manager` が返す learn の要約を確認してください。
+- `worklog_manager` が必要な learn を読めない、または起動後に worklog を更新できない場合は、直接編集へフォールバックせず、その時点で失敗として扱って報告してください。
 
 ### セッション終了時のまとめ
 
-- 会話の自然な区切りで、直ちに次のアクションが想定されない場合は、`worklog_manager` から summary 案を受け取り、以下の形式で 1 行のまとめを出力してください。
+- 会話の自然な区切りで、直ちに次のアクションが想定されない場合は、`worklog_manager` から要約案を受け取り、以下の形式で 1 行のまとめを出力してください。
 - `📝 まとめ: <このセッションで完了した内容を 1〜2 文で要約してください。未完了のタスクや次のアクションがあれば末尾に追記してください。>`

--- a/home/dot_config/codex/README.md
+++ b/home/dot_config/codex/README.md
@@ -1,4 +1,5 @@
 - This directory is the canonical source for Codex-specific guidance.
 - [AGENTS.md](AGENTS.md) is exposed as `~/.codex/AGENTS.md` through [home/dot_codex/](../../dot_codex/).
+- [agents/](agents/) is exposed as `~/.codex/agents` through [home/dot_codex/](../../dot_codex/).
 - The design keeps edits in one git-friendly place while preserving the familiar home path.
 - Edit files here; the adapter keeps the home path stable.

--- a/home/dot_config/codex/agents/worklog-manager.toml
+++ b/home/dot_config/codex/agents/worklog-manager.toml
@@ -1,0 +1,55 @@
+name = "worklog_manager"
+description = "Worklog-only agent that manages Codex session plan, todo, and learn files under .agents/worklog/codex."
+sandbox_mode = "workspace-write"
+developer_instructions = """
+You are the dedicated worklog manager for Codex sessions in this repository.
+
+Scope:
+- Only read or edit files under `.agents/worklog/codex/**`.
+- Never edit repository files outside `.agents/worklog/codex/**`.
+- Do not make product/code changes. Your job is worklog management only.
+
+Bootstrap:
+- The parent agent should start you once per non-trivial task and reuse the same thread.
+- Expect the first parent message to include a task summary, the initial user prompt, and `parent_owner`.
+- Derive your owner as `<parent_owner>-worklog`.
+- Ask the parent agent for missing context if the bootstrap payload is incomplete.
+
+Startup workflow:
+1. Ensure `.agents/worklog/codex/plan/`, `todo/`, and `learn/` exist.
+2. Read `.agents/worklog/codex/learn/learn_index.md`.
+3. Read the specific learn files that are relevant to the task.
+4. Reply to the parent with a short summary of the relevant learnings and the owner you will use before you continue with routine updates.
+
+Plan and todo rules:
+- Maintain the session worklog continuously while the parent agent works.
+- Use YAML frontmatter on every plan, todo, and learn file.
+- Required common keys: `type`, `id`, `owner`, `created_at`, `updated_at`.
+- Required `plan` key: `status`.
+- Required `todo` keys: `status`, `workstream`, `related_plan`.
+- Required `learn` keys: `validated`, `apply_to`.
+- Use these headings for plan files: `User Prompt`, `Goal`, `Scope`, `Assumptions`, `Design`, `Tests`, `Open Questions`.
+- Use these headings for todo files: `TODO`, `Done`.
+- Use these headings for learn files: `Date`, `Learnings`, `Plan Updates`.
+- Reuse one session id across the session's plan and todo files.
+- Record the first user prompt in the plan `User Prompt` section and append later requirement changes chronologically.
+- Keep `todo.status` within `active | blocked | done | superseded`.
+- Keep `plan.status` within `draft | active | done | superseded`.
+
+Todo completion:
+- Move completed tasks from `# TODO` to `# Done`.
+- When `# TODO` becomes empty, set `todo.status: done`, update `updated_at`, and rename the file from `*_todo.md` to `*_done.md`.
+- When the task is fully complete, also set the session plan status to `done`.
+
+Learn rules:
+- Create or update a learn file only when the information is reusable and validated.
+- Each learn file must state what was learned and where it should be applied.
+- When learn files change, update `.agents/worklog/codex/learn/learn_index.md`.
+- Each index entry must be one line in this format:
+  `- [タイトル](ファイル名) — 要約（150 文字以内）`
+- When learn changes affect the active plan, update the plan `Assumptions`, `Design`, or `Tests` accordingly.
+
+Output to parent:
+- Keep responses concise.
+- When the parent asks for a close-out summary, return a one-line candidate that starts with `📝 まとめ:`.
+"""

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -3,6 +3,8 @@
 readonly SHARED_AGENTS_PATH="./home/dot_config/exact_agents/AGENTS.md"
 readonly CODEX_AGENTS_PATH="./home/dot_config/codex/AGENTS.md"
 readonly CODEX_SYMLINK_TEMPLATE="./home/dot_codex/symlink_AGENTS.md.tmpl"
+readonly CODEX_AGENT_DIR_SYMLINK_TEMPLATE="./home/dot_codex/symlink_agents.tmpl"
+readonly CODEX_WORKLOG_AGENT_PATH="./home/dot_config/codex/agents/worklog-manager.toml"
 readonly AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS.md.tmpl"
 readonly CLAUDE_MD_PATH="./home/dot_config/claude/CLAUDE.md"
 readonly CLAUDE_SYMLINK_TEMPLATE="./home/dot_claude/symlink_CLAUDE.md.tmpl"
@@ -36,8 +38,25 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
 @test "[common] agent guidance adapters point to the canonical files" {
     [ "$(< "${AGENTS_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/AGENTS.md" ]
     [ "$(< "${CODEX_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/codex/AGENTS.md" ]
+    [ "$(< "${CODEX_AGENT_DIR_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/codex/agents" ]
     [ "$(< "${CLAUDE_MD_PATH}")" = "@~/.agents/AGENTS.md" ]
     [ "$(< "${CLAUDE_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/claude/CLAUDE.md" ]
+}
+
+@test "[common] codex worklog is delegated to the custom subagent" {
+    [ -f "${CODEX_WORKLOG_AGENT_PATH}" ]
+
+    run grep -F 'name = "worklog_manager"' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'sandbox_mode = "workspace-write"' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F "worklog_manager" "${CODEX_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '$(date +%Y%m%d_%H%M%S)_plan.md' "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
+    run grep -F "#### plan/todo/learn の frontmatter ルール" "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
 }
 
 @test "[common] layout readmes describe the adapter and canonical layout" {
@@ -66,6 +85,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F "../dot_config/codex/AGENTS.md" "${CODEX_README_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F "~/.codex/agents" "${CODEX_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F "../dot_config/codex/agents/" "${CODEX_README_PATH}"
+    [ "${status}" -eq 0 ]
     run grep -F "Edit the canonical source, not this adapter directory." "${CODEX_README_PATH}"
     [ "${status}" -eq 0 ]
 
@@ -86,6 +109,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     run grep -F "~/.codex/AGENTS.md" "${CANONICAL_CODEX_README_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F "(AGENTS.md)" "${CANONICAL_CODEX_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F "~/.codex/agents" "${CANONICAL_CODEX_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F "(agents/)" "${CANONICAL_CODEX_README_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F "../../dot_codex/" "${CANONICAL_CODEX_README_PATH}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Summary
- add a Codex `worklog_manager` custom agent and expose it through `~/.codex/agents`
- replace the detailed Codex worklog rules in `home/dot_config/codex/AGENTS.md` with Japanese subagent bootstrap and fail-hard delegation rules
- update Codex README files and install coverage in `tests/install/common/agents_guidance.bats`

## Verification
- parsed `home/dot_config/codex/agents/worklog-manager.toml` with `python3` `tomllib`
- confirmed the old detailed worklog rule block is no longer present in `home/dot_config/codex/AGENTS.md`
- reviewed `chezmoi diff --force` output for `.codex/AGENTS.md` and `.codex/agents`
