### PR TITLE
Ignore macOS-only cmux and Ghostty configs on Ubuntu

### DIFF
--- a/home/.chezmoitemplates/chezmoiignore.d/ubuntu/common
+++ b/home/.chezmoitemplates/chezmoiignore.d/ubuntu/common
@@ -1,2 +1,4 @@
 .config/iterm2
+.config/cmux
+.config/ghostty
 Library

--- a/tests/install/common/cmux.bats
+++ b/tests/install/common/cmux.bats
@@ -5,6 +5,7 @@ readonly CMUX_SYMLINK_TEMPLATE="./home/dot_config/cmux/symlink_cmux.json.tmpl"
 readonly LEGACY_CMUX_PAYLOAD_PATH="./home/dot_config/cmux/private_cmux.json"
 readonly LEGACY_CMUX_SYMLINK_TEMPLATE="./home/dot_config/cmux/symlink_private_cmux.json.tmpl"
 readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
+readonly UBUNTU_CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/ubuntu/common"
 
 @test "[common] cmux config payload lives under dot_cmux and is exposed via a config symlink template" {
     [ -f "${CMUX_PAYLOAD_PATH}" ]
@@ -19,5 +20,10 @@ readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
 
 @test "[common] cmux canonical payload does not apply a second ~/.cmux target" {
     run grep -Fx ".cmux" "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] cmux target is ignored on Ubuntu" {
+    run grep -Fx ".config/cmux" "${UBUNTU_CHEZMOIIGNORE_PATH}"
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/common/ghostty.bats
+++ b/tests/install/common/ghostty.bats
@@ -5,6 +5,7 @@ readonly GHOSTTY_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.tmpl
 readonly LEGACY_GHOSTTY_PAYLOAD_PATH="./home/dot_config/ghostty/config"
 readonly LEGACY_GHOSTTY_ALT_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.ghostty.tmpl"
 readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
+readonly UBUNTU_CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/ubuntu/common"
 
 @test "[common] ghostty config payload lives under dot_ghostty and is exposed via a config symlink template" {
     [ -f "${GHOSTTY_PAYLOAD_PATH}" ]
@@ -19,5 +20,10 @@ readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
 
 @test "[common] ghostty canonical payload does not apply a second ~/.ghostty target" {
     run grep -Fx ".ghostty" "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] ghostty target is ignored on Ubuntu" {
+    run grep -Fx ".config/ghostty" "${UBUNTU_CHEZMOIIGNORE_PATH}"
     [ "${status}" -eq 0 ]
 }


### PR DESCRIPTION
## Why
- `cmux` and `ghostty` are macOS-only configs, so Ubuntu applies should ignore their target paths.
- This keeps the Ubuntu-specific ignore list aligned with the canonical config layout and prevents regressions.

## What Changed
- Added `.config/cmux` and `.config/ghostty` to `home/.chezmoitemplates/chezmoiignore.d/ubuntu/common`.
- Added install tests that assert those target paths are ignored on Ubuntu.

## Validation
- Not run locally per repo policy (`bats` validation is handled in GitHub Actions).
