### PR TITLE
fix(mise): update bootstrap installer

### DIFF
--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -19,12 +19,12 @@ readonly DEFAULT_NPM_MIN_RELEASE_AGE_DAYS=7
 #
 function install_mise() {
     # https://mise.run
-    local version="v2026.3.7"
-    local url="https://raw.githubusercontent.com/jdx/mise/refs/tags/${version}/packaging/standalone/install.envsubst"
+    local version="v2026.6.13"
+    local url="https://github.com/jdx/mise/releases/download/${version}/install.sh"
 
-    export MISE_CURRENT_VERSION="${version}"
-    curl "${url}" | sh
-    unset MISE_CURRENT_VERSION
+    export MISE_VERSION="${version}"
+    curl -fsSL "${url}" | sh
+    unset MISE_VERSION
 
     eval "$(~/.local/bin/mise activate bash)"
 }
@@ -33,8 +33,9 @@ function install_mise() {
 # @description Run `mise install` with the repository npm age gate.
 #
 function run_mise_install() {
-    # `MISE_CURRENT_VERSION` is interpreted by mise as a tool env override for `current`.
+    # These installer envvars are interpreted by mise as tool env overrides.
     unset MISE_CURRENT_VERSION
+    unset MISE_VERSION
     mise install --before "${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d"
 }
 


### PR DESCRIPTION
## Summary
- update the pinned mise bootstrap version from v2026.3.7 to v2026.6.13
- use the release install.sh asset instead of the raw install.envsubst template
- clear mise installer env vars before running mise install

## Context
The scheduled Snippet install workflow failed in run 28215014929 during `mise install`. The old pinned mise build could not resolve the current antigravity-cli aqua registry entry and selected the old asdf sqlite plugin path, which attempted to download an outdated SQLite archive.

## Validation
- `shfmt -i 4 -sr -d install/common/mise.sh`
- `shellcheck install/common/mise.sh`
- `bash -n install/common/mise.sh`
- rendered `home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl` with chezmoi and checked it with `bash -n`
- verified mise v2026.6.13 resolves `sqlite` and `aqua:google-antigravity/antigravity-cli` versions

Note: bats tests were not run locally per repository policy.