### PR TITLE
fix(tmux): commonize allow-passthrough setting

### DIFF
--- a/home/dot_tmux.conf.d/common.conf
+++ b/home/dot_tmux.conf.d/common.conf
@@ -36,3 +36,7 @@ set-option -g default-terminal screen-256color
 set-option -s set-clipboard on
 set-option -gu terminal-features
 set-option -as terminal-features ',screen-256color:clipboard'
+
+# Enable passthrough on tmux 3.3+.
+# Older tmux versions treat this as an unknown option, so keep it quiet with -q.
+set-option -gq allow-passthrough on

--- a/home/dot_tmux.conf.d/os/macos.conf
+++ b/home/dot_tmux.conf.d/os/macos.conf
@@ -1,2 +1,0 @@
-# for performing sudo with Touch ID
-set-option -g allow-passthrough on


### PR DESCRIPTION
## Summary
- move `allow-passthrough` from the macOS-specific tmux config into the common tmux config
- use `set-option -gq` so older tmux versions ignore the option quietly
- keep the macOS tmux config focused on macOS-only settings

## Testing
- not run locally; rely on GitHub Actions checks
