### PR TITLE
feat(macos): add clop to cask packages

### DIFF
--- a/install/macos/common/misc.sh
+++ b/install/macos/common/misc.sh
@@ -25,6 +25,7 @@ readonly BREW_TAPS=(
 
 readonly CASK_PACKAGES=(
     adobe-acrobat-reader
+    clop
     cmux
     cyberduck
     google-chrome


### PR DESCRIPTION
This PR adds clop to the macOS cask packages list in install/macos/common/misc.sh.