### PR TITLE
chore: add dust to mise tools

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -33,6 +33,7 @@ shfmt = "latest"
 "github:shuntaka9576/blocc" = { version = "latest", os = ["linux"] }
 
 "cargo:pueue" = "latest"
+dust = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]


### PR DESCRIPTION
## Why
- install `dust` via `mise` alongside the other CLI tools

## What Changed
- add `dust = "latest"` to `home/dot_mise/config.toml`

## Validation
- `git diff --check`
- parse `home/dot_mise/config.toml` with Python `tomllib`