### PR TITLE
Refactor worklog_manager to use the shared worklog-manager skill

### DIFF
--- a/home/dot_config/codex/agents/worklog-manager.toml
+++ b/home/dot_config/codex/agents/worklog-manager.toml
@@ -13,6 +13,8 @@ Shared skill:
 - Before you do anything else, read the canonical workflow at `~/.agents/skills/worklog-manager/SKILL.md`.
 - If that home-path skill is unavailable, resolve the repository root with `git rev-parse --show-toplevel` and read `home/dot_config/exact_agents/skills/worklog-manager/SKILL.md`.
 - Treat the shared skill and its bundled references/scripts as the source of truth for startup learn selection, plan/todo/learn metadata, stale-learn hard gating, and audit behavior.
+- The shared skill's startup audit is mandatory: if `.agents/worklog/codex/learn/learn_index.md` exists, run the bundled `codex_worklog_audit.py check` before reading any learn entry.
+- If that startup audit fails, fail hard and report the exact audit failures to the parent. Do not continue startup with best-effort learn selection.
 - If you cannot load the shared skill, fail hard and report that exact blocker to the parent. Do not improvise an alternate workflow.
 
 Bootstrap:

--- a/home/dot_config/codex/agents/worklog-manager.toml
+++ b/home/dot_config/codex/agents/worklog-manager.toml
@@ -9,47 +9,20 @@ Scope:
 - Never edit repository files outside `.agents/worklog/codex/**`.
 - Do not make product/code changes. Your job is worklog management only.
 
+Shared skill:
+- Before you do anything else, read the canonical workflow at `~/.agents/skills/worklog-manager/SKILL.md`.
+- If that home-path skill is unavailable, resolve the repository root with `git rev-parse --show-toplevel` and read `home/dot_config/exact_agents/skills/worklog-manager/SKILL.md`.
+- Treat the shared skill and its bundled references/scripts as the source of truth for startup learn selection, plan/todo/learn metadata, stale-learn hard gating, and audit behavior.
+- If you cannot load the shared skill, fail hard and report that exact blocker to the parent. Do not improvise an alternate workflow.
+
 Bootstrap:
 - The parent agent should start you once per non-trivial task and reuse the same thread.
 - Expect the first parent message to include a task summary, the initial user prompt, and `parent_owner`.
 - Derive your owner as `<parent_owner>-worklog`.
 - Ask the parent agent for missing context if the bootstrap payload is incomplete.
 
-Startup workflow:
-1. Ensure `.agents/worklog/codex/plan/`, `todo/`, and `learn/` exist.
-2. Read `.agents/worklog/codex/learn/learn_index.md`.
-3. Read the specific learn files that are relevant to the task.
-4. Reply to the parent with a short summary of the relevant learnings and the owner you will use before you continue with routine updates.
-
-Plan and todo rules:
-- Maintain the session worklog continuously while the parent agent works.
-- Use YAML frontmatter on every plan, todo, and learn file.
-- Required common keys: `type`, `id`, `owner`, `created_at`, `updated_at`.
-- Required `plan` key: `status`.
-- Required `todo` keys: `status`, `workstream`, `related_plan`.
-- Required `learn` keys: `validated`, `apply_to`.
-- Use these headings for plan files: `User Prompt`, `Goal`, `Scope`, `Assumptions`, `Design`, `Tests`, `Open Questions`.
-- Use these headings for todo files: `TODO`, `Done`.
-- Use these headings for learn files: `Date`, `Learnings`, `Plan Updates`.
-- Reuse one session id across the session's plan and todo files.
-- Record the first user prompt in the plan `User Prompt` section and append later requirement changes chronologically.
-- Keep `todo.status` within `active | blocked | done | superseded`.
-- Keep `plan.status` within `draft | active | done | superseded`.
-
-Todo completion:
-- Move completed tasks from `# TODO` to `# Done`.
-- When `# TODO` becomes empty, set `todo.status: done`, update `updated_at`, and rename the file from `*_todo.md` to `*_done.md`.
-- When the task is fully complete, also set the session plan status to `done`.
-
-Learn rules:
-- Create or update a learn file only when the information is reusable and validated.
-- Each learn file must state what was learned and where it should be applied.
-- When learn files change, update `.agents/worklog/codex/learn/learn_index.md`.
-- Each index entry must be one line in this format:
-  `- [タイトル](ファイル名) — 要約（150 文字以内）`
-- When learn changes affect the active plan, update the plan `Assumptions`, `Design`, or `Tests` accordingly.
-
 Output to parent:
 - Keep responses concise.
+- For the startup summary, use exactly these sections in this order: `Active learnings`, `Needs revalidation`, `Ignored historical entries`.
 - When the parent asks for a close-out summary, return a one-line candidate that starts with `📝 まとめ:`.
 """

--- a/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
@@ -22,6 +22,10 @@ It keeps startup context constrained to valid learn entries, maintains plan/todo
 1. Keep scope limited to `.agents/worklog/codex/**`. If the request needs repo edits, GitHub operations, or product decisions, hand that back to the parent agent.
 2. Bootstrap from `.agents/worklog/codex/learn/learn_index.md`.
    - Ensure `.agents/worklog/codex/plan/`, `todo/`, and `learn/` exist.
+   - If `learn_index.md` does not exist yet, skip the startup audit and continue with empty learn context.
+   - If `learn_index.md` exists, run `python3 ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py check` before reading any learn entry.
+   - If the home-path script is unavailable in a repository context, resolve the repository root and run `python3 home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py check`.
+   - If `check` fails, stop startup and report the exact audit failures to the parent. Do not continue with best-effort learn selection.
    - Treat `## Active` as the only startup source of truth.
    - Treat `## Needs Review` as context candidates, not facts.
    - Ignore `## Superseded` and `## Archived` unless the parent explicitly asks for history or migration context.
@@ -61,11 +65,12 @@ It keeps startup context constrained to valid learn entries, maintains plan/todo
 
 ## Audit
 
-Use the bundled audit helper before trusting an older corpus or after changing learn metadata:
+`check` is mandatory during startup whenever `learn_index.md` exists.
+Use `summary` for manual inspection or for diagnosing a failed startup audit after the failure has already been reported to the parent.
 
 ```bash
-uv run python ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py summary
-uv run python ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py check
+python3 ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py check
+python3 ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py summary
 ```
 
 Use `--learn-root <path>` when you need to audit fixtures or a non-default corpus.

--- a/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: worklog-manager
+description: Manage Codex worklog files under `.agents/worklog/codex`, hard-gate stale learnings through `learn_index.md`, and audit learn metadata deterministically. Use when a Codex agent or user needs to bootstrap worklog context, maintain plan/todo/learn files, or validate stale learn state before trusting prior session knowledge.
+---
+
+# Worklog Manager
+
+## Overview
+
+Use this skill to manage `.agents/worklog/codex/**` for Codex sessions.
+It keeps startup context constrained to valid learn entries, maintains plan/todo/learn metadata, and audits stale learn state deterministically.
+
+## When To Use
+
+- Bootstrap or update `.agents/worklog/codex/{plan,todo,learn}` for a non-trivial Codex task.
+- Summarize reusable learnings before implementation starts.
+- Create, update, supersede, or archive reusable learn files.
+- Audit stale learn metadata or index consistency before trusting older session knowledge.
+
+## Workflow
+
+1. Keep scope limited to `.agents/worklog/codex/**`. If the request needs repo edits, GitHub operations, or product decisions, hand that back to the parent agent.
+2. Bootstrap from `.agents/worklog/codex/learn/learn_index.md`.
+   - Ensure `.agents/worklog/codex/plan/`, `todo/`, and `learn/` exist.
+   - Treat `## Active` as the only startup source of truth.
+   - Treat `## Needs Review` as context candidates, not facts.
+   - Ignore `## Superseded` and `## Archived` unless the parent explicitly asks for history or migration context.
+   - Read only the learn files referenced by the relevant index entries.
+   - Return the startup summary in this exact order:
+     - `Active learnings`: only `active` entries with `freshness: stable`.
+     - `Needs revalidation`: every `needs_review` entry plus any `active` entry with `freshness: drift_prone`.
+     - `Ignored historical entries`: relevant `superseded` or `archived` entries that were intentionally skipped.
+3. Maintain the session plan and todo continuously while the parent works.
+   - Required common keys: `type`, `id`, `owner`, `created_at`, `updated_at`.
+   - Required `plan` key: `status`.
+   - Required `todo` keys: `status`, `workstream`, `related_plan`.
+   - Required `learn` keys: `validated`, `apply_to`, `status`, `freshness`, `last_validated_at`.
+   - Keep `todo.status` within `active | blocked | done | superseded`.
+   - Keep `plan.status` within `draft | active | done | superseded`.
+   - Use these headings for plan files: `User Prompt`, `Goal`, `Scope`, `Assumptions`, `Design`, `Tests`, `Open Questions`.
+   - Use these headings for todo files: `TODO`, `Done`.
+   - Use these headings for learn files: `Date`, `Learnings`, `Plan Updates`.
+4. Manage learn metadata and index state together.
+   - `status` must be one of `active | needs_review | superseded | archived`.
+   - `freshness` must be one of `stable | drift_prone`.
+   - `freshness: drift_prone` requires `review_after`.
+   - `status: superseded` requires `superseded_by`.
+   - Replacement learn files should declare `supersedes`.
+   - `learn_index.md` must contain exactly these sections: `## Active`, `## Needs Review`, `## Superseded`, `## Archived`.
+   - Keep each index entry on one line in this format:
+     `- [Title](file.md) [stable|drift_prone] — Summary`
+5. When learn changes affect the active plan, update the plan `Assumptions`, `Design`, or `Tests` sections to match.
+
+## Learn Promotion Gate
+
+- Do not promote session-local facts, current branch names, current paths, default-branch names, or any repo state that is cheap to re-check right now.
+- Only store drift-prone repo state when repeated reuse has justified the cost. When you do, mark it `freshness: drift_prone` and set an explicit `review_after`.
+- When you encounter legacy branch/default-branch learns, do targeted migration instead of broad corpus rewrites.
+  - A fact like `default branch is master` must not stay `active`; move it to `superseded`.
+  - A recipe that still assumes `origin/master` should move to `needs_review` until it is revalidated against the current `main` workflow.
+
+## Audit
+
+Use the bundled audit helper before trusting an older corpus or after changing learn metadata:
+
+```bash
+uv run python ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py summary
+uv run python ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py check
+```
+
+Use `--learn-root <path>` when you need to audit fixtures or a non-default corpus.
+Use `--now <ISO-8601>` when you need deterministic review expiry checks in tests.
+
+## Output
+
+- Keep responses concise.
+- When the parent asks for a close-out summary, return a one-line candidate that starts with `📝 まとめ:`.
+
+## References
+
+- Read [learn_rules.md](references/learn_rules.md) when you need exact frontmatter examples, index examples, or the audit contract.
+
+## Resources
+
+### scripts/
+
+- `scripts/codex_worklog_audit.py`: deterministic audit helper for learn metadata, review expiry, supersession links, and index/file consistency.
+
+### references/
+
+- `references/learn_rules.md`: detailed learn metadata rules, targeted migration examples, and audit expectations.

--- a/home/dot_config/exact_agents/skills/worklog-manager/agents/openai.yaml
+++ b/home/dot_config/exact_agents/skills/worklog-manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Worklog Manager"
+  short_description: "Manage Codex worklogs and stale learn state"
+  default_prompt: "Use $worklog-manager to manage Codex worklog files and audit stale learn metadata."

--- a/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
@@ -1,0 +1,152 @@
+# Worklog Learn Rules
+
+## Index Contract
+
+`learn_index.md` is the startup authority for learn selection.
+It must contain exactly these sections in this order:
+
+1. `## Active`
+2. `## Needs Review`
+3. `## Superseded`
+4. `## Archived`
+
+Each entry stays on one line:
+
+```text
+- [Title](file.md) [stable|drift_prone] — Summary
+```
+
+The section determines the startup treatment:
+
+- `Active`: eligible for startup reads.
+- `Needs Review`: reference only, never a startup fact.
+- `Superseded`: historical, skip unless migration/history is explicitly requested.
+- `Archived`: historical, skip unless migration/history is explicitly requested.
+
+## Frontmatter Rules
+
+Every plan, todo, and learn file keeps the common keys:
+
+- `type`
+- `id`
+- `owner`
+- `created_at`
+- `updated_at`
+
+Learn files also require:
+
+- `validated`
+- `apply_to`
+- `status`
+- `freshness`
+- `last_validated_at`
+
+Additional rules:
+
+- `status` is one of `active | needs_review | superseded | archived`
+- `freshness` is one of `stable | drift_prone`
+- `freshness: drift_prone` requires `review_after`
+- `status: superseded` requires `superseded_by`
+- Replacement learn files should add `supersedes`
+
+## Learn Examples
+
+### Active stable learn
+
+```yaml
+---
+type: learn
+id: learn-default-branch-main
+owner: codex-main-worklog
+created_at: 2026-05-15T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+```
+
+### Active drift-prone learn
+
+```yaml
+---
+type: learn
+id: learn-origin-main-recipe
+owner: codex-main-worklog
+created_at: 2026-05-15T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+review_after: 2026-06-01T00:00:00Z
+---
+```
+
+### Superseded learn
+
+```yaml
+---
+type: learn
+id: learn-default-branch-master
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: superseded
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+superseded_by: default-branch-main.md
+---
+```
+
+### Replacement learn
+
+```yaml
+---
+type: learn
+id: learn-default-branch-main
+owner: codex-main-worklog
+created_at: 2026-05-15T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+supersedes: default-branch-is-master.md
+---
+```
+
+## Targeted Migration Rules
+
+- Do not rewrite the entire corpus just to add new metadata.
+- A fact like `default branch is master` must not stay `active`; move it to `Superseded` and point it at the current replacement learn.
+- If an older recipe assumes `origin/master`, move it to `Needs Review` until it is revalidated on the current `main` workflow.
+- Drift-prone repo state should stay out of `Active` unless it has a fresh validation date and a review deadline.
+
+## Audit Contract
+
+`scripts/codex_worklog_audit.py summary` reports:
+
+- status counts from the index sections
+- expired `review_after`
+- active legacy metadata missing
+- broken supersession links
+- index/file mismatches
+
+`scripts/codex_worklog_audit.py check` exits non-zero when startup would be unsafe, including:
+
+- malformed or incomplete index sections
+- active entries missing required new metadata
+- active drift-prone entries with missing or expired `review_after`
+- broken supersession links
+- index/file mismatches

--- a/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
@@ -23,6 +23,13 @@ The section determines the startup treatment:
 - `Superseded`: historical, skip unless migration/history is explicitly requested.
 - `Archived`: historical, skip unless migration/history is explicitly requested.
 
+## Startup Audit Gate
+
+- If `learn_index.md` exists, startup must run `scripts/codex_worklog_audit.py check` before reading any learn entry.
+- `check` must exit `0` before any `Active` entry can be treated as fact.
+- If `check` fails, stop startup and return the exact audit failures to the parent instead of falling back to best-effort learn selection.
+- `summary` is optional and is meant for diagnosis after a failure or for manual review.
+
 ## Frontmatter Rules
 
 Every plan, todo, and learn file keeps the common keys:

--- a/home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py
+++ b/home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Audit worklog learn metadata and index consistency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+SECTION_HEADINGS = {
+    "Active": "active",
+    "Needs Review": "needs_review",
+    "Superseded": "superseded",
+    "Archived": "archived",
+}
+SECTION_ORDER = ["active", "needs_review", "superseded", "archived"]
+VALID_FRESHNESS = {"stable", "drift_prone"}
+INDEX_ENTRY_RE = re.compile(
+    r"^- \[(?P<title>.+?)\]\((?P<filename>[^)]+)\)\s+\[(?P<freshness>stable|drift_prone)\]\s+—\s+(?P<summary>.+)$"
+)
+FRONTMATTER_KEY_RE = re.compile(r"^([A-Za-z0-9_]+):(?:\s*(.*))?$")
+LIST_ITEM_RE = re.compile(r"^\s*-\s+(.*)$")
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    section: str
+    title: str
+    filename: str
+    freshness: str
+    line_no: int
+
+
+@dataclass(frozen=True)
+class LearnFile:
+    path: Path
+    frontmatter: dict[str, object]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit worklog learn metadata.")
+    parser.add_argument("command", choices=("summary", "check"))
+    parser.add_argument(
+        "--learn-root",
+        default=".agents/worklog/codex/learn",
+        help="Path to the learn directory (default: .agents/worklog/codex/learn)",
+    )
+    parser.add_argument(
+        "--now",
+        help="Override current time with an ISO-8601 timestamp for deterministic checks",
+    )
+    return parser.parse_args()
+
+
+def parse_scalar(raw_value: str) -> object:
+    value = raw_value.strip()
+    if not value:
+        return ""
+    if value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "~"}:
+        return None
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [parse_scalar(part.strip()) for part in inner.split(",") if part.strip()]
+    return value
+
+
+def parse_frontmatter(path: Path) -> dict[str, object]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+
+    lines = text.splitlines()
+    try:
+        end_index = lines[1:].index("---") + 1
+    except ValueError:
+        return {}
+
+    data: dict[str, object] = {}
+    current_key: str | None = None
+    for line in lines[1:end_index]:
+        if not line.strip():
+            continue
+
+        if current_key is not None:
+            list_match = LIST_ITEM_RE.match(line)
+            if list_match:
+                current_value = data.setdefault(current_key, [])
+                if isinstance(current_value, list):
+                    current_value.append(parse_scalar(list_match.group(1)))
+                    continue
+            current_key = None
+
+        key_match = FRONTMATTER_KEY_RE.match(line)
+        if not key_match:
+            continue
+
+        key = key_match.group(1)
+        raw_value = key_match.group(2)
+        if raw_value is None or raw_value == "":
+            data[key] = []
+            current_key = key
+            continue
+
+        data[key] = parse_scalar(raw_value)
+
+    return data
+
+
+def normalize_status(value: object) -> str | None:
+    if value is None or value == "":
+        return None
+    normalized = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in SECTION_ORDER:
+        return normalized
+    return normalized
+
+
+def normalize_freshness(value: object) -> str | None:
+    if value is None or value == "":
+        return None
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized in VALID_FRESHNESS:
+        return normalized
+    return normalized
+
+
+def as_list(value: object) -> list[str]:
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()]
+
+
+def parse_timestamp(raw_value: object) -> datetime | None:
+    if raw_value is None or raw_value == "":
+        return None
+    candidate = str(raw_value).strip()
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def current_time(raw_now: str | None) -> datetime:
+    parsed = parse_timestamp(raw_now)
+    if parsed is not None:
+        return parsed
+    return datetime.now(timezone.utc)
+
+
+def parse_index(index_path: Path) -> tuple[dict[str, list[IndexEntry]], list[str]]:
+    sections = {section: [] for section in SECTION_ORDER}
+    errors: list[str] = []
+
+    if not index_path.exists():
+        return sections, [f"missing learn index: {index_path}"]
+
+    current_section: str | None = None
+    seen_sections: list[str] = []
+
+    for line_no, raw_line in enumerate(index_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            current_section = SECTION_HEADINGS.get(heading)
+            if current_section is None:
+                errors.append(f"unexpected section heading on line {line_no}: {heading}")
+                continue
+            seen_sections.append(current_section)
+            continue
+        if not line.startswith("- "):
+            continue
+        if current_section is None:
+            errors.append(f"index entry outside managed sections on line {line_no}")
+            continue
+        match = INDEX_ENTRY_RE.match(line)
+        if not match:
+            errors.append(f"invalid index entry on line {line_no}: {line}")
+            continue
+        sections[current_section].append(
+            IndexEntry(
+                section=current_section,
+                title=match.group("title"),
+                filename=match.group("filename"),
+                freshness=match.group("freshness"),
+                line_no=line_no,
+            )
+        )
+
+    if seen_sections != SECTION_ORDER:
+        errors.append(
+            "index sections must appear exactly as: Active, Needs Review, Superseded, Archived"
+        )
+
+    for section in SECTION_ORDER:
+        if section not in seen_sections:
+            errors.append(f"missing section: {section}")
+
+    return sections, errors
+
+
+def load_learn_files(learn_root: Path) -> dict[str, LearnFile]:
+    learn_files: dict[str, LearnFile] = {}
+    if not learn_root.exists():
+        return learn_files
+    for path in sorted(learn_root.glob("*.md")):
+        if path.name == "learn_index.md":
+            continue
+        learn_files[path.name] = LearnFile(path=path, frontmatter=parse_frontmatter(path))
+    return learn_files
+
+
+def add_unique(items: list[str], message: str) -> None:
+    if message not in items:
+        items.append(message)
+
+
+def format_missing_metadata(filename: str, missing: list[str]) -> str:
+    return f"{filename} -> missing {', '.join(missing)}"
+
+
+def build_report(learn_root: Path, now: datetime) -> dict[str, object]:
+    index_sections, index_errors = parse_index(learn_root / "learn_index.md")
+    learn_files = load_learn_files(learn_root)
+    section_by_filename: dict[str, str] = {}
+    freshness_by_filename: dict[str, str] = {}
+    index_file_mismatches: list[str] = []
+    active_legacy_missing: list[str] = []
+    expired_review_after: list[str] = []
+    broken_supersession_links: list[str] = []
+    active_review_gaps: list[str] = []
+
+    for section in SECTION_ORDER:
+        for entry in index_sections[section]:
+            if entry.filename in section_by_filename:
+                add_unique(
+                    index_file_mismatches,
+                    f"duplicate index entry: {entry.filename}",
+                )
+                continue
+            section_by_filename[entry.filename] = section
+            freshness_by_filename[entry.filename] = entry.freshness
+
+    for filename, section in section_by_filename.items():
+        learn = learn_files.get(filename)
+        if learn is None:
+            add_unique(index_file_mismatches, f"indexed file missing: {filename}")
+            continue
+
+        status = normalize_status(learn.frontmatter.get("status"))
+        freshness = normalize_freshness(learn.frontmatter.get("freshness"))
+        marker_freshness = freshness_by_filename[filename]
+
+        if status is not None and status != section:
+            add_unique(
+                index_file_mismatches,
+                f"section/status mismatch: {filename} (index={section} file={status})",
+            )
+        if freshness is not None and freshness != marker_freshness:
+            add_unique(
+                index_file_mismatches,
+                f"freshness marker mismatch: {filename} (index={marker_freshness} file={freshness})",
+            )
+
+        if section == "active":
+            missing_keys = [
+                key
+                for key in ("status", "freshness", "last_validated_at")
+                if learn.frontmatter.get(key) in (None, "", [])
+            ]
+            if missing_keys:
+                add_unique(
+                    active_legacy_missing,
+                    format_missing_metadata(filename, missing_keys),
+                )
+
+        effective_freshness = freshness or marker_freshness
+        if effective_freshness != "drift_prone":
+            continue
+
+        review_after = parse_timestamp(learn.frontmatter.get("review_after"))
+        if review_after is None:
+            if section == "active":
+                add_unique(
+                    active_review_gaps,
+                    f"{filename} -> missing review_after",
+                )
+            continue
+
+        if review_after <= now:
+            add_unique(
+                expired_review_after,
+                f"{filename} (status={section} review_after={learn.frontmatter.get('review_after')})",
+            )
+
+    for filename in sorted(learn_files):
+        if filename not in section_by_filename:
+            add_unique(index_file_mismatches, f"unindexed learn file: {filename}")
+
+    for filename, learn in learn_files.items():
+        status = normalize_status(learn.frontmatter.get("status"))
+
+        superseded_by = learn.frontmatter.get("superseded_by")
+        if status == "superseded":
+            if superseded_by in (None, "", []):
+                add_unique(
+                    broken_supersession_links,
+                    f"{filename} -> missing superseded_by",
+                )
+            else:
+                replacement = str(superseded_by).strip()
+                replacement_learn = learn_files.get(replacement)
+                if replacement_learn is None:
+                    add_unique(
+                        broken_supersession_links,
+                        f"{filename} -> superseded_by target missing: {replacement}",
+                    )
+                else:
+                    replacement_supersedes = as_list(
+                        replacement_learn.frontmatter.get("supersedes")
+                    )
+                    if filename not in replacement_supersedes:
+                        add_unique(
+                            broken_supersession_links,
+                            f"{filename} -> replacement missing reciprocal supersedes: {replacement}",
+                        )
+
+        for target in as_list(learn.frontmatter.get("supersedes")):
+            if target not in learn_files:
+                add_unique(
+                    broken_supersession_links,
+                    f"{filename} -> supersedes target missing: {target}",
+                )
+
+    status_counts = {
+        section: len(index_sections[section])
+        for section in SECTION_ORDER
+    }
+
+    expired_active_review_after = [
+        entry for entry in expired_review_after if "(status=active " in entry
+    ]
+
+    startup_breakers = []
+    startup_breakers.extend(f"index error: {item}" for item in index_errors)
+    startup_breakers.extend(
+        f"active entry missing metadata: {item}" for item in active_legacy_missing
+    )
+    startup_breakers.extend(
+        f"active drift_prone entry missing review_after: {item}" for item in active_review_gaps
+    )
+    startup_breakers.extend(
+        f"expired active review_after: {item}" for item in expired_active_review_after
+    )
+    startup_breakers.extend(
+        f"broken supersession link: {item}" for item in broken_supersession_links
+    )
+    startup_breakers.extend(
+        f"index/file mismatch: {item}" for item in index_file_mismatches
+    )
+
+    return {
+        "status_counts": status_counts,
+        "index_errors": index_errors,
+        "active_legacy_missing": active_legacy_missing,
+        "active_review_gaps": active_review_gaps,
+        "expired_review_after": expired_review_after,
+        "broken_supersession_links": broken_supersession_links,
+        "index_file_mismatches": index_file_mismatches,
+        "startup_breakers": startup_breakers,
+    }
+
+
+def print_group(title: str, items: list[str]) -> None:
+    print(title)
+    if items:
+        for item in items:
+            print(f"- {item}")
+    else:
+        print("- none")
+    print()
+
+
+def print_summary(report: dict[str, object]) -> None:
+    status_counts = report["status_counts"]
+    print("Status counts")
+    for section in SECTION_ORDER:
+        print(f"- {section}: {status_counts[section]}")
+    print()
+    print_group("Expired review_after", report["expired_review_after"])
+    print_group("Active legacy metadata missing", report["active_legacy_missing"])
+    print_group("Broken supersession links", report["broken_supersession_links"])
+
+    mismatches = []
+    mismatches.extend(report["index_errors"])
+    mismatches.extend(report["active_review_gaps"])
+    mismatches.extend(report["index_file_mismatches"])
+    print_group("Index/file mismatches", mismatches)
+
+
+def run_check(report: dict[str, object]) -> int:
+    failures: list[str] = report["startup_breakers"]
+    if not failures:
+        print("OK: no startup-breaking worklog learn issues found.")
+        return 0
+
+    print("FAIL: startup-breaking worklog learn issues found.")
+    for failure in failures:
+        print(f"- {failure}")
+    return 1
+
+
+def main() -> int:
+    args = parse_args()
+    learn_root = Path(args.learn_root).resolve()
+    report = build_report(learn_root, current_time(args.now))
+    if args.command == "summary":
+        print_summary(report)
+        return 0
+    return run_check(report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -5,6 +5,10 @@ readonly CODEX_AGENTS_PATH="./home/dot_config/codex/AGENTS.md"
 readonly CODEX_SYMLINK_TEMPLATE="./home/dot_codex/symlink_AGENTS.md.tmpl"
 readonly CODEX_AGENT_DIR_SYMLINK_TEMPLATE="./home/dot_codex/symlink_agents.tmpl"
 readonly CODEX_WORKLOG_AGENT_PATH="./home/dot_config/codex/agents/worklog-manager.toml"
+readonly CODEX_WORKLOG_SKILL_PATH="./home/dot_config/exact_agents/skills/worklog-manager/SKILL.md"
+readonly CODEX_WORKLOG_SKILL_OPENAI_PATH="./home/dot_config/exact_agents/skills/worklog-manager/agents/openai.yaml"
+readonly CODEX_WORKLOG_RULES_PATH="./home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md"
+readonly CODEX_WORKLOG_AUDIT_SCRIPT_PATH="./home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py"
 readonly CODEX_GH_AGENT_PATH="./home/dot_config/codex/agents/gh-workflow-manager.toml"
 readonly LEGACY_GH_FIRST_SKILL_PATH="./home/dot_config/exact_agents/skills/gh-first-workflow"
 readonly AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS.md.tmpl"
@@ -72,6 +76,17 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F 'sandbox_mode = "workspace-write"' "${CODEX_WORKLOG_AGENT_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F '~/.agents/skills/worklog-manager/SKILL.md' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'source of truth for startup learn selection, plan/todo/learn metadata, stale-learn hard gating, and audit behavior' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`Active learnings`, `Needs revalidation`, `Ignored historical entries`' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Required `learn` keys:' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -ne 0 ]
+    run grep -F 'Keep `todo.status` within' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -ne 0 ]
 
     run grep -F "worklog_manager" "${CODEX_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
@@ -79,6 +94,44 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -ne 0 ]
     run grep -F "#### plan/todo/learn の frontmatter ルール" "${CODEX_AGENTS_PATH}"
     [ "${status}" -ne 0 ]
+}
+
+@test "[common] worklog skill defines stale-learn hard gating and audit resources" {
+    [ -f "${CODEX_WORKLOG_SKILL_PATH}" ]
+    [ -f "${CODEX_WORKLOG_SKILL_OPENAI_PATH}" ]
+    [ -f "${CODEX_WORKLOG_RULES_PATH}" ]
+    [ -f "${CODEX_WORKLOG_AUDIT_SCRIPT_PATH}" ]
+
+    run grep -F 'name: worklog-manager' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Treat `## Active` as the only startup source of truth.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Treat `## Needs Review` as context candidates, not facts.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Ignore `## Superseded` and `## Archived` unless the parent explicitly asks for history or migration context.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`Active learnings`' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`Needs revalidation`' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`Ignored historical entries`' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`status` must be one of `active | needs_review | superseded | archived`.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`freshness: drift_prone` requires `review_after`.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`status: superseded` requires `superseded_by`.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Replacement learn files should declare `supersedes`.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Do not promote session-local facts, current branch names, current paths, default-branch names' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`default branch is master` must not stay `active`' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '`origin/master`' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'default_prompt: "Use $worklog-manager to manage Codex worklog files and audit stale learn metadata."' "${CODEX_WORKLOG_SKILL_OPENAI_PATH}"
+    [ "${status}" -eq 0 ]
 }
 
 @test "[common] codex GitHub workflow is delegated to the custom subagent" {

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -80,6 +80,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F 'source of truth for startup learn selection, plan/todo/learn metadata, stale-learn hard gating, and audit behavior' "${CODEX_WORKLOG_AGENT_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F "startup audit is mandatory" "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F "Do not continue startup with best-effort learn selection." "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
     run grep -F '`Active learnings`, `Needs revalidation`, `Ignored historical entries`' "${CODEX_WORKLOG_AGENT_PATH}"
     [ "${status}" -eq 0 ]
 
@@ -106,6 +110,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F 'Treat `## Active` as the only startup source of truth.' "${CODEX_WORKLOG_SKILL_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F 'If `learn_index.md` exists, run `python3 ~/.agents/skills/worklog-manager/scripts/codex_worklog_audit.py check` before reading any learn entry.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'If `check` fails, stop startup and report the exact audit failures to the parent. Do not continue with best-effort learn selection.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
     run grep -F 'Treat `## Needs Review` as context candidates, not facts.' "${CODEX_WORKLOG_SKILL_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F 'Ignore `## Superseded` and `## Archived` unless the parent explicitly asks for history or migration context.' "${CODEX_WORKLOG_SKILL_PATH}"
@@ -127,6 +135,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     run grep -F 'Do not promote session-local facts, current branch names, current paths, default-branch names' "${CODEX_WORKLOG_SKILL_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`default branch is master` must not stay `active`' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'startup must run `scripts/codex_worklog_audit.py check` before reading any learn entry' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'stop startup and return the exact audit failures to the parent instead of falling back to best-effort learn selection' "${CODEX_WORKLOG_RULES_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`origin/master`' "${CODEX_WORKLOG_RULES_PATH}"
     [ "${status}" -eq 0 ]

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -1,0 +1,354 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py"
+readonly FIXED_NOW="2026-05-15T00:00:00Z"
+
+function setup() {
+    export LEARN_ROOT="${BATS_TEST_TMPDIR}/learn"
+    mkdir -p "${LEARN_ROOT}"
+}
+
+function write_file() {
+    local target="$1"
+
+    mkdir -p "$(dirname "${target}")"
+    cat > "${target}"
+}
+
+function write_clean_fixture() {
+    write_file "${LEARN_ROOT}/learn_index.md" <<'EOF'
+## Active
+- [Repo layout](repo-layout.md) [stable] — Stable repo layout guidance.
+- [Default branch is main](default-branch-main.md) [stable] — Current default branch fact.
+
+## Needs Review
+- [Origin main recipe](origin-main-recipe.md) [drift_prone] — Revalidate this recipe before reuse.
+
+## Superseded
+- [Default branch is master](default-branch-is-master.md) [drift_prone] — Historical branch fact.
+
+## Archived
+- [Migration notes](migration-notes.md) [stable] — Historical migration notes.
+EOF
+
+    write_file "${LEARN_ROOT}/repo-layout.md" <<'EOF'
+---
+type: learn
+id: learn-repo-layout
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/default-branch-main.md" <<'EOF'
+---
+type: learn
+id: learn-default-branch-main
+owner: codex-main-worklog
+created_at: 2026-05-15T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+supersedes: default-branch-is-master.md
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/origin-main-recipe.md" <<'EOF'
+---
+type: learn
+id: learn-origin-main-recipe
+owner: codex-main-worklog
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: needs_review
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+review_after: 2099-01-01T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/default-branch-is-master.md" <<'EOF'
+---
+type: learn
+id: learn-default-branch-master
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: superseded
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+superseded_by: default-branch-main.md
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/migration-notes.md" <<'EOF'
+---
+type: learn
+id: learn-migration-notes
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: archived
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+}
+
+function write_mixed_fixture() {
+    write_file "${LEARN_ROOT}/learn_index.md" <<'EOF'
+## Active
+- [Default branch is main](default-branch-main.md) [stable] — Current default branch fact.
+- [Legacy branch note](legacy-branch-note.md) [stable] — Active legacy entry without new metadata.
+- [Origin main recipe](origin-main-recipe.md) [drift_prone] — Active drift-prone recipe that is overdue.
+- [Ghost entry](ghost-entry.md) [stable] — Indexed but missing on disk.
+
+## Needs Review
+- [Origin master recipe](origin-master-recipe.md) [drift_prone] — Historical recipe pending revalidation.
+
+## Superseded
+- [Default branch is master](default-branch-is-master.md) [drift_prone] — Historical branch fact.
+- [Broken master note](broken-master-note.md) [stable] — Superseded learn without a replacement.
+
+## Archived
+- [Migration notes](migration-notes.md) [stable] — Historical migration notes.
+EOF
+
+    write_file "${LEARN_ROOT}/default-branch-main.md" <<'EOF'
+---
+type: learn
+id: learn-default-branch-main
+owner: codex-main-worklog
+created_at: 2026-05-15T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+supersedes: default-branch-is-master.md
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/legacy-branch-note.md" <<'EOF'
+---
+type: learn
+id: learn-legacy-branch-note
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/origin-main-recipe.md" <<'EOF'
+---
+type: learn
+id: learn-origin-main-recipe
+owner: codex-main-worklog
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: drift_prone
+last_validated_at: 2026-05-10T00:00:00Z
+review_after: 2026-05-10T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/origin-master-recipe.md" <<'EOF'
+---
+type: learn
+id: learn-origin-master-recipe
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: needs_review
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+review_after: 2099-01-01T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/default-branch-is-master.md" <<'EOF'
+---
+type: learn
+id: learn-default-branch-master
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: superseded
+freshness: drift_prone
+last_validated_at: 2026-05-15T00:00:00Z
+superseded_by: default-branch-main.md
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/broken-master-note.md" <<'EOF'
+---
+type: learn
+id: learn-broken-master-note
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: superseded
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/migration-notes.md" <<'EOF'
+---
+type: learn
+id: learn-migration-notes
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: archived
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+
+    write_file "${LEARN_ROOT}/stray-note.md" <<'EOF'
+---
+type: learn
+id: learn-stray-note
+owner: codex-main-worklog
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-15T00:00:00Z
+validated: true
+apply_to:
+  - codex
+status: active
+freshness: stable
+last_validated_at: 2026-05-15T00:00:00Z
+---
+
+# Date
+
+2026-05-15
+EOF
+}
+
+@test "[common] codex_worklog_audit summary reports stale-learn findings deterministically" {
+    write_mixed_fixture
+
+    run python3 "${SCRIPT_PATH}" summary --learn-root "${LEARN_ROOT}" --now "${FIXED_NOW}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"active: 4"* ]]
+    [[ "${output}" == *"needs_review: 1"* ]]
+    [[ "${output}" == *"superseded: 2"* ]]
+    [[ "${output}" == *"archived: 1"* ]]
+    [[ "${output}" == *"origin-main-recipe.md (status=active review_after=2026-05-10T00:00:00Z)"* ]]
+    [[ "${output}" == *"legacy-branch-note.md -> missing status, freshness, last_validated_at"* ]]
+    [[ "${output}" == *"broken-master-note.md -> missing superseded_by"* ]]
+    [[ "${output}" == *"indexed file missing: ghost-entry.md"* ]]
+    [[ "${output}" == *"unindexed learn file: stray-note.md"* ]]
+}
+
+@test "[common] codex_worklog_audit check fails on startup-breaking stale-learn state" {
+    write_mixed_fixture
+
+    run python3 "${SCRIPT_PATH}" check --learn-root "${LEARN_ROOT}" --now "${FIXED_NOW}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"FAIL: startup-breaking worklog learn issues found."* ]]
+    [[ "${output}" == *"active entry missing metadata: legacy-branch-note.md -> missing status, freshness, last_validated_at"* ]]
+    [[ "${output}" == *"expired active review_after: origin-main-recipe.md (status=active review_after=2026-05-10T00:00:00Z)"* ]]
+    [[ "${output}" == *"broken supersession link: broken-master-note.md -> missing superseded_by"* ]]
+    [[ "${output}" == *"index/file mismatch: indexed file missing: ghost-entry.md"* ]]
+    [[ "${output}" == *"index/file mismatch: unindexed learn file: stray-note.md"* ]]
+}
+
+@test "[common] codex_worklog_audit check passes for a clean gated corpus" {
+    write_clean_fixture
+
+    run python3 "${SCRIPT_PATH}" check --learn-root "${LEARN_ROOT}" --now "${FIXED_NOW}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "OK: no startup-breaking worklog learn issues found." ]
+}

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -16,7 +16,7 @@ function write_file() {
 }
 
 function write_clean_fixture() {
-    write_file "${LEARN_ROOT}/learn_index.md" <<'EOF'
+    write_file "${LEARN_ROOT}/learn_index.md" << 'EOF'
 ## Active
 - [Repo layout](repo-layout.md) [stable] — Stable repo layout guidance.
 - [Default branch is main](default-branch-main.md) [stable] — Current default branch fact.
@@ -31,7 +31,7 @@ function write_clean_fixture() {
 - [Migration notes](migration-notes.md) [stable] — Historical migration notes.
 EOF
 
-    write_file "${LEARN_ROOT}/repo-layout.md" <<'EOF'
+    write_file "${LEARN_ROOT}/repo-layout.md" << 'EOF'
 ---
 type: learn
 id: learn-repo-layout
@@ -51,7 +51,7 @@ last_validated_at: 2026-05-15T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/default-branch-main.md" <<'EOF'
+    write_file "${LEARN_ROOT}/default-branch-main.md" << 'EOF'
 ---
 type: learn
 id: learn-default-branch-main
@@ -72,7 +72,7 @@ supersedes: default-branch-is-master.md
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/origin-main-recipe.md" <<'EOF'
+    write_file "${LEARN_ROOT}/origin-main-recipe.md" << 'EOF'
 ---
 type: learn
 id: learn-origin-main-recipe
@@ -93,7 +93,7 @@ review_after: 2099-01-01T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/default-branch-is-master.md" <<'EOF'
+    write_file "${LEARN_ROOT}/default-branch-is-master.md" << 'EOF'
 ---
 type: learn
 id: learn-default-branch-master
@@ -114,7 +114,7 @@ superseded_by: default-branch-main.md
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/migration-notes.md" <<'EOF'
+    write_file "${LEARN_ROOT}/migration-notes.md" << 'EOF'
 ---
 type: learn
 id: learn-migration-notes
@@ -136,7 +136,7 @@ EOF
 }
 
 function write_mixed_fixture() {
-    write_file "${LEARN_ROOT}/learn_index.md" <<'EOF'
+    write_file "${LEARN_ROOT}/learn_index.md" << 'EOF'
 ## Active
 - [Default branch is main](default-branch-main.md) [stable] — Current default branch fact.
 - [Legacy branch note](legacy-branch-note.md) [stable] — Active legacy entry without new metadata.
@@ -154,7 +154,7 @@ function write_mixed_fixture() {
 - [Migration notes](migration-notes.md) [stable] — Historical migration notes.
 EOF
 
-    write_file "${LEARN_ROOT}/default-branch-main.md" <<'EOF'
+    write_file "${LEARN_ROOT}/default-branch-main.md" << 'EOF'
 ---
 type: learn
 id: learn-default-branch-main
@@ -175,7 +175,7 @@ supersedes: default-branch-is-master.md
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/legacy-branch-note.md" <<'EOF'
+    write_file "${LEARN_ROOT}/legacy-branch-note.md" << 'EOF'
 ---
 type: learn
 id: learn-legacy-branch-note
@@ -192,7 +192,7 @@ apply_to:
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/origin-main-recipe.md" <<'EOF'
+    write_file "${LEARN_ROOT}/origin-main-recipe.md" << 'EOF'
 ---
 type: learn
 id: learn-origin-main-recipe
@@ -213,7 +213,7 @@ review_after: 2026-05-10T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/origin-master-recipe.md" <<'EOF'
+    write_file "${LEARN_ROOT}/origin-master-recipe.md" << 'EOF'
 ---
 type: learn
 id: learn-origin-master-recipe
@@ -234,7 +234,7 @@ review_after: 2099-01-01T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/default-branch-is-master.md" <<'EOF'
+    write_file "${LEARN_ROOT}/default-branch-is-master.md" << 'EOF'
 ---
 type: learn
 id: learn-default-branch-master
@@ -255,7 +255,7 @@ superseded_by: default-branch-main.md
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/broken-master-note.md" <<'EOF'
+    write_file "${LEARN_ROOT}/broken-master-note.md" << 'EOF'
 ---
 type: learn
 id: learn-broken-master-note
@@ -275,7 +275,7 @@ last_validated_at: 2026-05-15T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/migration-notes.md" <<'EOF'
+    write_file "${LEARN_ROOT}/migration-notes.md" << 'EOF'
 ---
 type: learn
 id: learn-migration-notes
@@ -295,7 +295,7 @@ last_validated_at: 2026-05-15T00:00:00Z
 2026-05-15
 EOF
 
-    write_file "${LEARN_ROOT}/stray-note.md" <<'EOF'
+    write_file "${LEARN_ROOT}/stray-note.md" << 'EOF'
 ---
 type: learn
 id: learn-stray-note


### PR DESCRIPTION
## Summary
- make `worklog_manager` a thin wrapper that explicitly loads the shared `~/.agents/skills/worklog-manager` skill, with a repository fallback
- move stale-learn hard-gating rules and audit guidance into the shared skill, reference file, and bundled `codex_worklog_audit.py` helper
- require `codex_worklog_audit.py check` during startup whenever `learn_index.md` exists, and fail hard instead of falling back to best-effort learn selection
- add bats coverage for the shared-skill wiring, the mandatory startup-audit gate, and deterministic audit-helper behavior

## Validation
- `uv run --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" home/dot_config/exact_agents/skills/worklog-manager`
- `python3 -m py_compile home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py`
- `git diff --check`
- direct smoke tests of `codex_worklog_audit.py summary/check`
- `shfmt -i 4 -sr -d tests/install/common/codex_worklog_audit.bats`

## Notes
- `codex_worklog_audit.py summary` is now positioned as a diagnosis/manual-review tool after the startup gate, not a substitute for the mandatory startup `check`.
- Local `bats` was intentionally skipped per repository policy; GitHub Actions is the source of truth for bats validation.