### PR TITLE
Add canonical cmux and Ghostty config layouts

### DIFF
--- a/home/.chezmoitemplates/chezmoiignore.d/common
+++ b/home/.chezmoitemplates/chezmoiignore.d/common
@@ -4,6 +4,8 @@ plugin.jupyterlab-settings
 
 .mise
 .uv
+.cmux
+.ghostty
 .tmux.conf.d/
 .agents/README.md
 .claude/README.md

--- a/home/dot_cmux/private_cmux.json
+++ b/home/dot_cmux/private_cmux.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+  "schemaVersion": 1,
+
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when ~/.config/cmux/cmux.json is missing.
+  // Legacy settings.json files are read only as fallback for keys not present here.
+
+  //   "app" : {
+  //     "appearance" : "system",
+  //     "appIcon" : "automatic",
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "focusPaneOnFirstClick" : false,
+  //     "iMessageMode" : false,
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "language" : "system",
+  //     "menuBarOnly" : false,
+  //     "minimalMode" : false,
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "openMarkdownInCmuxViewer" : false,
+  //     "preferredEditor" : "",
+  //     "renameSelectsExistingName" : true,
+  //     "reorderOnNotification" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "warnBeforeQuit" : true
+  //   },
+
+  //   "terminal" : {
+  //     "showScrollBar" : true
+  //   },
+
+  //   "notifications" : {
+  //     "command" : "",
+  //     "customSoundFilePath" : "",
+  //     "dockBadge" : true,
+  //     "paneFlash" : true,
+  //     "showInMenuBar" : true,
+  //     "sound" : "default",
+  //     "unreadPaneRing" : true
+  //   },
+
+  //   "sidebar" : {
+  //     "branchLayout" : "vertical",
+  //     "hideAllDetails" : false,
+  //     "makePullRequestsClickable" : true,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showBranchDirectory" : true,
+  //     "showCustomMetadata" : true,
+  //     "showLog" : true,
+  //     "showNotificationMessage" : true,
+  //     "showPorts" : true,
+  //     "showProgress" : true,
+  //     "showPullRequests" : true,
+  //     "showSSH" : true
+  //   },
+
+  //   "workspaceColors" : {
+  //     "colors" : {
+  //       "Amber" : "#7D6608",
+  //       "Aqua" : "#0E6B8C",
+  //       "Blue" : "#1565C0",
+  //       "Brown" : "#7B3F00",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Crimson" : "#922B21",
+  //       "Green" : "#196F3D",
+  //       "Indigo" : "#283593",
+  //       "Magenta" : "#AD1457",
+  //       "Navy" : "#1A5276",
+  //       "Olive" : "#4A5C18",
+  //       "Orange" : "#A04000",
+  //       "Purple" : "#6A1B9A",
+  //       "Red" : "#C0392B",
+  //       "Rose" : "#880E4F",
+  //       "Teal" : "#006B6B"
+  //     },
+  //     "indicatorStyle" : "leftRail",
+  //     "notificationBadgeColor" : null,
+  //     "selectionColor" : null
+  //   },
+
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "lightModeTintColor" : null,
+  //     "matchTerminalBackground" : false,
+  //     "tintColor" : "#000000",
+  //     "tintOpacity" : 0.17999999999999999
+  //   },
+
+  //   "automation" : {
+  //     "claudeBinaryPath" : "",
+  //     "claudeCodeIntegration" : true,
+  //     "cursorIntegration" : true,
+  //     "geminiIntegration" : true,
+  //     "portBase" : 9100,
+  //     "portRange" : 10,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "socketPassword" : ""
+  //   },
+
+  //   "browser" : {
+  //     "defaultSearchEngine" : "google",
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  //
+  //     ],
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ],
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "reactGrabVersion" : "0.1.29",
+  //     "showImportHintOnBlankTabs" : true,
+  //     "showSearchSuggestions" : true,
+  //     "theme" : "system",
+  //     "urlsToAlwaysOpenExternally" : [
+  //
+  //     ]
+  //   },
+
+  //   "shortcuts" : {
+  //     "bindings" : {
+  //       "browserBack" : "cmd+[",
+  //       "browserForward" : "cmd+]",
+  //       "browserReload" : "cmd+r",
+  //       "browserZoomIn" : "cmd+=",
+  //       "browserZoomOut" : "cmd+-",
+  //       "browserZoomReset" : "cmd+0",
+  //       "closeOtherTabsInPane" : "cmd+opt+t",
+  //       "closeTab" : "cmd+w",
+  //       "closeWindow" : "cmd+ctrl+w",
+  //       "closeWorkspace" : "cmd+shift+w",
+  //       "commandPalette" : "cmd+shift+p",
+  //       "commandPaletteNext" : "ctrl+n",
+  //       "commandPalettePrevious" : "ctrl+p",
+  //       "editWorkspaceDescription" : "cmd+opt+e",
+  //       "equalizeSplits" : "cmd+ctrl+=",
+  //       "find" : "cmd+f",
+  //       "findInDirectory" : "cmd+shift+f",
+  //       "findNext" : "cmd+g",
+  //       "findPrevious" : "cmd+opt+g",
+  //       "focusBrowserAddressBar" : "cmd+l",
+  //       "focusDown" : "cmd+opt+↓",
+  //       "focusLeft" : "cmd+opt+←",
+  //       "focusRight" : "cmd+opt+→",
+  //       "focusRightSidebar" : "cmd+shift+e",
+  //       "focusUp" : "cmd+opt+↑",
+  //       "goToWorkspace" : "cmd+p",
+  //       "hideFind" : "cmd+shift+opt+f",
+  //       "jumpToUnread" : "cmd+shift+u",
+  //       "newSurface" : "cmd+t",
+  //       "newTab" : "cmd+n",
+  //       "newWindow" : "cmd+shift+n",
+  //       "nextSidebarTab" : "cmd+ctrl+]",
+  //       "nextSurface" : "cmd+shift+]",
+  //       "openBrowser" : "cmd+shift+l",
+  //       "openFolder" : "cmd+o",
+  //       "openSettings" : "cmd+,",
+  //       "prevSidebarTab" : "cmd+ctrl+[",
+  //       "prevSurface" : "cmd+shift+[",
+  //       "quit" : "cmd+q",
+  //       "reloadConfiguration" : "cmd+shift+,",
+  //       "renameTab" : "cmd+r",
+  //       "renameWorkspace" : "cmd+shift+r",
+  //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+  //       "reopenPreviousSession" : "cmd+shift+o",
+  //       "saveFilePreview" : "cmd+s",
+  //       "selectSurfaceByNumber" : "ctrl+1",
+  //       "selectWorkspaceByNumber" : "cmd+1",
+  //       "sendFeedback" : "cmd+opt+f",
+  //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+  //       "showHideAllWindows" : "cmd+opt+ctrl+.",
+  //       "showNotifications" : "cmd+i",
+  //       "splitBrowserDown" : "cmd+shift+opt+d",
+  //       "splitBrowserRight" : "cmd+opt+d",
+  //       "splitDown" : "cmd+shift+d",
+  //       "splitRight" : "cmd+d",
+  //       "switchRightSidebarToDock" : "ctrl+5",
+  //       "switchRightSidebarToFeed" : "ctrl+4",
+  //       "switchRightSidebarToFiles" : "ctrl+1",
+  //       "switchRightSidebarToFind" : "ctrl+2",
+  //       "switchRightSidebarToSessions" : "ctrl+3",
+  //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+  //       "toggleFileExplorer" : "cmd+opt+b",
+  //       "toggleFullScreen" : "cmd+ctrl+f",
+  //       "toggleReactGrab" : "cmd+shift+g",
+  //       "toggleSidebar" : "cmd+b",
+  //       "toggleSplitZoom" : "cmd+shift+\r",
+  //       "toggleTerminalCopyMode" : "cmd+shift+m",
+  //       "triggerFlash" : "cmd+shift+h",
+  //       "useSelectionForFind" : "cmd+e"
+  //     },
+  //     "showModifierHoldHints" : true
+  //   },
+}

--- a/home/dot_config/cmux/symlink_cmux.json.tmpl
+++ b/home/dot_config/cmux/symlink_cmux.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_cmux/private_cmux.json

--- a/home/dot_config/ghostty/symlink_config.tmpl
+++ b/home/dot_config/ghostty/symlink_config.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_ghostty/config

--- a/home/dot_ghostty/config
+++ b/home/dot_ghostty/config
@@ -1,0 +1,30 @@
+theme = iTerm2 Default
+maximize = true
+initial-window = false
+
+window-theme = "ghostty"
+window-padding-balance = true
+
+font-family = RobotoMono Nerd Font Mono
+font-size = 12
+font-thicken
+font-feature = "-calt"
+font-feature = "-dlig"
+font-feature = "-liga"
+
+cursor-style = block
+cursor-style-blink = true
+
+background = #000000
+background-opacity = 0.8
+
+quick-terminal-size = 100%,100%
+quick-terminal-animation-duration = 0
+
+keybind = global:ctrl+t=toggle_quick_terminal
+
+term = "xterm-256color"
+shell-integration-features = no-cursor
+
+macos-titlebar-style = hidden
+macos-non-native-fullscreen = true

--- a/tests/install/common/cmux.bats
+++ b/tests/install/common/cmux.bats
@@ -13,7 +13,7 @@ readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
     [ ! -e "${LEGACY_CMUX_SYMLINK_TEMPLATE}" ]
     [ "$(< "${CMUX_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_cmux/private_cmux.json" ]
 
-    run grep -F '".config/cmux/cmux.json is missing.' "${CMUX_PAYLOAD_PATH}"
+    run grep -F 'cmux creates this template on launch when ~/.config/cmux/cmux.json is missing.' "${CMUX_PAYLOAD_PATH}"
     [ "${status}" -eq 0 ]
 }
 

--- a/tests/install/common/cmux.bats
+++ b/tests/install/common/cmux.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+readonly CMUX_PAYLOAD_PATH="./home/dot_cmux/private_cmux.json"
+readonly CMUX_SYMLINK_TEMPLATE="./home/dot_config/cmux/symlink_cmux.json.tmpl"
+readonly LEGACY_CMUX_PAYLOAD_PATH="./home/dot_config/cmux/private_cmux.json"
+readonly LEGACY_CMUX_SYMLINK_TEMPLATE="./home/dot_config/cmux/symlink_private_cmux.json.tmpl"
+readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
+
+@test "[common] cmux config payload lives under dot_cmux and is exposed via a config symlink template" {
+    [ -f "${CMUX_PAYLOAD_PATH}" ]
+    [ -f "${CMUX_SYMLINK_TEMPLATE}" ]
+    [ ! -e "${LEGACY_CMUX_PAYLOAD_PATH}" ]
+    [ ! -e "${LEGACY_CMUX_SYMLINK_TEMPLATE}" ]
+    [ "$(< "${CMUX_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_cmux/private_cmux.json" ]
+
+    run grep -F '".config/cmux/cmux.json is missing.' "${CMUX_PAYLOAD_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] cmux canonical payload does not apply a second ~/.cmux target" {
+    run grep -Fx ".cmux" "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/common/ghostty.bats
+++ b/tests/install/common/ghostty.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+readonly GHOSTTY_PAYLOAD_PATH="./home/dot_ghostty/config"
+readonly GHOSTTY_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.tmpl"
+readonly LEGACY_GHOSTTY_PAYLOAD_PATH="./home/dot_config/ghostty/config"
+readonly LEGACY_GHOSTTY_ALT_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.ghostty.tmpl"
+readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
+
+@test "[common] ghostty config payload lives under dot_ghostty and is exposed via a config symlink template" {
+    [ -f "${GHOSTTY_PAYLOAD_PATH}" ]
+    [ -f "${GHOSTTY_SYMLINK_TEMPLATE}" ]
+    [ ! -e "${LEGACY_GHOSTTY_PAYLOAD_PATH}" ]
+    [ ! -e "${LEGACY_GHOSTTY_ALT_SYMLINK_TEMPLATE}" ]
+    [ "$(< "${GHOSTTY_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_ghostty/config" ]
+
+    run grep -F 'window-theme = "ghostty"' "${GHOSTTY_PAYLOAD_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] ghostty canonical payload does not apply a second ~/.ghostty target" {
+    run grep -Fx ".ghostty" "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Why
- keep cmux and Ghostty on canonical source-state payload paths instead of applying duplicate legacy targets
- document the new layout with install tests so future moves do not regress

## What Changed
- added `.cmux` and `.ghostty` to `home/.chezmoitemplates/chezmoiignore.d/common`
- added canonical payload files under `home/dot_cmux/private_cmux.json` and `home/dot_ghostty/config`
- exposed those payloads through `home/dot_config/cmux/symlink_cmux.json.tmpl` and `home/dot_config/ghostty/symlink_config.tmpl`
- added install tests for the new cmux and Ghostty layout expectations, including the canonical cmux payload template string

## Validation
- Not run locally per repository policy; GitHub Actions will validate the change.
