### PR TITLE
docs: add worktree-first editing policy guidance

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -10,15 +10,15 @@
 - 最終成果物でも例外処理は入れなくて構いません。
 - 研究開発用途が主なため後方互換性は気にしないでください。あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
 
-### Worktree Policy
+### Worktree の方針
 
-- When the current checkout is `main` or the repository default branch, treat it as read-only for repo-tracked files.
-- Before any task that may modify repo-tracked files, inspect the current branch/worktree first.
-- If you are on `main` or the default branch, create or move to a fresh task-specific `git worktree` before editing, even when the worktree is clean.
-- Read-only investigation may stay in the current checkout.
-- Reuse the current checkout for mutating work only when the user explicitly asks you to work there, or when you are already in a dedicated non-default task worktree for this task.
-- If unrelated local changes exist, never mix them into the task. Use a separate worktree and carry only task-relevant files.
-- This rule overrides weaker defaults that only require a separate worktree when the current checkout is dirty.
+- 現在の checkout が `main` またはリポジトリの default branch である場合、リポジトリ管理下のファイルに対しては読み取り専用として扱ってください。
+- リポジトリ管理下のファイルを変更する可能性があるタスクに入る前に、現在の branch / worktree を最初に確認してください。
+- `main` または default branch にいる場合は、worktree が clean でも、編集前に task-specific な新しい `git worktree` を作成するか、そこへ移動してください。
+- 読み取り専用の調査は、現在の checkout のままで構いません。
+- 現在の checkout を変更系の作業で再利用してよいのは、ユーザが明示的にそこで作業するよう求めた場合、またはこのタスク専用の non-default branch worktree にすでにいる場合だけです。
+- 関係のないローカル変更がある場合は、そのタスクに混ぜないでください。別の worktree を使い、task-relevant files だけを持ち込んでください。
+- このルールは、現在の checkout が dirty な場合にだけ別 worktree を要求する、より弱いデフォルトより優先されます。
 
 ## サブエージェントの進捗可視化
 

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -10,6 +10,16 @@
 - 最終成果物でも例外処理は入れなくて構いません。
 - 研究開発用途が主なため後方互換性は気にしないでください。あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
 
+### Worktree Policy
+
+- When the current checkout is `main` or the repository default branch, treat it as read-only for repo-tracked files.
+- Before any task that may modify repo-tracked files, inspect the current branch/worktree first.
+- If you are on `main` or the default branch, create or move to a fresh task-specific `git worktree` before editing, even when the worktree is clean.
+- Read-only investigation may stay in the current checkout.
+- Reuse the current checkout for mutating work only when the user explicitly asks you to work there, or when you are already in a dedicated non-default task worktree for this task.
+- If unrelated local changes exist, never mix them into the task. Use a separate worktree and carry only task-relevant files.
+- This rule overrides weaker defaults that only require a separate worktree when the current checkout is dirty.
+
 ## サブエージェントの進捗可視化
 
 - subagent を spawn した直後に、親 agent は「何を委譲したか」と「最初に何を確認させるか」をユーザへ短く伝えてください。

--- a/home/dot_config/codex/agents/gh-workflow-manager.toml
+++ b/home/dot_config/codex/agents/gh-workflow-manager.toml
@@ -23,16 +23,18 @@ Repository/worktree health gate:
 2. If the directory may be a linked worktree, inspect `.git`.
 3. If `.git` contains `gitdir: <path>` and that path does not exist, stop and report an orphaned worktree.
 4. In multi-repo, nested-repo, or multi-worktree situations, pin every `gh` and `git` command to the intended repository/worktree.
-5. If branch/commit/PR work would mix with unrelated local changes, create a fresh task-specific `git worktree` from the default branch instead of reusing the dirty worktree.
+5. If the current checkout is `main` or the repository default branch, treat it as read-only for repo-tracked files and create a fresh task-specific `git worktree` from the default branch before any branch/commit/push work, even when the worktree is clean.
+6. If branch/commit/PR work would mix with unrelated local changes, create a fresh task-specific `git worktree` from the default branch instead of reusing the dirty worktree.
 
 Workflow:
 - Start issue and pull request investigation with `gh`, not `web`.
 - Use `web` only when `gh` cannot provide required information. When that happens, report what was missing from `gh`.
 - Collect the URL of each investigated issue/PR and include it in your report to the parent agent.
-- When the task includes branch/commit/PR work from a dirty source worktree:
+- When the task includes branch/commit/PR work from the default branch checkout or from a dirty source worktree:
   - inspect the source worktree state
+  - treat the default branch checkout as read-only for repo-tracked files
   - create a fresh task worktree from the default branch
-  - copy only `task_relevant_files` from the source worktree into the fresh worktree
+  - if task-relevant changes already exist outside the fresh worktree, copy only `task_relevant_files` from the source worktree into the fresh worktree
   - avoid any other file changes
 - Use Conventional Commit format for commit messages: `<type>(<scope>): <summary>`.
 - Pull request titles and descriptions must be English.

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -10,15 +10,15 @@
 - 最終成果物でも例外処理は入れなくて構いません。
 - 研究開発用途が主なため後方互換性は気にしないでください。あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
 
-### Worktree Policy
+### Worktree の方針
 
-- When the current checkout is `main` or the repository default branch, treat it as read-only for repo-tracked files.
-- Before any task that may modify repo-tracked files, inspect the current branch/worktree first.
-- If you are on `main` or the default branch, create or move to a fresh task-specific `git worktree` before editing, even when the worktree is clean.
-- Read-only investigation may stay in the current checkout.
-- Reuse the current checkout for mutating work only when the user explicitly asks you to work there, or when you are already in a dedicated non-default task worktree for this task.
-- If unrelated local changes exist, never mix them into the task. Use a separate worktree and carry only task-relevant files.
-- This rule overrides weaker defaults that only require a separate worktree when the current checkout is dirty.
+- 現在の checkout が `main` またはリポジトリの default branch である場合、リポジトリ管理下のファイルに対しては読み取り専用として扱ってください。
+- リポジトリ管理下のファイルを変更する可能性があるタスクに入る前に、現在の branch / worktree を最初に確認してください。
+- `main` または default branch にいる場合は、worktree が clean でも、編集前に task-specific な新しい `git worktree` を作成するか、そこへ移動してください。
+- 読み取り専用の調査は、現在の checkout のままで構いません。
+- 現在の checkout を変更系の作業で再利用してよいのは、ユーザが明示的にそこで作業するよう求めた場合、またはこのタスク専用の non-default branch worktree にすでにいる場合だけです。
+- 関係のないローカル変更がある場合は、そのタスクに混ぜないでください。別の worktree を使い、task-relevant files だけを持ち込んでください。
+- このルールは、現在の checkout が dirty な場合にだけ別 worktree を要求する、より弱いデフォルトより優先されます。
 
 ## サブエージェントの進捗可視化
 

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -10,6 +10,16 @@
 - 最終成果物でも例外処理は入れなくて構いません。
 - 研究開発用途が主なため後方互換性は気にしないでください。あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
 
+### Worktree Policy
+
+- When the current checkout is `main` or the repository default branch, treat it as read-only for repo-tracked files.
+- Before any task that may modify repo-tracked files, inspect the current branch/worktree first.
+- If you are on `main` or the default branch, create or move to a fresh task-specific `git worktree` before editing, even when the worktree is clean.
+- Read-only investigation may stay in the current checkout.
+- Reuse the current checkout for mutating work only when the user explicitly asks you to work there, or when you are already in a dedicated non-default task worktree for this task.
+- If unrelated local changes exist, never mix them into the task. Use a separate worktree and carry only task-relevant files.
+- This rule overrides weaker defaults that only require a separate worktree when the current checkout is dirty.
+
 ## サブエージェントの進捗可視化
 
 - subagent を spawn した直後に、親 agent は「何を委譲したか」と「最初に何を確認させるか」をユーザへ短く伝えてください。


### PR DESCRIPTION
## Summary
- add a worktree-first editing policy to the Codex and exact agents instructions
- translate the Worktree Policy section in the Codex and exact agents instructions into Japanese while preserving the original meaning
- require the GitHub workflow manager to treat the default branch checkout as read-only for repo-tracked files and clarify when task-relevant files should be copied into a fresh task worktree

## Testing
- not run locally (documentation-only change)
- GitHub Actions re-run after the latest push