### PR TITLE
feat(gemini): manage settings as symlinks and add GEMINI.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following are the tools and coding assistants I mainly use in this setup.
 
 [![anthropics/claude-code](https://img.shields.io/github/v/tag/anthropics/claude-code?color=D97757&display_name=release&label=claude-code&logo=claude&logoColor=D97757&sort=semver)](https://github.com/anthropics/claude-code)
 [![openai/codex](https://img.shields.io/github/v/tag/openai/codex?color=0081A5&display_name=release&label=codex&logo=openaigym&logoColor=0081A5&sort=semver)](https://github.com/openai/codex)
+[![google-gemini/gemini-cli](https://img.shields.io/github/v/tag/google-gemini/gemini-cli?color=8E75B2&display_name=release&label=googlegemini&logo=googlegemini&logoColor=8E75B2&sort=semver)](https://github.com/google-gemini/gemini-cli)
 
 ## 📥 Setup
 

--- a/home/dot_config/gemini/GEMINI.md
+++ b/home/dot_config/gemini/GEMINI.md
@@ -1,0 +1,8 @@
+@~/.agents/AGENTS.md
+
+> [!NOTE]
+> After reading this `GEMINI.md`, say: `🤖 I read ~/.gemini/GEMINI.md.`
+
+## Gemini Only
+
+- 現在のところ、Gemini 固有の設定はありませんが、将来的に追加される可能性があります。

--- a/home/dot_config/gemini/README.md
+++ b/home/dot_config/gemini/README.md
@@ -1,0 +1,4 @@
+- This directory is the canonical source for `~/.gemini`.
+- [home/dot_gemini/](../../dot_gemini/) is only the adapter layer that exposes this source in the applied home layout.
+- The design keeps edits in one git-friendly place while preserving the familiar home path.
+- Edit files here; the adapter keeps the home path stable.

--- a/home/dot_config/gemini/settings.json
+++ b/home/dot_config/gemini/settings.json
@@ -1,0 +1,13 @@
+{
+  "security": {
+    "auth": {
+      "selectedType": "oauth-personal"
+    }
+  },
+  "general": {
+    "enableAutoUpdate": true
+  },
+  "ui": {
+    "inlineThinkingMode": "full"
+  }
+}

--- a/home/dot_config/gemini/settings.json
+++ b/home/dot_config/gemini/settings.json
@@ -7,6 +7,12 @@
   "general": {
     "enableAutoUpdate": true
   },
+  "context": {
+    "fileName": [
+      "AGENTS.md",
+      "GEMINI.md"
+    ]
+  },
   "ui": {
     "inlineThinkingMode": "full"
   }

--- a/home/dot_gemini/symlink_GEMINI.md.tmpl
+++ b/home/dot_gemini/symlink_GEMINI.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/gemini/GEMINI.md

--- a/home/dot_gemini/symlink_settings.json.tmpl
+++ b/home/dot_gemini/symlink_settings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/gemini/settings.json

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -34,6 +34,7 @@ shfmt = "latest"
 
 "cargo:pueue" = "latest"
 dust = "latest"
+"npm:@google/gemini-cli" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]


### PR DESCRIPTION
## Changes
- Move `settings.json` to `home/dot_config/gemini/` and manage `~/.gemini/settings.json` as a symlink.
- Add `GEMINI.md` to `home/dot_config/gemini/` and expose it as a symlink at `~/.gemini/GEMINI.md`.
- Update `settings.json` context to include `AGENTS.md` and `GEMINI.md`.
- Update `home/dot_mise/config.toml` with `gemini-cli`.
- Add documentation `README.md` for the new gemini config directory.