### PR TITLE
Add cmux to the default macOS Dock apps

### DIFF
--- a/install/macos/common/defaults.sh
+++ b/install/macos/common/defaults.sh
@@ -112,6 +112,7 @@ function defaults_dock() {
         "$(dock_item /Applications/Visual\ Studio\ Code.app)" \
         "$(dock_item /Applications/Slack.app)" \
         "$(dock_item /Applications/iTerm.app)" \
+        "$(dock_item /Applications/cmux.app)" \
         "$(dock_item "$(get_system_app_path)")"
 }
 

--- a/tests/install/macos/common/defaults.bats
+++ b/tests/install/macos/common/defaults.bats
@@ -6,6 +6,13 @@ function setup() {
     source "${SCRIPT_PATH}"
 }
 
+function dock_app_path() {
+    local dock_plist="$1"
+    local app_index="$2"
+
+    plutil -extract "persistent-apps.${app_index}.tile-data.file-data._CFURLString" raw -o - "${dock_plist}"
+}
+
 @test "[macos] test for ui" {
     defaults_ui
 
@@ -42,6 +49,21 @@ function setup() {
 @test "[macos] test for dock" {
     defaults_dock
 
+    local dock_plist
+    dock_plist="$(mktemp)"
+
     [ $(defaults read com.apple.dock autohide) -eq 1 ]
     [ $(defaults read com.apple.dock tilesize) -eq 30 ]
+    [ $(defaults read com.apple.dock mru-spaces) -eq 0 ]
+
+    defaults export com.apple.dock - > "${dock_plist}"
+
+    [ "$(dock_app_path "${dock_plist}" 0)" = "/Applications/Google Chrome.app" ]
+    [ "$(dock_app_path "${dock_plist}" 1)" = "/Applications/Visual Studio Code.app" ]
+    [ "$(dock_app_path "${dock_plist}" 2)" = "/Applications/Slack.app" ]
+    [ "$(dock_app_path "${dock_plist}" 3)" = "/Applications/iTerm.app" ]
+    [ "$(dock_app_path "${dock_plist}" 4)" = "/Applications/cmux.app" ]
+    [ "$(dock_app_path "${dock_plist}" 5)" = "$(get_system_app_path)" ]
+
+    rm -f "${dock_plist}"
 }


### PR DESCRIPTION
## Why

The default macOS Dock setup should include cmux alongside the other primary apps so a fresh machine gets the expected launcher order.

## What Changed

- added `/Applications/cmux.app` to `defaults_dock()` immediately after iTerm
- added a `dock_app_path()` helper in the macOS defaults bats test
- extended the Dock test to assert `mru-spaces == 0` and the full app order through the system app entry

## Validation

- `git diff --check`
- GitHub Actions
