### PR TITLE
docs(codex): reformat fallback validation guidance

### DIFF
--- a/home/dot_config/codex/agents/gh-workflow-manager.toml
+++ b/home/dot_config/codex/agents/gh-workflow-manager.toml
@@ -45,6 +45,11 @@ Workflow:
   - `## Validation`
 - In either case, describe the full current PR, not only the latest delta.
 - Keep the `Validation` section repo-relative and never include local absolute paths.
+- In the `Validation` section, prefer repeated command-based steps instead of bullet lists.
+- For each command-based validation step, write one short natural-language line that explains what the command verified, then place the exact command in a fenced `shell` block.
+- Use descriptive lines such as `Check the updated guidance assertions.` or `Inspect the staged diff for formatting issues.`, not placeholder labels like `Try command 1`.
+- Repeat that pattern for each command-based validation step.
+- If a validation item is not command-based, keep it as one short prose line without forcing a code block.
 - After any additional push, inspect the updated commits/diff and refresh the PR description so it matches the full current PR.
 - Do not treat "PR created" or "PR updated" as task completion when CI verification is still pending.
 - After pushing, check GitHub Actions / checks and continue until all required checks pass or a failure requires parent/user intervention.

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -294,6 +294,21 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
 
     run grep -F 'Keep the `Validation` section repo-relative and never include local absolute paths.' "${CODEX_GH_AGENT_PATH}"
     [ "${status}" -eq 0 ]
+
+    run grep -F 'In the `Validation` section, prefer repeated command-based steps instead of bullet lists.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'For each command-based validation step, write one short natural-language line that explains what the command verified, then place the exact command in a fenced `shell` block.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Use descriptive lines such as `Check the updated guidance assertions.` or `Inspect the staged diff for formatting issues.`, not placeholder labels like `Try command 1`.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Repeat that pattern for each command-based validation step.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'If a validation item is not command-based, keep it as one short prose line without forcing a code block.' "${CODEX_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
 }
 
 @test "[common] layout readmes describe the adapter and canonical layout" {


### PR DESCRIPTION
## Why
The fallback PR body guidance for `gh-workflow-manager` already enforced repo-relative `Validation` content, but it did not specify how command-based validation steps should be formatted. This change makes the fallback format more explicit so PR descriptions stay readable and consistent when no repository template exists.

## What Changed
- clarified in `home/dot_config/codex/agents/gh-workflow-manager.toml` that command-based validation should be written as repeated natural-language lines followed by fenced `shell` blocks
- added guidance to avoid placeholder labels such as `Try command 1` and to keep non-command validation items as short prose lines
- added matching fixed-string grep assertions in `tests/install/common/agents_guidance.bats`

## Validation
Check the touched files for whitespace or formatting issues.
```shell
git diff --check -- home/dot_config/codex/agents/gh-workflow-manager.toml tests/install/common/agents_guidance.bats
```

Inspect the final guidance and assertion changes together.
```shell
git diff origin/main...HEAD -- home/dot_config/codex/agents/gh-workflow-manager.toml tests/install/common/agents_guidance.bats
```

Local `bats` were not run because this repository validates them in GitHub Actions.