### PR TITLE
docs(worklog-manager): add session override conflict contract

### DIFF
--- a/home/dot_config/codex/agents/worklog-manager.toml
+++ b/home/dot_config/codex/agents/worklog-manager.toml
@@ -26,5 +26,37 @@ Bootstrap:
 Output to parent:
 - Keep responses concise.
 - For the startup summary, use exactly these sections in this order: `Active learnings`, `Needs revalidation`, `Ignored historical entries`.
+- Conflict reports are a separate parent-facing contract, not a close-out summary.
+- When a later user direction conflicts with a startup fact, a current plan assumption, or an unfinished todo, return this exact contract and include every line shown below:
+  ```text
+  CONFLICT_REPORT
+  source_type: startup_fact|plan_assumption|todo
+  source_ref: <learn filename | plan section | todo line>
+  old_statement: <current assumption>
+  user_request: <new direction>
+  rationale: <why this is a direction change instead of a minor refinement>
+  proposed_session_action: ignore_for_session|rewrite_plan_todo
+  learn_update: pending_revalidation
+  ```
+- Wait for one of these parent responses before changing session state:
+  ```text
+  CONFIRM_OVERRIDE
+  source_ref: <same value>
+  approved_action: rewrite_plan_todo
+  ```
+  ```text
+  REJECT_OVERRIDE
+  source_ref: <same value>
+  keep_existing_assumption: true
+  ```
+  ```text
+  NEEDS_USER_CLARIFICATION
+  source_ref: <same value>
+  clarification_question: <short question>
+  ```
+- Do not write `.agents/worklog/codex/**` before confirmation.
+- Until `CONFIRM_OVERRIDE`, keep plan/todo unchanged.
+- Do not generate user-facing wording for this path; return parent-facing status only.
+- Persistent learn updates stay at `pending_revalidation` until separate revalidation evidence exists.
 - When the parent asks for a close-out summary, return a one-line candidate that starts with `📝 まとめ:`.
 """

--- a/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/SKILL.md
@@ -55,6 +55,74 @@ It keeps startup context constrained to valid learn entries, maintains plan/todo
      `- [Title](file.md) [stable|drift_prone] — Summary`
 5. When learn changes affect the active plan, update the plan `Assumptions`, `Design`, or `Tests` sections to match.
 
+## Conflict Handling
+
+Use this flow only when a later user direction conflicts with the current session facts.
+For this workflow, `startup facts` means only the learn entries listed under the startup summary `Active learnings`.
+`Needs revalidation`, `## Needs Review`, and any `active` learn with `freshness: drift_prone` are context only and are not `startup facts`.
+
+The conflict detection scope is limited to:
+
+- `startup facts`
+- current plan `Assumptions`
+- unfinished todo items
+
+When a later user message conflicts with one of those sources:
+
+1. Identify the exact source that is being contradicted.
+2. Return `CONFLICT_REPORT` to the parent.
+3. Wait for `CONFIRM_OVERRIDE`, `REJECT_OVERRIDE`, or `NEEDS_USER_CLARIFICATION`.
+4. Rewrite session-local plan/todo state only after `CONFIRM_OVERRIDE`.
+5. Do not update persistent learn state at this stage.
+6. If you later record this session outcome in a learn file, use `Plan Updates` to note that it is a corpus migration candidate only after revalidation evidence exists.
+
+The audit validates corpus integrity, not parent confirmation flow.
+
+Use these parent-facing message contracts:
+
+```text
+CONFLICT_REPORT
+source_type: startup_fact|plan_assumption|todo
+source_ref: <learn filename | plan section | todo line>
+old_statement: <current assumption>
+user_request: <new direction>
+rationale: <why this is a direction change instead of a minor refinement>
+proposed_session_action: ignore_for_session|rewrite_plan_todo
+learn_update: pending_revalidation
+```
+
+```text
+CONFIRM_OVERRIDE
+source_ref: <same value>
+approved_action: rewrite_plan_todo
+```
+
+```text
+REJECT_OVERRIDE
+source_ref: <same value>
+keep_existing_assumption: true
+```
+
+```text
+NEEDS_USER_CLARIFICATION
+source_ref: <same value>
+clarification_question: <short question>
+```
+
+Do not write `.agents/worklog/codex/**` before confirmation.
+
+After `CONFIRM_OVERRIDE`, rewrite `.agents/worklog/codex/**` with these rules:
+
+- `User Prompt` update: append the user message that changed direction.
+- `Assumptions` note: keep the old assumption, but annotate it with `Superseded in this session by user direction on YYYY-MM-DD`.
+- `Design` update: add the new direction.
+- `Open Questions` revalidation note: add one line when persistent learn revalidation is still needed.
+- `TODO` rewrite: move unfinished items that depend on the old assumption to `# Done`, mark the individual line as superseded after the confirmed direction change, do not replace them with the literal line `[x] Superseded by confirmed direction change`, and add replacement work under `# TODO`.
+- Keep top-level `todo.status` as `active` because the session is still in progress.
+
+If the parent responds with `REJECT_OVERRIDE`, keep plan/todo unchanged and tell the parent `existing assumption kept`.
+If the parent responds with `NEEDS_USER_CLARIFICATION`, keep plan/todo unchanged and wait for the parent's clarification flow.
+
 ## Learn Promotion Gate
 
 - Do not promote session-local facts, current branch names, current paths, default-branch names, or any repo state that is cheap to re-check right now.

--- a/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
+++ b/home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md
@@ -140,6 +140,20 @@ supersedes: default-branch-is-master.md
 - If an older recipe assumes `origin/master`, move it to `Needs Review` until it is revalidated on the current `main` workflow.
 - Drift-prone repo state should stay out of `Active` unless it has a fresh validation date and a review deadline.
 
+## Session-local override
+
+- Session-local override is not a corpus migration.
+- User direction alone must not move a learn entry to `needs_review` or `superseded`.
+- A confirmed override still keeps persistent learn state unchanged until repo, system, or execution evidence exists.
+- When a confirmed override plus revalidation evidence shows an `active` learn is obsolete, move it in the next corpus update to `needs_review` or `superseded`.
+- Session-local overrides are governed by the conflict contract, not by audit.
+
+```yaml
+trigger: user asks for a different workflow than the startup fact assumes
+immediate_action: session-local override only
+persistent_action: defer until revalidation evidence exists
+```
+
 ## Audit Contract
 
 `scripts/codex_worklog_audit.py summary` reports:

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -153,6 +153,20 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F '`Active learnings`, `Needs revalidation`, `Ignored historical entries`' "${CODEX_WORKLOG_AGENT_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F 'CONFLICT_REPORT' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'source_type: startup_fact|plan_assumption|todo' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'CONFIRM_OVERRIDE' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'REJECT_OVERRIDE' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'NEEDS_USER_CLARIFICATION' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Do not write `.agents/worklog/codex/**` before confirmation.' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'pending_revalidation' "${CODEX_WORKLOG_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
 
     run grep -F 'Required `learn` keys:' "${CODEX_WORKLOG_AGENT_PATH}"
     [ "${status}" -ne 0 ]
@@ -191,6 +205,26 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
     run grep -F '`Ignored historical entries`' "${CODEX_WORKLOG_SKILL_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F '`startup facts`' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'are context only and are not `startup facts`.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'CONFLICT_REPORT' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'source_type: startup_fact|plan_assumption|todo' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'CONFIRM_OVERRIDE' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'REJECT_OVERRIDE' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'NEEDS_USER_CLARIFICATION' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Do not write `.agents/worklog/codex/**` before confirmation.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'learn_update: pending_revalidation' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'The audit validates corpus integrity, not parent confirmation flow.' "${CODEX_WORKLOG_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
     run grep -F '`status` must be one of `active | needs_review | superseded | archived`.' "${CODEX_WORKLOG_SKILL_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`freshness: drift_prone` requires `review_after`.' "${CODEX_WORKLOG_SKILL_PATH}"
@@ -208,6 +242,10 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     run grep -F 'stop startup and return the exact audit failures to the parent instead of falling back to best-effort learn selection' "${CODEX_WORKLOG_RULES_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`origin/master`' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Session-local override is not a corpus migration.' "${CODEX_WORKLOG_RULES_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Session-local overrides are governed by the conflict contract, not by audit.' "${CODEX_WORKLOG_RULES_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F 'default_prompt: "Use $worklog-manager to manage Codex worklog files and audit stale learn metadata."' "${CODEX_WORKLOG_SKILL_OPENAI_PATH}"
     [ "${status}" -eq 0 ]

--- a/tests/install/common/codex_worklog_audit.bats
+++ b/tests/install/common/codex_worklog_audit.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 readonly SCRIPT_PATH="./home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py"
+readonly SKILL_PATH="./home/dot_config/exact_agents/skills/worklog-manager/SKILL.md"
+readonly RULES_PATH="./home/dot_config/exact_agents/skills/worklog-manager/references/learn_rules.md"
 readonly FIXED_NOW="2026-05-15T00:00:00Z"
 
 function setup() {
@@ -351,4 +353,12 @@ EOF
     run python3 "${SCRIPT_PATH}" check --learn-root "${LEARN_ROOT}" --now "${FIXED_NOW}"
     [ "${status}" -eq 0 ]
     [ "${output}" = "OK: no startup-breaking worklog learn issues found." ]
+}
+
+@test "[common] conflict handling stays outside codex_worklog_audit responsibilities" {
+    run grep -F 'The audit validates corpus integrity, not parent confirmation flow.' "${SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Session-local overrides are governed by the conflict contract, not by audit.' "${RULES_PATH}"
+    [ "${status}" -eq 0 ]
 }

--- a/tests/install/common/fixtures/worklog_manager_conflict_contract/confirmed_override_prompt.txt
+++ b/tests/install/common/fixtures/worklog_manager_conflict_contract/confirmed_override_prompt.txt
@@ -1,0 +1,7 @@
+confirmed-override::CONFIRM_OVERRIDE
+confirmed-override::`User Prompt` update
+confirmed-override::`Assumptions` note
+confirmed-override::`Design` update
+confirmed-override::`Open Questions` revalidation note
+confirmed-override::`TODO` rewrite
+confirmed-override::Keep top-level `todo.status` as `active`

--- a/tests/install/common/fixtures/worklog_manager_conflict_contract/startup_conflict_prompt.txt
+++ b/tests/install/common/fixtures/worklog_manager_conflict_contract/startup_conflict_prompt.txt
@@ -1,0 +1,9 @@
+conflict-report::source_type: startup_fact|plan_assumption|todo
+conflict-report::CONFLICT_REPORT
+conflict-report::source_ref
+conflict-report::proposed_session_action: ignore_for_session|rewrite_plan_todo
+conflict-report::learn_update: pending_revalidation
+conflict-report::Do not write `.agents/worklog/codex/**` before confirmation.
+clarification-rejection::NEEDS_USER_CLARIFICATION
+clarification-rejection::REJECT_OVERRIDE
+clarification-rejection::plan/todo unchanged

--- a/tests/install/common/worklog_manager_conflict_contract.bats
+++ b/tests/install/common/worklog_manager_conflict_contract.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+readonly CODEX_WORKLOG_AGENT_PATH="./home/dot_config/codex/agents/worklog-manager.toml"
+readonly CODEX_WORKLOG_SKILL_PATH="./home/dot_config/exact_agents/skills/worklog-manager/SKILL.md"
+readonly STARTUP_CONFLICT_FIXTURE="./tests/install/common/fixtures/worklog_manager_conflict_contract/startup_conflict_prompt.txt"
+readonly CONFIRMED_OVERRIDE_FIXTURE="./tests/install/common/fixtures/worklog_manager_conflict_contract/confirmed_override_prompt.txt"
+
+function combined_worklog_contract_text() {
+    printf '%s\n%s\n' "$(< "${CODEX_WORKLOG_SKILL_PATH}")" "$(< "${CODEX_WORKLOG_AGENT_PATH}")"
+}
+
+function assert_fixture_group_present() {
+    local fixture="$1"
+    local group_name="$2"
+    local haystack="$3"
+    local entry=""
+    local group=""
+    local found=0
+    local token=""
+
+    while IFS= read -r entry; do
+        [ -n "${entry}" ] || continue
+        group="${entry%%::*}"
+        token="${entry#*::}"
+        [ "${group}" = "${group_name}" ] || continue
+        found=1
+
+        if [[ "${haystack}" != *"${token}"* ]]; then
+            echo "missing ${group_name} token: ${token}"
+            return 1
+        fi
+    done < "${fixture}"
+
+    [ "${found}" -eq 1 ]
+}
+
+@test "[common] worklog conflict report contract defers writes until confirmation" {
+    local combined_text
+    combined_text="$(combined_worklog_contract_text)"
+
+    assert_fixture_group_present "${STARTUP_CONFLICT_FIXTURE}" "conflict-report" "${combined_text}"
+}
+
+@test "[common] confirmed override contract rewrites plan and todo session-locally" {
+    local combined_text
+    combined_text="$(combined_worklog_contract_text)"
+
+    assert_fixture_group_present "${CONFIRMED_OVERRIDE_FIXTURE}" "confirmed-override" "${combined_text}"
+}
+
+@test "[common] rejection and clarification leave plan and todo unchanged" {
+    local combined_text
+    combined_text="$(combined_worklog_contract_text)"
+
+    assert_fixture_group_present "${STARTUP_CONFLICT_FIXTURE}" "clarification-rejection" "${combined_text}"
+}


### PR DESCRIPTION
## Why

`worklog-manager` needs an explicit parent confirmation flow when startup facts conflict with fresh user intent so it does not silently rewrite session state or blur session-local overrides into durable learn migrations.

## What Changed

- added a parent-facing `CONFLICT_REPORT` / `CONFIRM_OVERRIDE` / `REJECT_OVERRIDE` / `NEEDS_USER_CLARIFICATION` contract to `home/dot_config/codex/agents/worklog-manager.toml`
- updated the `worklog-manager` skill guidance and `references/learn_rules.md` to define startup-fact conflicts, session-local override handling, and the boundary between audit responsibilities and parent confirmation flow
- expanded `tests/install/common/agents_guidance.bats` and `tests/install/common/codex_worklog_audit.bats`, and added fixture-backed coverage in `tests/install/common/worklog_manager_conflict_contract.bats`

## Validation

- `python3 home/dot_config/exact_agents/skills/worklog-manager/scripts/codex_worklog_audit.py check --learn-root .agents/worklog/codex/learn` (completed before GitHub workflow handoff)
- `python3 -c "import pathlib,tomllib; tomllib.load(pathlib.Path('home/dot_config/codex/agents/worklog-manager.toml').open('rb'))"`
- `git diff --check`
- Local `bats` intentionally not run; GitHub Actions is the validation path in this repository.
