### PR TITLE
chore(agents): ignore .config/agents apply target

### DIFF
--- a/home/.chezmoitemplates/chezmoiignore.d/common
+++ b/home/.chezmoitemplates/chezmoiignore.d/common
@@ -8,7 +8,7 @@ plugin.jupyterlab-settings
 .agents/README.md
 .claude/README.md
 .codex/README.md
-.config/agents/README.md
+.config/agents
 .config/sheldon/plugin_sources
 .config/claude
 .config/codex

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -291,7 +291,7 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
 }
 
-@test "[common] layout readmes stay repo-only" {
+@test "[common] layout docs and adapter-only config paths stay repo-only" {
     [ -f "${CHEZMOIIGNORE_PATH}" ]
 
     run grep -Fx ".agents/README.md" "${CHEZMOIIGNORE_PATH}"
@@ -300,6 +300,6 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -Fx ".codex/README.md" "${CHEZMOIIGNORE_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -Fx ".config/agents/README.md" "${CHEZMOIIGNORE_PATH}"
+    run grep -Fx ".config/agents" "${CHEZMOIIGNORE_PATH}"
     [ "${status}" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- ignore `.config/agents` as an adapter-only apply target
- align the generated home config handling with `.config/codex` and `.config/claude`
- update the guidance test to assert the directory-level ignore entry

## Testing
- `git diff --check`
- Not run: local `bats` tests (repository policy; validated via GitHub Actions)
