### PR TITLE
Clarify chezmoi exact_ semantics in exact_agents guidance

### DIFF
--- a/home/dot_config/exact_agents/README.md
+++ b/home/dot_config/exact_agents/README.md
@@ -1,9 +1,8 @@
-- In this repo, this directory is the editable shared source for agent guidance that is exposed as `~/.agents` through adapter templates.
-- The `exact_` segment in this path is a chezmoi source-state attribute, not a generic "canonical source" naming convention. See the official chezmoi reference for [Source state attributes](https://www.chezmoi.io/reference/source-state-attributes/).
-- In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` removes entries in the target directory that are not explicitly managed in the source state.
-- This repo does not apply `.config/agents` directly: [home/.chezmoitemplates/chezmoiignore.d/common](../../.chezmoitemplates/chezmoiignore.d/common) ignores that target, while [home/exact_dot_agents/](../../exact_dot_agents/) provides the home-facing `~/.agents` adapter.
-- [AGENTS.md](AGENTS.md) is the shared guidance used directly by `~/.agents/AGENTS.md`, imported from `~/.claude/CLAUDE.md` with `@~/.agents/AGENTS.md`, and read first from `~/.codex/AGENTS.md` before `~/.codex/AGENTS.codex-only.md`.
-- Edit files here; the adapter keeps the home path stable.
+In this repo, this directory is the editable shared source for agent guidance that is exposed as `~/.agents` through adapter templates. The `exact_` segment in this path is a chezmoi source-state attribute, not a generic "canonical source" naming convention. See the official chezmoi reference for [Source state attributes](https://www.chezmoi.io/reference/source-state-attributes/).
+
+In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` removes entries in the target directory that are not explicitly managed in the source state. This repo does not apply `.config/agents` directly: [home/.chezmoitemplates/chezmoiignore.d/common](../../.chezmoitemplates/chezmoiignore.d/common) ignores that target, while [home/exact_dot_agents/](../../exact_dot_agents/) provides the home-facing `~/.agents` adapter.
+
+[AGENTS.md](AGENTS.md) is the shared guidance used directly by `~/.agents/AGENTS.md`, imported from `~/.claude/CLAUDE.md` with `@~/.agents/AGENTS.md`, and read first from `~/.codex/AGENTS.md` before `~/.codex/AGENTS.codex-only.md`. Edit files here; the adapter keeps the home path stable.
 
 The diagram below describes this repository's source-of-truth layout, not the meaning of chezmoi's `exact_` attribute itself.
 

--- a/home/dot_config/exact_agents/README.md
+++ b/home/dot_config/exact_agents/README.md
@@ -1,8 +1,11 @@
-- This directory is the canonical source for `~/.agents`.
+- In this repo, this directory is the editable shared source for agent guidance that is exposed as `~/.agents` through adapter templates.
+- The `exact_` segment in this path is a chezmoi source-state attribute, not a generic "canonical source" naming convention. See the official chezmoi reference for [Source state attributes](https://www.chezmoi.io/reference/source-state-attributes/).
+- In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` removes entries in the target directory that are not explicitly managed in the source state.
+- This repo does not apply `.config/agents` directly: [home/.chezmoitemplates/chezmoiignore.d/common](../../.chezmoitemplates/chezmoiignore.d/common) ignores that target, while [home/exact_dot_agents/](../../exact_dot_agents/) provides the home-facing `~/.agents` adapter.
 - [AGENTS.md](AGENTS.md) is the shared guidance used directly by `~/.agents/AGENTS.md`, imported from `~/.claude/CLAUDE.md` with `@~/.agents/AGENTS.md`, and read first from `~/.codex/AGENTS.md` before `~/.codex/AGENTS.codex-only.md`.
-- [home/exact_dot_agents/](../../exact_dot_agents/) is only the adapter layer that exposes this source in the applied home layout.
-- The design keeps edits in one git-friendly place while preserving the familiar home path.
 - Edit files here; the adapter keeps the home path stable.
+
+The diagram below describes this repository's source-of-truth layout, not the meaning of chezmoi's `exact_` attribute itself.
 
 ## Layout Overview
 

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -339,6 +339,18 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
 
     run grep -F "~/.agents" "${CANONICAL_AGENTS_README_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F 'The `exact_` segment in this path is a chezmoi source-state attribute' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'https://www.chezmoi.io/reference/source-state-attributes/' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'dot_` changes a target name to start with `.`' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'exact_` removes entries in the target directory that are not explicitly managed in the source state' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '.config/agents' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '../../.chezmoitemplates/chezmoiignore.d/common' "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
     run grep -F "../../exact_dot_agents/" "${CANONICAL_AGENTS_README_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F 'read first from `~/.codex/AGENTS.md` before `~/.codex/AGENTS.codex-only.md`' "${CANONICAL_AGENTS_README_PATH}"
@@ -348,6 +360,8 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     run grep -F "AGENTS.codex-only.md" "${CANONICAL_AGENTS_README_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F "keeps the home path stable" "${CANONICAL_AGENTS_README_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F "The diagram below describes this repository's source-of-truth layout" "${CANONICAL_AGENTS_README_PATH}"
     [ "${status}" -eq 0 ]
 
     run grep -F "~/.claude" "${CANONICAL_CLAUDE_README_PATH}"


### PR DESCRIPTION
## Why
- Clarify that the `exact_` segment in `home/dot_config/exact_agents` comes from chezmoi source-state attributes, not a repo-specific naming convention.
- Keep the shared `exact_agents` README and its bats contract aligned on the source-versus-adapter explanation.

## What Changed
- Updated `home/dot_config/exact_agents/README.md` to explain `dot_` and `exact_`, link to the chezmoi source-state attributes reference, and distinguish the ignored `.config/agents` target from the `home/exact_dot_agents` adapter.
- Added assertions to `tests/install/common/agents_guidance.bats` so the README wording stays explicit about chezmoi semantics and this repo's adapter layout.

## Validation
- `git diff --check -- home/dot_config/exact_agents/README.md tests/install/common/agents_guidance.bats`
- Reviewed the scoped README and bats content changes; no local `bats` execution was performed.