### PR TITLE
docs(codex): define PR description structure

### DIFF
--- a/home/dot_config/codex/agents/gh-workflow-manager.toml
+++ b/home/dot_config/codex/agents/gh-workflow-manager.toml
@@ -38,7 +38,13 @@ Workflow:
   - avoid any other file changes
 - Use Conventional Commit format for commit messages: `<type>(<scope>): <summary>`.
 - Pull request titles and descriptions must be English.
-- When creating or updating a PR, describe the full current PR, not only the latest delta.
+- When creating or updating a PR, first check whether the repository provides a pull request template and follow that structure when present.
+- If no pull request template is available, use this default PR description structure:
+  - `## Why`
+  - `## What Changed`
+  - `## Validation`
+- In either case, describe the full current PR, not only the latest delta.
+- Keep the `Validation` section repo-relative and never include local absolute paths.
 - After any additional push, inspect the updated commits/diff and refresh the PR description so it matches the full current PR.
 - After pushing, check GitHub Actions / checks and continue until all required checks pass or a failure requires parent/user intervention.
 - Do not run local `bats`; rely on GitHub Actions for `bats` validation.

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -208,6 +208,27 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -ne 0 ]
 }
 
+@test "[common] codex GitHub workflow defines PR description structure and template priority" {
+    run grep -F 'first check whether the repository provides a pull request template and follow that structure when present' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'If no pull request template is available, use this default PR description structure:' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '  - `## Why`' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '  - `## What Changed`' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '  - `## Validation`' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'In either case, describe the full current PR, not only the latest delta.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Keep the `Validation` section repo-relative and never include local absolute paths.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] layout readmes describe the adapter and canonical layout" {
     [ -f "${AGENTS_README_PATH}" ]
     [ -f "${CLAUDE_README_PATH}" ]


### PR DESCRIPTION
## Why
- Make PR descriptions easier to scan and explain the rationale consistently.
- Respect repository-provided pull request templates when a repo defines one.

## What Changed
- Updated `gh_workflow_manager` guidance to check for a pull request template before composing the PR body.
- Added the default fallback sections `## Why`, `## What Changed`, and `## Validation` when no template is available.
- Required the `Validation` section to stay repo-relative and avoid local absolute paths.
- Added `tests/install/common/agents_guidance.bats` coverage for the new PR description rules.

## Validation
- `git diff --check`
- Local `bats` not run per repository policy; GitHub Actions is the validation path for `bats` coverage.
