### PR TITLE
feat(worklog): hard-gate stale learn startup

### DIFF
--- a/home/dot_config/codex/agents/worklog-manager.toml
+++ b/home/dot_config/codex/agents/worklog-manager.toml
@@ -17,9 +17,9 @@ Bootstrap:
 
 Startup workflow:
 1. Ensure `.agents/worklog/codex/plan/`, `todo/`, and `learn/` exist.
-2. Read `.agents/worklog/codex/learn/learn_index.md`.
-3. Read the specific learn files that are relevant to the task.
-4. Reply to the parent with a short summary of the relevant learnings and the owner you will use before you continue with routine updates.
+2. Read `.agents/worklog/codex/learn/learn_index.md` and treat only the `## Active` section as the startup source of truth.
+3. Read only the specific active learn files that are relevant to the task. `## Needs Review` may be consulted as reference but never as validated fact during startup. Do not read `## Superseded` or `## Archived` unless the parent explicitly asks for historical context.
+4. Reply to the parent with exactly three short sections in this order: `Active learnings`, `Needs revalidation`, `Ignored historical entries`. When an active learn has `freshness: drift_prone`, include it under `Active learnings` but state that the parent must revalidate it before relying on it. Also include the owner you will use before you continue with routine updates.
 
 Plan and todo rules:
 - Maintain the session worklog continuously while the parent agent works.
@@ -27,7 +27,7 @@ Plan and todo rules:
 - Required common keys: `type`, `id`, `owner`, `created_at`, `updated_at`.
 - Required `plan` key: `status`.
 - Required `todo` keys: `status`, `workstream`, `related_plan`.
-- Required `learn` keys: `validated`, `apply_to`.
+- Required `learn` keys: `validated`, `apply_to`, `status`, `freshness`, `last_validated_at`.
 - Use these headings for plan files: `User Prompt`, `Goal`, `Scope`, `Assumptions`, `Design`, `Tests`, `Open Questions`.
 - Use these headings for todo files: `TODO`, `Done`.
 - Use these headings for learn files: `Date`, `Learnings`, `Plan Updates`.
@@ -35,6 +35,12 @@ Plan and todo rules:
 - Record the first user prompt in the plan `User Prompt` section and append later requirement changes chronologically.
 - Keep `todo.status` within `active | blocked | done | superseded`.
 - Keep `plan.status` within `draft | active | done | superseded`.
+- Keep `learn.status` within `active | needs_review | superseded | archived`.
+- Keep `learn.freshness` within `stable | drift_prone`.
+- Use ISO `YYYY-MM-DD` strings for `last_validated_at` and `review_after`.
+- `freshness: drift_prone` requires `review_after`.
+- `status: superseded` requires `superseded_by`.
+- Replacement learn files should record the prior file in `supersedes`.
 
 Todo completion:
 - Move completed tasks from `# TODO` to `# Done`.
@@ -43,10 +49,16 @@ Todo completion:
 
 Learn rules:
 - Create or update a learn file only when the information is reusable and validated.
+- Do not promote session-limited facts, current branch/path/default branch, or state that can be rechecked immediately into learn files.
+- If a drift-prone repository fact must be stored, mark it `freshness: drift_prone` and set a concrete `review_after`.
 - Each learn file must state what was learned and where it should be applied.
 - When learn files change, update `.agents/worklog/codex/learn/learn_index.md`.
+- Keep the learn index in four sections: `## Active`, `## Needs Review`, `## Superseded`, `## Archived`.
 - Each index entry must be one line in this format:
-  `- [タイトル](ファイル名) — 要約（150 文字以内）`
+  `- [タイトル](ファイル名) [stable|drift_prone] — 要約（150 文字以内）`
+- `## Active` entries are startup-eligible only when their metadata is complete and current.
+- `## Needs Review` entries are reference candidates, not facts.
+- `## Superseded` and `## Archived` entries are historical and should stay out of startup unless the parent asks for history.
 - When learn changes affect the active plan, update the plan `Assumptions`, `Design`, or `Tests` accordingly.
 
 Output to parent:

--- a/home/dot_local/bin/exact_common/executable_codex-worklog-audit
+++ b/home/dot_local/bin/exact_common/executable_codex-worklog-audit
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+
+# @file home/dot_local/bin/exact_common/executable_codex-worklog-audit
+# @brief Audit Codex worklog learn metadata and index consistency.
+# @description
+#   Reads the learn index plus learn frontmatter under the configured worklog
+#   learn root, reports status counts and review deadlines, and fails `check`
+#   when startup-hard-gating would be unreliable.
+
+set -uo pipefail
+
+readonly TODAY="$(date +%F)"
+
+# @description Trim leading and trailing whitespace from a scalar value.
+# @arg $1 string Raw scalar value.
+function trim_scalar() {
+    local raw_value="${1:-}"
+
+    printf "%s\n" "${raw_value}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+# @description Resolve the learn root, honoring `CODEX_WORKLOG_LEARN_ROOT`.
+function resolve_learn_root() {
+    local source_path
+
+    if [ -n "${CODEX_WORKLOG_LEARN_ROOT:-}" ]; then
+        printf "%s\n" "${CODEX_WORKLOG_LEARN_ROOT}"
+        return 0
+    fi
+
+    if ! command -v chezmoi > /dev/null 2>&1; then
+        printf "chezmoi is required unless CODEX_WORKLOG_LEARN_ROOT is set\n" >&2
+        return 1
+    fi
+
+    source_path="$(chezmoi source-path)" || return 1
+    printf "%s/.agents/worklog/codex/learn\n" "${source_path}"
+}
+
+# @description Extract one scalar frontmatter value from a learn file.
+# @arg $1 path Learn file path.
+# @arg $2 string Frontmatter key.
+function frontmatter_value() {
+    local file_path="$1"
+    local key="$2"
+
+    awk -v key="${key}" '
+        BEGIN {
+            in_frontmatter = 0
+            seen_delimiter = 0
+        }
+
+        /^---[[:space:]]*$/ {
+            if (seen_delimiter == 0) {
+                in_frontmatter = 1
+                seen_delimiter = 1
+                next
+            }
+
+            if (in_frontmatter) {
+                exit
+            }
+        }
+
+        in_frontmatter && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+            sub("^[[:space:]]*" key ":[[:space:]]*", "", $0)
+            print $0
+            exit
+        }
+    ' "${file_path}"
+}
+
+# @description Convert a markdown section heading into a normalized status token.
+# @arg $1 string Markdown heading text without the `## ` prefix.
+function normalize_section() {
+    local heading="$1"
+
+    case "${heading}" in
+    Active)
+        printf "active\n"
+        ;;
+    "Needs Review")
+        printf "needs_review\n"
+        ;;
+    Superseded)
+        printf "superseded\n"
+        ;;
+    Archived)
+        printf "archived\n"
+        ;;
+    *)
+        printf "\n"
+        ;;
+    esac
+}
+
+# @description Parse `learn_index.md` into a TSV of section, filename, marker, and title.
+# @arg $1 path Learn root directory.
+# @arg $2 path Output TSV file.
+function collect_index_entries() {
+    local learn_root="$1"
+    local output_path="$2"
+    local index_path="${learn_root}/learn_index.md"
+    local section=""
+    local line
+    local filename
+    local marker
+    local title
+
+    : > "${output_path}"
+
+    while IFS= read -r line; do
+        case "${line}" in
+        "## "*)
+            section="$(normalize_section "${line#\#\# }")"
+            ;;
+        "- ["*)
+            if [ -z "${section}" ]; then
+                continue
+            fi
+
+            filename="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[(stable|drift_prone)\][[:space:]]+\[[^]]+\]\(([^)]+)\).*$/\2/p')"
+
+            if [ -z "${filename}" ]; then
+                filename="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[[^]]+\]\(([^)]+)\).*$/\1/p')"
+            fi
+            marker="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[(stable|drift_prone)\][[:space:]]+\[[^]]+\]\([^)]+\).*/\1/p')"
+
+            if [ -z "${marker}" ]; then
+                marker="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[[^]]+\]\([^)]+\)[[:space:]]+\[(stable|drift_prone)\].*/\1/p')"
+            fi
+
+            title="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[(stable|drift_prone)\][[:space:]]+\[([^]]+)\]\([^)]+\).*$/\2/p')"
+
+            if [ -z "${title}" ]; then
+                title="$(printf "%s\n" "${line}" | sed -nE 's/^-[[:space:]]+\[([^]]+)\]\([^)]+\)([[:space:]]+\[(stable|drift_prone)\])?.*$/\1/p')"
+            fi
+
+            printf "%s\t%s\t%s\t%s\n" "${section}" "${filename}" "${marker}" "${title}" >> "${output_path}"
+            ;;
+        esac
+    done < "${index_path}"
+}
+
+# @description Parse learn frontmatter into a TSV keyed by filename.
+# @arg $1 path Learn root directory.
+# @arg $2 path Output TSV file.
+function collect_learn_files() {
+    local learn_root="$1"
+    local output_path="$2"
+    local file_path
+    local filename
+    local status
+    local freshness
+    local last_validated_at
+    local review_after
+    local superseded_by
+    local supersedes
+
+    : > "${output_path}"
+
+    while IFS= read -r file_path; do
+        filename="${file_path##*/}"
+        status="$(trim_scalar "$(frontmatter_value "${file_path}" status)")"
+        freshness="$(trim_scalar "$(frontmatter_value "${file_path}" freshness)")"
+        last_validated_at="$(trim_scalar "$(frontmatter_value "${file_path}" last_validated_at)")"
+        review_after="$(trim_scalar "$(frontmatter_value "${file_path}" review_after)")"
+        superseded_by="$(trim_scalar "$(frontmatter_value "${file_path}" superseded_by)")"
+        supersedes="$(trim_scalar "$(frontmatter_value "${file_path}" supersedes)")"
+
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+            "${filename}" \
+            "${status}" \
+            "${freshness}" \
+            "${last_validated_at}" \
+            "${review_after}" \
+            "${superseded_by}" \
+            "${supersedes}" >> "${output_path}"
+    done < <(find "${learn_root}" -maxdepth 1 -type f -name '*_learn.md' | sort)
+}
+
+# @description Look up one column from a TSV keyed by the first field.
+# @arg $1 path TSV file path.
+# @arg $2 string Key value for the first field.
+# @arg $3 integer One-based column index to return.
+function lookup_tsv_value() {
+    local tsv_path="$1"
+    local key="$2"
+    local column="$3"
+
+    awk -F '\t' -v key="${key}" -v column="${column}" '
+        $1 == key {
+            print $column
+            exit
+        }
+    ' "${tsv_path}"
+}
+
+# @description Check whether a TSV keyed by the first field contains the given key.
+# @arg $1 path TSV file path.
+# @arg $2 string Key value for the first field.
+function tsv_has_key() {
+    local tsv_path="$1"
+    local key="$2"
+
+    awk -F '\t' -v key="${key}" '
+        $1 == key {
+            found = 1
+            exit
+        }
+
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "${tsv_path}"
+}
+
+# @description Join index data with file metadata for downstream checks.
+# @arg $1 path Index TSV path.
+# @arg $2 path File metadata TSV path.
+# @arg $3 path Output TSV path.
+function build_joined_view() {
+    local index_tsv="$1"
+    local files_tsv="$2"
+    local output_path="$3"
+    local section
+    local filename
+    local marker
+    local title
+    local file_present
+    local status
+    local freshness
+    local last_validated_at
+    local review_after
+    local superseded_by
+    local supersedes
+
+    : > "${output_path}"
+
+    while IFS=$'\t' read -r section filename marker title; do
+        file_present="no"
+        status=""
+        freshness=""
+        last_validated_at=""
+        review_after=""
+        superseded_by=""
+        supersedes=""
+
+        if tsv_has_key "${files_tsv}" "${filename}"; then
+            file_present="yes"
+            status="$(lookup_tsv_value "${files_tsv}" "${filename}" 2)"
+            freshness="$(lookup_tsv_value "${files_tsv}" "${filename}" 3)"
+            last_validated_at="$(lookup_tsv_value "${files_tsv}" "${filename}" 4)"
+            review_after="$(lookup_tsv_value "${files_tsv}" "${filename}" 5)"
+            superseded_by="$(lookup_tsv_value "${files_tsv}" "${filename}" 6)"
+            supersedes="$(lookup_tsv_value "${files_tsv}" "${filename}" 7)"
+        fi
+
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+            "${section}" \
+            "${filename}" \
+            "${marker}" \
+            "${status}" \
+            "${freshness}" \
+            "${last_validated_at}" \
+            "${review_after}" \
+            "${superseded_by}" \
+            "${supersedes}" \
+            "${file_present}" >> "${output_path}"
+    done < "${index_tsv}"
+}
+
+# @description Collect active entries that are missing required startup metadata.
+# @arg $1 path Joined TSV path.
+# @arg $2 path Output findings file.
+function collect_active_metadata_issues() {
+    local joined_tsv="$1"
+    local output_path="$2"
+
+    awk -F '\t' '
+        function append_issue(current, next_item) {
+            if (current == "") {
+                return next_item
+            }
+
+            return current ", " next_item
+        }
+
+        $1 == "active" && $10 == "yes" {
+            missing = ""
+
+            if ($4 == "") {
+                missing = append_issue(missing, "status")
+            }
+
+            if ($5 == "") {
+                missing = append_issue(missing, "freshness")
+            }
+
+            if ($6 == "") {
+                missing = append_issue(missing, "last_validated_at")
+            }
+
+            if ($5 == "drift_prone" && $7 == "") {
+                missing = append_issue(missing, "review_after")
+            }
+
+            if (missing != "") {
+                printf "- %s (%s)\n", $2, missing
+            }
+        }
+    ' "${joined_tsv}" > "${output_path}"
+}
+
+# @description Collect entries whose `review_after` date is already in the past.
+# @arg $1 path Joined TSV path.
+# @arg $2 path Output findings file.
+function collect_expired_reviews() {
+    local joined_tsv="$1"
+    local output_path="$2"
+
+    awk -F '\t' -v today="${TODAY}" '
+        $10 == "yes" && $7 != "" && $7 < today {
+            effective_status = $4
+
+            if (effective_status == "") {
+                effective_status = $1
+            }
+
+            printf "- %s (%s, review_after=%s)\n", $2, effective_status, $7
+        }
+    ' "${joined_tsv}" > "${output_path}"
+}
+
+# @description Collect broken `superseded_by` / `supersedes` relationships.
+# @arg $1 path File metadata TSV path.
+# @arg $2 path Output findings file.
+function collect_supersession_issues() {
+    local files_tsv="$1"
+    local output_path="$2"
+    local filename
+    local status
+    local freshness
+    local last_validated_at
+    local review_after
+    local superseded_by
+    local supersedes
+    local reciprocal
+
+    : > "${output_path}"
+
+    while IFS=$'\t' read -r filename status freshness last_validated_at review_after superseded_by supersedes; do
+        if [ "${status}" = "superseded" ]; then
+            if [ -z "${superseded_by}" ]; then
+                printf -- "- %s (missing superseded_by)\n" "${filename}" >> "${output_path}"
+            elif ! tsv_has_key "${files_tsv}" "${superseded_by}"; then
+                printf -- "- %s (superseded_by=%s)\n" "${filename}" "${superseded_by}" >> "${output_path}"
+            else
+                reciprocal="$(lookup_tsv_value "${files_tsv}" "${superseded_by}" 7)"
+
+                if [ "${reciprocal}" != "${filename}" ]; then
+                    printf -- "- %s (replacement %s is missing reciprocal supersedes)\n" "${filename}" "${superseded_by}" >> "${output_path}"
+                fi
+            fi
+        fi
+
+        if [ -n "${supersedes}" ] && ! tsv_has_key "${files_tsv}" "${supersedes}"; then
+            printf -- "- %s (supersedes=%s)\n" "${filename}" "${supersedes}" >> "${output_path}"
+        fi
+    done < "${files_tsv}"
+
+    sort -u -o "${output_path}" "${output_path}"
+}
+
+# @description Collect index-to-file inconsistencies.
+# @arg $1 path Index TSV path.
+# @arg $2 path File metadata TSV path.
+# @arg $3 path Joined TSV path.
+# @arg $4 path Output findings file.
+function collect_index_issues() {
+    local index_tsv="$1"
+    local files_tsv="$2"
+    local joined_tsv="$3"
+    local output_path="$4"
+    local tmp_dir
+    local indexed_files_path
+    local learn_files_path
+    local missing_on_disk_path
+    local missing_from_index_path
+
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-worklog-audit-index.XXXXXX")" || return 1
+    indexed_files_path="${tmp_dir}/indexed_files.txt"
+    learn_files_path="${tmp_dir}/learn_files.txt"
+    missing_on_disk_path="${tmp_dir}/missing_on_disk.txt"
+    missing_from_index_path="${tmp_dir}/missing_from_index.txt"
+
+    cut -f2 "${index_tsv}" | LC_ALL=C sort -u > "${indexed_files_path}"
+    cut -f1 "${files_tsv}" | LC_ALL=C sort -u > "${learn_files_path}"
+    comm -23 "${indexed_files_path}" "${learn_files_path}" > "${missing_on_disk_path}"
+    comm -13 "${indexed_files_path}" "${learn_files_path}" > "${missing_from_index_path}"
+
+    : > "${output_path}"
+
+    while IFS= read -r filename; do
+        [ -n "${filename}" ] || continue
+        printf -- "- indexed file missing on disk: %s\n" "${filename}" >> "${output_path}"
+    done < "${missing_on_disk_path}"
+
+    while IFS= read -r filename; do
+        [ -n "${filename}" ] || continue
+        printf -- "- file missing from index: %s\n" "${filename}" >> "${output_path}"
+    done < "${missing_from_index_path}"
+
+    awk -F '\t' '
+        $10 == "yes" && $4 != "" && $1 != $4 {
+            printf "- status mismatch: %s (index=%s, file=%s)\n", $2, $1, $4
+        }
+    ' "${joined_tsv}" >> "${output_path}"
+
+    rm -rf "${tmp_dir}"
+}
+
+# @description Count how many index entries belong to one status section.
+# @arg $1 path Index TSV path.
+# @arg $2 string Status token.
+function count_entries_for_status() {
+    local index_tsv="$1"
+    local status="$2"
+
+    awk -F '\t' -v status="${status}" '
+        $1 == status {
+            count += 1
+        }
+
+        END {
+            print count + 0
+        }
+    ' "${index_tsv}"
+}
+
+# @description Render a report section or `none` when it is empty.
+# @arg $1 string Heading.
+# @arg $2 path Findings file.
+function print_findings_section() {
+    local heading="$1"
+    local findings_path="$2"
+
+    printf "%s:\n" "${heading}"
+
+    if [ -s "${findings_path}" ]; then
+        cat "${findings_path}"
+    else
+        printf "none\n"
+    fi
+
+    printf "\n"
+}
+
+# @description Build the audit snapshots used by `summary` and `check`.
+# @arg $1 path Learn root directory.
+# @arg $2 path Scratch directory.
+function analyze_learn_root() {
+    local learn_root="$1"
+    local scratch_dir="$2"
+    local index_path="${learn_root}/learn_index.md"
+
+    if [ ! -d "${learn_root}" ]; then
+        printf "learn root not found: %s\n" "${learn_root}" >&2
+        return 1
+    fi
+
+    if [ ! -f "${index_path}" ]; then
+        printf "learn index not found: %s\n" "${index_path}" >&2
+        return 1
+    fi
+
+    collect_index_entries "${learn_root}" "${scratch_dir}/index.tsv"
+    collect_learn_files "${learn_root}" "${scratch_dir}/files.tsv"
+    build_joined_view "${scratch_dir}/index.tsv" "${scratch_dir}/files.tsv" "${scratch_dir}/joined.tsv"
+    collect_active_metadata_issues "${scratch_dir}/joined.tsv" "${scratch_dir}/active_metadata_issues.txt"
+    collect_expired_reviews "${scratch_dir}/joined.tsv" "${scratch_dir}/expired_reviews.txt"
+    collect_supersession_issues "${scratch_dir}/files.tsv" "${scratch_dir}/supersession_issues.txt"
+    collect_index_issues "${scratch_dir}/index.tsv" "${scratch_dir}/files.tsv" "${scratch_dir}/joined.tsv" "${scratch_dir}/index_issues.txt"
+
+    awk -F '\t' -v today="${TODAY}" '
+        $1 == "active" && $10 == "yes" && $7 != "" && $7 < today {
+            printf "- %s (review_after=%s)\n", $2, $7
+        }
+    ' "${scratch_dir}/joined.tsv" > "${scratch_dir}/active_expired_reviews.txt"
+}
+
+# @description Print the full audit summary to stdout.
+# @arg $1 path Learn root directory.
+function summary() {
+    local learn_root="$1"
+    local scratch_dir
+
+    scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-worklog-audit.XXXXXX")" || return 1
+    if ! analyze_learn_root "${learn_root}" "${scratch_dir}"; then
+        rm -rf "${scratch_dir}"
+        return 1
+    fi
+
+    printf "Status counts:\n"
+    printf -- "- active: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" active)"
+    printf -- "- needs_review: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" needs_review)"
+    printf -- "- superseded: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" superseded)"
+    printf -- "- archived: %s\n\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" archived)"
+
+    print_findings_section "Expired review_after" "${scratch_dir}/expired_reviews.txt"
+    print_findings_section "Active entries missing required metadata" "${scratch_dir}/active_metadata_issues.txt"
+    print_findings_section "Broken supersession links" "${scratch_dir}/supersession_issues.txt"
+    print_findings_section "Index mismatches" "${scratch_dir}/index_issues.txt"
+
+    rm -rf "${scratch_dir}"
+}
+
+# @description Run the audit and fail when startup-hard-gating would be unreliable.
+# @arg $1 path Learn root directory.
+function check() {
+    local learn_root="$1"
+    local scratch_dir
+    local failed=0
+
+    scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-worklog-audit.XXXXXX")" || return 1
+    if ! analyze_learn_root "${learn_root}" "${scratch_dir}"; then
+        rm -rf "${scratch_dir}"
+        return 1
+    fi
+
+    printf "Status counts:\n"
+    printf -- "- active: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" active)"
+    printf -- "- needs_review: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" needs_review)"
+    printf -- "- superseded: %s\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" superseded)"
+    printf -- "- archived: %s\n\n" "$(count_entries_for_status "${scratch_dir}/index.tsv" archived)"
+
+    print_findings_section "Expired review_after" "${scratch_dir}/expired_reviews.txt"
+    print_findings_section "Active entries missing required metadata" "${scratch_dir}/active_metadata_issues.txt"
+    print_findings_section "Broken supersession links" "${scratch_dir}/supersession_issues.txt"
+    print_findings_section "Index mismatches" "${scratch_dir}/index_issues.txt"
+
+    if [ -s "${scratch_dir}/active_expired_reviews.txt" ] || \
+        [ -s "${scratch_dir}/active_metadata_issues.txt" ] || \
+        [ -s "${scratch_dir}/supersession_issues.txt" ] || \
+        [ -s "${scratch_dir}/index_issues.txt" ]; then
+        failed=1
+    fi
+
+    if [ "${failed}" -eq 0 ]; then
+        printf "check: OK\n"
+        rm -rf "${scratch_dir}"
+        return 0
+    fi
+
+    printf "check: FAIL\n"
+    rm -rf "${scratch_dir}"
+    return 1
+}
+
+# @description Dispatch the helper subcommands.
+# @arg $1 string Either `summary` or `check`.
+function main() {
+    local command="${1:-}"
+    local learn_root
+
+    learn_root="$(resolve_learn_root)" || return 1
+
+    case "${command}" in
+    summary)
+        summary "${learn_root}"
+        ;;
+    check)
+        check "${learn_root}"
+        ;;
+    *)
+        printf "usage: %s {summary|check}\n" "${0##*/}" >&2
+        return 1
+        ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/home/dot_local/bin/exact_common/executable_codex-worklog-audit
+++ b/home/dot_local/bin/exact_common/executable_codex-worklog-audit
@@ -44,30 +44,7 @@ function frontmatter_value() {
     local file_path="$1"
     local key="$2"
 
-    awk -v key="${key}" '
-        BEGIN {
-            in_frontmatter = 0
-            seen_delimiter = 0
-        }
-
-        /^---[[:space:]]*$/ {
-            if (seen_delimiter == 0) {
-                in_frontmatter = 1
-                seen_delimiter = 1
-                next
-            }
-
-            if (in_frontmatter) {
-                exit
-            }
-        }
-
-        in_frontmatter && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
-            sub("^[[:space:]]*" key ":[[:space:]]*", "", $0)
-            print $0
-            exit
-        }
-    ' "${file_path}"
+    awk -v key="${key}" 'BEGIN{in_frontmatter=0;seen_delimiter=0} /^---[[:space:]]*$/ {if(seen_delimiter==0){in_frontmatter=1;seen_delimiter=1;next} if(in_frontmatter){exit}} in_frontmatter && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {sub("^[[:space:]]*" key ":[[:space:]]*", "", $0); print $0; exit}' "${file_path}"
 }
 
 # @description Convert a markdown section heading into a normalized status token.
@@ -188,12 +165,7 @@ function lookup_tsv_value() {
     local key="$2"
     local column="$3"
 
-    awk -F '\t' -v key="${key}" -v column="${column}" '
-        $1 == key {
-            print $column
-            exit
-        }
-    ' "${tsv_path}"
+    awk -F '\t' -v key="${key}" -v column="${column}" '$1 == key {print $column; exit}' "${tsv_path}"
 }
 
 # @description Check whether a TSV keyed by the first field contains the given key.
@@ -203,16 +175,7 @@ function tsv_has_key() {
     local tsv_path="$1"
     local key="$2"
 
-    awk -F '\t' -v key="${key}" '
-        $1 == key {
-            found = 1
-            exit
-        }
-
-        END {
-            exit(found ? 0 : 1)
-        }
-    ' "${tsv_path}"
+    awk -F '\t' -v key="${key}" '$1 == key {found = 1; exit} END {exit(found ? 0 : 1)}' "${tsv_path}"
 }
 
 # @description Join index data with file metadata for downstream checks.
@@ -277,39 +240,7 @@ function collect_active_metadata_issues() {
     local joined_tsv="$1"
     local output_path="$2"
 
-    awk -F '\t' '
-        function append_issue(current, next_item) {
-            if (current == "") {
-                return next_item
-            }
-
-            return current ", " next_item
-        }
-
-        $1 == "active" && $10 == "yes" {
-            missing = ""
-
-            if ($4 == "") {
-                missing = append_issue(missing, "status")
-            }
-
-            if ($5 == "") {
-                missing = append_issue(missing, "freshness")
-            }
-
-            if ($6 == "") {
-                missing = append_issue(missing, "last_validated_at")
-            }
-
-            if ($5 == "drift_prone" && $7 == "") {
-                missing = append_issue(missing, "review_after")
-            }
-
-            if (missing != "") {
-                printf "- %s (%s)\n", $2, missing
-            }
-        }
-    ' "${joined_tsv}" > "${output_path}"
+    awk -F '\t' 'function append_issue(current, next_item) {return current == "" ? next_item : current ", " next_item} $1 == "active" && $10 == "yes" {missing = ""; if ($4 == "") {missing = append_issue(missing, "status")} if ($5 == "") {missing = append_issue(missing, "freshness")} if ($6 == "") {missing = append_issue(missing, "last_validated_at")} if ($5 == "drift_prone" && $7 == "") {missing = append_issue(missing, "review_after")} if (missing != "") {printf "- %s (%s)\n", $2, missing}}' "${joined_tsv}" > "${output_path}"
 }
 
 # @description Collect entries whose `review_after` date is already in the past.
@@ -319,17 +250,7 @@ function collect_expired_reviews() {
     local joined_tsv="$1"
     local output_path="$2"
 
-    awk -F '\t' -v today="${TODAY}" '
-        $10 == "yes" && $7 != "" && $7 < today {
-            effective_status = $4
-
-            if (effective_status == "") {
-                effective_status = $1
-            }
-
-            printf "- %s (%s, review_after=%s)\n", $2, effective_status, $7
-        }
-    ' "${joined_tsv}" > "${output_path}"
+    awk -F '\t' -v today="${TODAY}" '$10 == "yes" && $7 != "" && $7 < today {effective_status = $4; if (effective_status == "") {effective_status = $1} printf "- %s (%s, review_after=%s)\n", $2, effective_status, $7}' "${joined_tsv}" > "${output_path}"
 }
 
 # @description Collect broken `superseded_by` / `supersedes` relationships.
@@ -338,6 +259,7 @@ function collect_expired_reviews() {
 function collect_supersession_issues() {
     local files_tsv="$1"
     local output_path="$2"
+    local line
     local filename
     local status
     local freshness
@@ -349,7 +271,15 @@ function collect_supersession_issues() {
 
     : > "${output_path}"
 
-    while IFS=$'\t' read -r filename status freshness last_validated_at review_after superseded_by supersedes; do
+    while IFS= read -r line; do
+        filename="$(printf "%s\n" "${line}" | cut -f1)"
+        status="$(printf "%s\n" "${line}" | cut -f2)"
+        freshness="$(printf "%s\n" "${line}" | cut -f3)"
+        last_validated_at="$(printf "%s\n" "${line}" | cut -f4)"
+        review_after="$(printf "%s\n" "${line}" | cut -f5)"
+        superseded_by="$(printf "%s\n" "${line}" | cut -f6)"
+        supersedes="$(printf "%s\n" "${line}" | cut -f7)"
+
         if [ "${status}" = "superseded" ]; then
             if [ -z "${superseded_by}" ]; then
                 printf -- "- %s (missing superseded_by)\n" "${filename}" >> "${output_path}"
@@ -411,11 +341,7 @@ function collect_index_issues() {
         printf -- "- file missing from index: %s\n" "${filename}" >> "${output_path}"
     done < "${missing_from_index_path}"
 
-    awk -F '\t' '
-        $10 == "yes" && $4 != "" && $1 != $4 {
-            printf "- status mismatch: %s (index=%s, file=%s)\n", $2, $1, $4
-        }
-    ' "${joined_tsv}" >> "${output_path}"
+    awk -F '\t' '$10 == "yes" && $4 != "" && $1 != $4 {printf "- status mismatch: %s (index=%s, file=%s)\n", $2, $1, $4}' "${joined_tsv}" >> "${output_path}"
 
     rm -rf "${tmp_dir}"
 }
@@ -427,15 +353,7 @@ function count_entries_for_status() {
     local index_tsv="$1"
     local status="$2"
 
-    awk -F '\t' -v status="${status}" '
-        $1 == status {
-            count += 1
-        }
-
-        END {
-            print count + 0
-        }
-    ' "${index_tsv}"
+    awk -F '\t' -v status="${status}" '$1 == status {count += 1} END {print count + 0}' "${index_tsv}"
 }
 
 # @description Render a report section or `none` when it is empty.
@@ -482,11 +400,7 @@ function analyze_learn_root() {
     collect_supersession_issues "${scratch_dir}/files.tsv" "${scratch_dir}/supersession_issues.txt"
     collect_index_issues "${scratch_dir}/index.tsv" "${scratch_dir}/files.tsv" "${scratch_dir}/joined.tsv" "${scratch_dir}/index_issues.txt"
 
-    awk -F '\t' -v today="${TODAY}" '
-        $1 == "active" && $10 == "yes" && $7 != "" && $7 < today {
-            printf "- %s (review_after=%s)\n", $2, $7
-        }
-    ' "${scratch_dir}/joined.tsv" > "${scratch_dir}/active_expired_reviews.txt"
+    awk -F '\t' -v today="${TODAY}" '$1 == "active" && $10 == "yes" && $7 != "" && $7 < today {printf "- %s (review_after=%s)\n", $2, $7}' "${scratch_dir}/joined.tsv" > "${scratch_dir}/active_expired_reviews.txt"
 }
 
 # @description Print the full audit summary to stdout.

--- a/home/dot_local/bin/exact_common/executable_codex-worklog-audit
+++ b/home/dot_local/bin/exact_common/executable_codex-worklog-audit
@@ -539,9 +539,9 @@ function check() {
     print_findings_section "Broken supersession links" "${scratch_dir}/supersession_issues.txt"
     print_findings_section "Index mismatches" "${scratch_dir}/index_issues.txt"
 
-    if [ -s "${scratch_dir}/active_expired_reviews.txt" ] || \
-        [ -s "${scratch_dir}/active_metadata_issues.txt" ] || \
-        [ -s "${scratch_dir}/supersession_issues.txt" ] || \
+    if [ -s "${scratch_dir}/active_expired_reviews.txt" ] ||
+        [ -s "${scratch_dir}/active_metadata_issues.txt" ] ||
+        [ -s "${scratch_dir}/supersession_issues.txt" ] ||
         [ -s "${scratch_dir}/index_issues.txt" ]; then
         failed=1
     fi

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -81,6 +81,44 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -ne 0 ]
 }
 
+@test "[common] codex worklog manager hard-gates startup learns" {
+    [ -f "${CODEX_WORKLOG_AGENT_PATH}" ]
+
+    run grep -F 'treat only the `## Active` section as the startup source of truth' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '`## Needs Review` may be consulted as reference but never as validated fact during startup' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Do not read `## Superseded` or `## Archived` unless the parent explicitly asks for historical context' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Reply to the parent with exactly three short sections in this order: `Active learnings`, `Needs revalidation`, `Ignored historical entries`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] codex worklog manager defines the learn freshness metadata rules" {
+    [ -f "${CODEX_WORKLOG_AGENT_PATH}" ]
+
+    run grep -F 'Required `learn` keys: `validated`, `apply_to`, `status`, `freshness`, `last_validated_at`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '`freshness: drift_prone` requires `review_after`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '`status: superseded` requires `superseded_by`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Replacement learn files should record the prior file in `supersedes`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Do not promote session-limited facts, current branch/path/default branch, or state that can be rechecked immediately into learn files' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '`- [タイトル](ファイル名) [stable|drift_prone] — 要約（150 文字以内）`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] codex GitHub workflow is delegated to the custom subagent" {
     [ -f "${CODEX_GH_AGENT_PATH}" ]
     [ ! -e "${LEGACY_GH_FIRST_SKILL_PATH}" ]

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -9,7 +9,7 @@ function setup() {
 
 function write_learn_file() {
     local filename="$1"
-    local status="$2"
+    local learn_status="$2"
     local freshness="$3"
     local last_validated_at="$4"
     local review_after="$5"
@@ -26,8 +26,8 @@ function write_learn_file() {
         printf "%s\n" "validated: true"
         printf "%s\n" "apply_to: []"
 
-        if [ -n "${status}" ]; then
-            printf "%s\n" "status: ${status}"
+        if [ -n "${learn_status}" ]; then
+            printf "%s\n" "status: ${learn_status}"
         fi
 
         if [ -n "${freshness}" ]; then
@@ -56,7 +56,7 @@ function write_learn_file() {
 }
 
 function write_failing_fixture() {
-    cat > "${LEARN_ROOT}/learn_index.md" <<'EOF'
+    cat > "${LEARN_ROOT}/learn_index.md" << 'EOF'
 # learn_index.md
 
 ## Active
@@ -85,7 +85,7 @@ EOF
 }
 
 function write_healthy_fixture() {
-    cat > "${LEARN_ROOT}/learn_index.md" <<'EOF'
+    cat > "${LEARN_ROOT}/learn_index.md" << 'EOF'
 # learn_index.md
 
 ## Active

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./home/dot_local/bin/exact_common/executable_codex-worklog-audit"
+
+function setup() {
+    export LEARN_ROOT="${BATS_TEST_TMPDIR}/learn"
+    mkdir -p "${LEARN_ROOT}"
+}
+
+function write_learn_file() {
+    local filename="$1"
+    local status="$2"
+    local freshness="$3"
+    local last_validated_at="$4"
+    local review_after="$5"
+    local superseded_by="$6"
+    local supersedes="$7"
+
+    {
+        printf "%s\n" "---"
+        printf "%s\n" "type: learn"
+        printf "%s\n" "id: ${filename%_learn.md}"
+        printf "%s\n" "owner: test"
+        printf "%s\n" "created_at: 2026-05-14T00:00:00+09:00"
+        printf "%s\n" "updated_at: 2026-05-14T00:00:00+09:00"
+        printf "%s\n" "validated: true"
+        printf "%s\n" "apply_to: []"
+
+        if [ -n "${status}" ]; then
+            printf "%s\n" "status: ${status}"
+        fi
+
+        if [ -n "${freshness}" ]; then
+            printf "%s\n" "freshness: ${freshness}"
+        fi
+
+        if [ -n "${last_validated_at}" ]; then
+            printf "%s\n" "last_validated_at: ${last_validated_at}"
+        fi
+
+        if [ -n "${review_after}" ]; then
+            printf "%s\n" "review_after: ${review_after}"
+        fi
+
+        if [ -n "${superseded_by}" ]; then
+            printf "%s\n" "superseded_by: ${superseded_by}"
+        fi
+
+        if [ -n "${supersedes}" ]; then
+            printf "%s\n" "supersedes: ${supersedes}"
+        fi
+
+        printf "%s\n" "---"
+        printf "\n# Date\n2026-05-14\n\n# Learnings\n- Fixture entry.\n\n# Plan Updates\n- None.\n"
+    } > "${LEARN_ROOT}/${filename}"
+}
+
+function write_failing_fixture() {
+    cat > "${LEARN_ROOT}/learn_index.md" <<'EOF'
+# learn_index.md
+
+## Active
+- [Active stable](active_stable_learn.md) [stable] — Healthy active learn.
+- [Active expired](active_expired_learn.md) [drift_prone] — Active drift-prone learn whose deadline passed.
+- [Active legacy](active_legacy_learn.md) [stable] — Active entry without the new metadata.
+- [Missing from disk](missing_from_disk_learn.md) [stable] — Index entry pointing to a missing file.
+
+## Needs Review
+- [drift_prone] [Needs review](needs_review_learn.md) — Reference-only learn pending revalidation.
+
+## Superseded
+- [Superseded](superseded_learn.md) [drift_prone] — Historical learn replaced by another file.
+
+## Archived
+- [Archived](archived_learn.md) [stable] — Archived learn kept only for history.
+EOF
+
+    write_learn_file "active_stable_learn.md" "active" "stable" "2026-05-14" "" "" ""
+    write_learn_file "active_expired_learn.md" "active" "drift_prone" "2026-04-01" "2026-04-15" "" ""
+    write_learn_file "active_legacy_learn.md" "" "" "" "" "" ""
+    write_learn_file "needs_review_learn.md" "needs_review" "drift_prone" "2026-04-01" "2026-04-15" "" ""
+    write_learn_file "superseded_learn.md" "superseded" "drift_prone" "2026-04-01" "2026-04-15" "missing_replacement_learn.md" ""
+    write_learn_file "archived_learn.md" "archived" "stable" "2026-03-20" "" "" ""
+    write_learn_file "orphan_learn.md" "needs_review" "stable" "2026-05-14" "" "" ""
+}
+
+function write_healthy_fixture() {
+    cat > "${LEARN_ROOT}/learn_index.md" <<'EOF'
+# learn_index.md
+
+## Active
+- [Active stable](active_stable_learn.md) [stable] — Healthy active learn.
+- [Active drift-prone](active_drift_prone_learn.md) [drift_prone] — Active learn with a future review date.
+- [stable] [Replacement](replacement_learn.md) — Active learn that supersedes the historical entry.
+
+## Needs Review
+- [Needs review](needs_review_learn.md) [drift_prone] — Reference-only learn pending revalidation.
+
+## Superseded
+- [Superseded](superseded_learn.md) [drift_prone] — Historical learn linked to its replacement.
+
+## Archived
+- [Archived](archived_learn.md) [stable] — Archived learn kept only for history.
+EOF
+
+    write_learn_file "active_stable_learn.md" "active" "stable" "2026-05-14" "" "" ""
+    write_learn_file "active_drift_prone_learn.md" "active" "drift_prone" "2026-05-14" "2026-06-14" "" ""
+    write_learn_file "replacement_learn.md" "active" "stable" "2026-05-14" "" "" "superseded_learn.md"
+    write_learn_file "needs_review_learn.md" "needs_review" "drift_prone" "2026-05-14" "2026-06-14" "" ""
+    write_learn_file "superseded_learn.md" "superseded" "drift_prone" "2026-05-14" "2026-06-14" "replacement_learn.md" ""
+    write_learn_file "archived_learn.md" "archived" "stable" "2026-05-14" "" "" ""
+}
+
+@test "[common] codex-worklog-audit summary reports counts and stale learn findings" {
+    write_failing_fixture
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${LEARN_ROOT}" bash "${SCRIPT_PATH}" summary
+    [ "${status}" -eq 0 ]
+
+    [[ "${output}" == *"Status counts:"* ]]
+    [[ "${output}" == *"- active: 4"* ]]
+    [[ "${output}" == *"- needs_review: 1"* ]]
+    [[ "${output}" == *"- superseded: 1"* ]]
+    [[ "${output}" == *"- archived: 1"* ]]
+    [[ "${output}" == *"- active_expired_learn.md (active, review_after=2026-04-15)"* ]]
+    [[ "${output}" == *"- active_legacy_learn.md (status, freshness, last_validated_at)"* ]]
+    [[ "${output}" == *"- superseded_learn.md (superseded_by=missing_replacement_learn.md)"* ]]
+    [[ "${output}" == *"- indexed file missing on disk: missing_from_disk_learn.md"* ]]
+    [[ "${output}" == *"- file missing from index: orphan_learn.md"* ]]
+}
+
+@test "[common] codex-worklog-audit check fails on startup-breaking learn states" {
+    write_failing_fixture
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${LEARN_ROOT}" bash "${SCRIPT_PATH}" check
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"check: FAIL"* ]]
+    [[ "${output}" == *"- active_expired_learn.md (active, review_after=2026-04-15)"* ]]
+    [[ "${output}" == *"- active_legacy_learn.md (status, freshness, last_validated_at)"* ]]
+}
+
+@test "[common] codex-worklog-audit check passes for a healthy learn corpus" {
+    write_healthy_fixture
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${LEARN_ROOT}" bash "${SCRIPT_PATH}" check
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"check: OK"* ]]
+    [[ "${output}" == *"Active entries missing required metadata:\nnone"* || "${output}" == *$'Active entries missing required metadata:\nnone'* ]]
+    [[ "${output}" == *"Broken supersession links:\nnone"* || "${output}" == *$'Broken supersession links:\nnone'* ]]
+    [[ "${output}" == *"Index mismatches:\nnone"* || "${output}" == *$'Index mismatches:\nnone'* ]]
+}

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -111,6 +111,54 @@ EOF
     write_learn_file "archived_learn.md" "archived" "stable" "2026-05-14" "" "" ""
 }
 
+function write_edge_case_fixture() {
+    cat > "${LEARN_ROOT}/learn_index.md" << 'EOF'
+# learn_index.md
+
+## Future Ideas
+- [Ignored future learn](ignored_future_learn.md) [stable] — Unknown sections must stay out of the audit.
+
+## Active
+- [Missing review_after](active_missing_review_after_learn.md) [drift_prone] — Drift-prone active learn missing review_after.
+- [Status mismatch](status_mismatch_learn.md) [stable] — File metadata disagrees with the index section.
+- [Replacement without reciprocal](replacement_without_supersedes_learn.md) [stable] — Replacement learn missing reciprocal supersedes.
+- [Missing supersedes target](supersedes_missing_target_learn.md) [stable] — Learn points to a missing superseded file.
+
+## Superseded
+- [Missing replacement](superseded_missing_replacement_learn.md) [stable] — Superseded learn missing superseded_by.
+- [Needs reciprocal supersedes](superseded_nonreciprocal_learn.md) [stable] — Replacement exists but omits supersedes.
+EOF
+
+    write_learn_file "active_missing_review_after_learn.md" "active" "drift_prone" "2026-05-14" "" "" ""
+    write_learn_file "status_mismatch_learn.md" "needs_review" "stable" "2026-05-14" "" "" ""
+    write_learn_file "replacement_without_supersedes_learn.md" "active" "stable" "2026-05-14" "" "" ""
+    write_learn_file "supersedes_missing_target_learn.md" "active" "stable" "2026-05-14" "" "" "missing_target_learn.md"
+    write_learn_file "superseded_missing_replacement_learn.md" "superseded" "stable" "2026-05-14" "" "" ""
+    write_learn_file "superseded_nonreciprocal_learn.md" "superseded" "stable" "2026-05-14" "" "replacement_without_supersedes_learn.md" ""
+}
+
+function write_mock_chezmoi() {
+    local source_path="$1"
+    local mock_bin="${BATS_TEST_TMPDIR}/bin"
+
+    mkdir -p "${mock_bin}"
+
+    cat > "${mock_bin}/chezmoi" << EOF
+#!/usr/bin/env bash
+
+if [ "\${1:-}" = "source-path" ]; then
+    printf "%s\n" "${source_path}"
+    exit 0
+fi
+
+printf "unsupported chezmoi subcommand: %s\n" "\${1:-}" >&2
+exit 1
+EOF
+
+    chmod +x "${mock_bin}/chezmoi"
+    printf "%s\n" "${mock_bin}"
+}
+
 @test "[common] codex-worklog-audit summary reports counts and stale learn findings" {
     write_failing_fixture
 
@@ -148,4 +196,66 @@ EOF
     [[ "${output}" == *"Active entries missing required metadata:\nnone"* || "${output}" == *$'Active entries missing required metadata:\nnone'* ]]
     [[ "${output}" == *"Broken supersession links:\nnone"* || "${output}" == *$'Broken supersession links:\nnone'* ]]
     [[ "${output}" == *"Index mismatches:\nnone"* || "${output}" == *$'Index mismatches:\nnone'* ]]
+}
+
+@test "[common] codex-worklog-audit summary reports review, supersession, and status edge cases" {
+    write_edge_case_fixture
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${LEARN_ROOT}" bash "${SCRIPT_PATH}" summary
+    [ "${status}" -eq 0 ]
+
+    [[ "${output}" == *"- active: 4"* ]]
+    [[ "${output}" == *"- superseded: 2"* ]]
+    [[ "${output}" == *"- active_missing_review_after_learn.md (review_after)"* ]]
+    [[ "${output}" == *"- superseded_missing_replacement_learn.md (missing superseded_by)"* ]]
+    [[ "${output}" == *"- superseded_nonreciprocal_learn.md (replacement replacement_without_supersedes_learn.md is missing reciprocal supersedes)"* ]]
+    [[ "${output}" == *"- supersedes_missing_target_learn.md (supersedes=missing_target_learn.md)"* ]]
+    [[ "${output}" == *"- status mismatch: status_mismatch_learn.md (index=active, file=needs_review)"* ]]
+    [[ "${output}" != *"ignored_future_learn.md"* ]]
+}
+
+@test "[common] codex-worklog-audit resolves the learn root through chezmoi source-path" {
+    local source_root="${BATS_TEST_TMPDIR}/chezmoi-source"
+    local mock_bin
+
+    export LEARN_ROOT="${source_root}/.agents/worklog/codex/learn"
+    mkdir -p "${LEARN_ROOT}"
+    write_healthy_fixture
+    mock_bin="$(write_mock_chezmoi "${source_root}")"
+
+    run env -u CODEX_WORKLOG_LEARN_ROOT PATH="${mock_bin}:${PATH}" bash "${SCRIPT_PATH}" check
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"check: OK"* ]]
+}
+
+@test "[common] codex-worklog-audit fails when the learn root path is missing" {
+    local missing_root="${BATS_TEST_TMPDIR}/missing-learn-root"
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${missing_root}" bash "${SCRIPT_PATH}" summary
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"learn root not found: ${missing_root}"* ]]
+}
+
+@test "[common] codex-worklog-audit fails when the learn index is missing" {
+    local indexless_root="${BATS_TEST_TMPDIR}/indexless-root"
+
+    mkdir -p "${indexless_root}"
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${indexless_root}" bash "${SCRIPT_PATH}" check
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"learn index not found: ${indexless_root}/learn_index.md"* ]]
+}
+
+@test "[common] codex-worklog-audit errors when chezmoi is unavailable and no learn root is set" {
+    run env -u CODEX_WORKLOG_LEARN_ROOT PATH="/usr/bin:/bin" bash "${SCRIPT_PATH}" summary
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"chezmoi is required unless CODEX_WORKLOG_LEARN_ROOT is set"* ]]
+}
+
+@test "[common] codex-worklog-audit rejects unsupported commands" {
+    write_healthy_fixture
+
+    run env CODEX_WORKLOG_LEARN_ROOT="${LEARN_ROOT}" bash "${SCRIPT_PATH}" unsupported
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"usage: executable_codex-worklog-audit {summary|check}"* ]]
 }


### PR DESCRIPTION
## Summary
- hard-gate `worklog-manager` startup learn loading to the `## Active` section and document the new learn metadata and lifecycle rules
- add `codex-worklog-audit` to validate learn index metadata, stale review deadlines, supersession links, startup-breaking inconsistencies, and command-path failures
- expand audit coverage with edge-case fixtures and simplify embedded `awk` coverage tracing while preserving empty TSV field parsing in supersession checks

## Testing
- `bash -n home/dot_local/bin/exact_common/executable_codex-worklog-audit`
- `shfmt -i 4 -sr -d tests/install/common/codex_worklog_audit.bats home/dot_local/bin/exact_common/executable_codex-worklog-audit`
- `CODEX_WORKLOG_LEARN_ROOT=/Users/s.kitada/.local/share/chezmoi/.agents/worklog/codex/learn bash home/dot_local/bin/exact_common/executable_codex-worklog-audit check`
- direct failing-fixture smoke check for `check: FAIL`
- Not run locally: `bats` is CI-only in this repository
