### PR TITLE
Bootstrap agmsg with chezmoi

### DIFF
--- a/home/.chezmoiscripts/common/run_once_after_04-install-agmsg.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_once_after_04-install-agmsg.sh.tmpl
@@ -1,0 +1,1 @@
+{{ include "../install/common/agmsg.sh" }}

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -37,6 +37,7 @@ yq = "latest"
 "npm:fast-cli" = "latest"
 "npm:@openai/codex" = "latest"
 "npm:pyright" = "latest"
+"npm:agmsg" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -1,4 +1,5 @@
 [tools]
+# Keep tools sorted by backend group and package name, ignoring backend prefixes and leading `@`.
 go = "latest"
 node = "lts"
 rust = "latest"
@@ -32,12 +33,12 @@ yq = "latest"
 "github:shuntaka9576/blocc" = { version = "latest", os = ["linux"] }
 "github:x-motemen/ghq" = "latest"
 
+"npm:agmsg" = "latest"
 "npm:@anthropic-ai/claude-code" = "latest"
 "npm:bash-language-server" = "latest"
 "npm:fast-cli" = "latest"
 "npm:@openai/codex" = "latest"
 "npm:pyright" = "latest"
-"npm:agmsg" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -1,10 +1,13 @@
 [tools]
-# Keep tools sorted by backend group and package name, ignoring backend prefixes and leading `@`.
+# Keep each group sorted by package name, ignoring backend prefixes and leading `@`.
+
+# Language runtimes
 go = "latest"
 node = "lts"
-rust = "latest"
 python = "3.11"
+rust = "latest"
 
+# CLI tools
 age = "latest"
 aws-cli = "latest"
 bats = "latest"
@@ -24,15 +27,19 @@ uv = "latest"
 yazi = "latest"
 yq = "latest"
 
+# Aqua tools
 "aqua:google-antigravity/antigravity-cli" = "latest"
 
+# Cargo tools
 "cargo:pueue" = "latest"
 
+# GitHub release tools
 "github:cli/cli" = "latest"
 "github:d-kuro/gwq" = "latest"
 "github:shuntaka9576/blocc" = { version = "latest", os = ["linux"] }
 "github:x-motemen/ghq" = "latest"
 
+# npm tools
 "npm:agmsg" = "latest"
 "npm:@anthropic-ai/claude-code" = "latest"
 "npm:bash-language-server" = "latest"

--- a/install/common/agmsg.sh
+++ b/install/common/agmsg.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# @file install/common/agmsg.sh
+# @brief Install agmsg runtime assets.
+# @description
+#   Activates `mise` when available, then runs `agmsg install`.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly MISE_BIN="${HOME}/.local/bin/mise"
+
+#
+# @description Activate `mise` so `agmsg` can resolve from the configured toolchain.
+#
+function activate_mise() {
+    if [ -x "${MISE_BIN}" ]; then
+        eval "$("${MISE_BIN}" activate bash)"
+    fi
+}
+
+#
+# @description Install agmsg runtime assets.
+#
+function install_agmsg() {
+    agmsg install
+}
+
+#
+# @description Run the agmsg installation workflow.
+#
+function main() {
+    activate_mise
+    install_agmsg
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi


### PR DESCRIPTION
## Why

`agmsg` is managed through mise, but its runtime assets still need to be installed after mise installs the tool. The mise tool list also needs clear grouping and sorting guidance so future edits keep package entries in natural order.

## What Changed

- Add `npm:agmsg` to the mise tool configuration and keep it sorted at the top of the npm tools group.
- Add a `[tools]` comment documenting that each group should stay sorted by package name, ignoring backend prefixes and leading `@`.
- Add category comments for language runtimes, CLI tools, Aqua tools, Cargo tools, GitHub release tools, and npm tools.
- Keep the language runtime group sorted by package name.
- Add a common `agmsg` installer script that activates mise when available and runs `agmsg install`.
- Add a chezmoi run-once script ordered after the mise installer so the `agmsg` bootstrap runs after mise setup.

## Validation

Check shell formatting for the agmsg installer.
```shell
shfmt -i 4 -sr -d install/common/agmsg.sh
```

Lint the agmsg installer.
```shell
shellcheck install/common/agmsg.sh
```

Parse the agmsg installer with bash.
```shell
bash -n install/common/agmsg.sh
```

Render the chezmoi run-once template for agmsg.
```shell
chezmoi --source "$PWD/home" execute-template < home/.chezmoiscripts/common/run_once_after_04-install-agmsg.sh.tmpl
```

Check the updated mise tool comment diff for whitespace errors.
```shell
git diff --check -- home/dot_mise/config.toml
```

Attempt the broader chezmoi script status check; this is currently blocked by an unrelated GitHub API rate limit while resolving `ryanoasis/nerd-fonts` from `.chezmoiexternal.yaml.tmpl`.
```shell
chezmoi --source "$PWD/home" status --include scripts
```
