### PR TITLE
fix(ghostty): add cmuxterm Ghostty symlink template

### DIFF
--- a/home/private_Library/private_Application Support/com.cmuxterm.app/symlink_config.ghostty.tmpl
+++ b/home/private_Library/private_Application Support/com.cmuxterm.app/symlink_config.ghostty.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_ghostty/config

--- a/tests/install/common/ghostty.bats
+++ b/tests/install/common/ghostty.bats
@@ -2,6 +2,7 @@
 
 readonly GHOSTTY_PAYLOAD_PATH="./home/dot_ghostty/config"
 readonly GHOSTTY_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.tmpl"
+readonly CMUXTERM_GHOSTTY_SYMLINK_TEMPLATE="./home/private_Library/private_Application Support/com.cmuxterm.app/symlink_config.ghostty.tmpl"
 readonly LEGACY_GHOSTTY_PAYLOAD_PATH="./home/dot_config/ghostty/config"
 readonly LEGACY_GHOSTTY_ALT_SYMLINK_TEMPLATE="./home/dot_config/ghostty/symlink_config.ghostty.tmpl"
 readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
@@ -10,9 +11,11 @@ readonly UBUNTU_CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/ubu
 @test "[common] ghostty config payload lives under dot_ghostty and is exposed via a config symlink template" {
     [ -f "${GHOSTTY_PAYLOAD_PATH}" ]
     [ -f "${GHOSTTY_SYMLINK_TEMPLATE}" ]
+    [ -f "${CMUXTERM_GHOSTTY_SYMLINK_TEMPLATE}" ]
     [ ! -e "${LEGACY_GHOSTTY_PAYLOAD_PATH}" ]
     [ ! -e "${LEGACY_GHOSTTY_ALT_SYMLINK_TEMPLATE}" ]
     [ "$(< "${GHOSTTY_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_ghostty/config" ]
+    [ "$(< "${CMUXTERM_GHOSTTY_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_ghostty/config" ]
 
     run grep -F 'window-theme = "ghostty"' "${GHOSTTY_PAYLOAD_PATH}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why
cmuxterm also needs to point at the canonical Ghostty config that now lives under `home/dot_ghostty/config`.
Without a dedicated symlink template, the app-specific path is left behind when Ghostty config is consumed through chezmoi.

## What Changed
- add `home/private_Library/private_Application Support/com.cmuxterm.app/symlink_config.ghostty.tmpl` pointing at the canonical Ghostty config payload
- extend `tests/install/common/ghostty.bats` to assert that both the standard Ghostty symlink template and the cmuxterm-specific template exist and render the same source path

## Validation
- `git diff --check`
- `chezmoi -S . execute-template home/private_Library/private_Application Support/com.cmuxterm.app/symlink_config.ghostty.tmpl`
- GitHub Actions