### PR TITLE
Add autostash handling to update-dotfiles

### DIFF
--- a/home/dot_local/bin/exact_common/executable_update-dotfiles
+++ b/home/dot_local/bin/exact_common/executable_update-dotfiles
@@ -4,7 +4,8 @@
 # @brief Update and apply the public and private chezmoi source repositories.
 # @description
 #   Fetches the latest `origin/main` for each selected source, fast-forwards
-#   clean main checkouts only, then runs `chezmoi apply --verbose`.
+#   main checkouts only, temporarily stashes local source changes, then runs
+#   `chezmoi apply --verbose`.
 
 set -Eeuo pipefail
 
@@ -58,13 +59,12 @@ function source_label() {
     esac
 }
 
-# @description Refuse dirty or non-main source checkouts.
+# @description Refuse non-main source checkouts.
 # @arg $1 string Source name, either `public` or `private`.
-function assert_clean_main() {
+function assert_main() {
     local source_name="$1"
     local label
     local branch
-    local status
 
     label="$(source_label "${source_name}")"
     branch="$(run_chezmoi "${source_name}" git -- rev-parse --abbrev-ref HEAD)"
@@ -73,11 +73,43 @@ function assert_clean_main() {
         printf "Error: %s chezmoi source is on %s, expected %s.\n" "${label}" "${branch}" "${DEFAULT_BRANCH}" >&2
         return 1
     fi
+}
+
+# @description Return whether the selected source has local changes.
+# @arg $1 string Source name, either `public` or `private`.
+function source_has_changes() {
+    local source_name="$1"
+    local status
 
     status="$(run_chezmoi "${source_name}" git -- status --porcelain)"
-    if [[ -n "${status}" ]]; then
-        printf "Error: %s chezmoi source has uncommitted changes.\n" "${label}" >&2
-        printf "%s\n" "${status}" >&2
+    [[ -n "${status}" ]]
+}
+
+# @description Stash local source changes, including untracked files.
+# @arg $1 string Source name, either `public` or `private`.
+function stash_source_changes() {
+    local source_name="$1"
+    local label
+
+    label="$(source_label "${source_name}")"
+    printf "Stashing local %s chezmoi source changes...\n" "${label}"
+    run_chezmoi "${source_name}" git -- stash push --include-untracked -m "update-dotfiles autostash: ${label}"
+}
+
+# @description Restore a source autostash after the update attempt.
+# @arg $1 string Source name, either `public` or `private`.
+function restore_source_autostash() {
+    local source_name="$1"
+    local label
+
+    label="$(source_label "${source_name}")"
+    printf "Restoring local %s chezmoi source changes...\n" "${label}"
+
+    # `stash pop` can conflict after the source fast-forwards. Git keeps the
+    # stash in that case, so report the failure instead of hiding local work in
+    # an easy-to-forget stash entry.
+    if ! run_chezmoi "${source_name}" git -- stash pop --index; then
+        printf "Error: failed to restore %s chezmoi source autostash. Resolve the conflict, then inspect the remaining stash entry.\n" "${label}" >&2
         return 1
     fi
 }
@@ -124,13 +156,34 @@ function apply_source() {
 function update_source() {
     local source_name="$1"
     local label
+    local autostashed=0
+    local update_status=0
+    local restore_status=0
 
     label="$(source_label "${source_name}")"
     printf "Updating %s chezmoi source...\n" "${label}"
 
-    assert_clean_main "${source_name}"
-    fast_forward_source "${source_name}"
-    apply_source "${source_name}"
+    assert_main "${source_name}"
+
+    if source_has_changes "${source_name}"; then
+        stash_source_changes "${source_name}"
+        autostashed=1
+    fi
+
+    fast_forward_source "${source_name}" || update_status=$?
+    if ((update_status == 0)); then
+        apply_source "${source_name}" || update_status=$?
+    fi
+
+    if ((autostashed)); then
+        restore_source_autostash "${source_name}" || restore_status=$?
+    fi
+
+    if ((restore_status != 0)); then
+        return "${restore_status}"
+    fi
+
+    return "${update_status}"
 }
 
 # @description Dispatch the selected update target.

--- a/tests/install/common/update_dotfiles.bats
+++ b/tests/install/common/update_dotfiles.bats
@@ -19,6 +19,8 @@ function setup() {
     export PRIVATE_LOCAL_REV="private-local"
     export PRIVATE_REMOTE_REV="private-local"
     export PRIVATE_BASE_REV="private-local"
+    export PUBLIC_STASH_POP_STATUS=0
+    export PRIVATE_STASH_POP_STATUS=0
     PATH="${TEST_BIN_DIR}:$(getconf PATH)"
     export PATH
 
@@ -80,6 +82,15 @@ if [[ "${1:-}" == "git" && "${2:-}" == "--" ]]; then
             printf "%s\n" "${PRIVATE_BASE_REV}"
         fi
         ;;
+    stash)
+        if [[ "$2" == "pop" ]]; then
+            if [[ "${source_name}" == "public" ]]; then
+                exit "${PUBLIC_STASH_POP_STATUS}"
+            else
+                exit "${PRIVATE_STASH_POP_STATUS}"
+            fi
+        fi
+        ;;
     fetch | merge)
         ;;
     esac
@@ -135,14 +146,32 @@ EOF
     [ "$(grep -c '^public:' "${CHEZMOI_CALLS_PATH}")" -eq 0 ]
 }
 
-@test "[common] dirty source stops before fetch and apply" {
+@test "[common] dirty source is stashed before update and restored after apply" {
     export PUBLIC_STATUS=" M home/dot_zshrc"
 
     run bash "${SCRIPT_PATH}" public
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Stashing local public chezmoi source changes..."* ]]
+    [[ "${output}" == *"Restoring local public chezmoi source changes..."* ]]
+    run grep -F 'public:git -- stash push --include-untracked -m update-dotfiles autostash: public' "${CHEZMOI_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'public:git -- stash pop --index' "${CHEZMOI_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    run tail -n 1 "${CHEZMOI_CALLS_PATH}"
+    [ "${output}" = "public:git -- stash pop --index" ]
+}
+
+@test "[common] autostash restore failure reports the remaining stash risk" {
+    export PUBLIC_STATUS=" M home/dot_zshrc"
+    export PUBLIC_STASH_POP_STATUS=1
+
+    run bash "${SCRIPT_PATH}" public
     [ "${status}" -eq 1 ]
-    [[ "${output}" == *"has uncommitted changes"* ]]
-    [ "$(grep -c 'fetch --prune origin' "${CHEZMOI_CALLS_PATH}")" -eq 0 ]
-    [ "$(grep -c 'apply --verbose' "${CHEZMOI_CALLS_PATH}")" -eq 0 ]
+    [[ "${output}" == *"failed to restore public chezmoi source autostash"* ]]
+    run grep -F 'public:apply --verbose' "${CHEZMOI_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'public:git -- stash pop --index' "${CHEZMOI_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
 }
 
 @test "[common] non-main branch stops before fetch and apply" {


### PR DESCRIPTION
## Summary
- Autostash dirty public/private chezmoi source changes before fetching and applying updates.
- Restore the autostash with `git stash pop --index` immediately after the update attempt so local work is not left hidden by default.
- Cover the happy path and restore-failure path in the `update-dotfiles` bats tests.

## Autostash Risk Notes
- `git stash pop --index` can conflict after the source repository fast-forwards. When that happens, Git keeps the stash entry; the command now reports the restore failure and tells the operator to inspect the remaining stash.
- This only handles dirty source repositories. Destination-side chezmoi conflicts, such as files changed since chezmoi last wrote them, are separate and still require interactive handling or explicit skip behavior.

## Validation
- `bash -n home/dot_local/bin/exact_common/executable_update-dotfiles`
- `shfmt -i 4 -sr -d home/dot_local/bin/exact_common/executable_update-dotfiles tests/install/common/update_dotfiles.bats`
- `shellcheck home/dot_local/bin/exact_common/executable_update-dotfiles`
- Manual stub smoke test for dirty-source autostash call order

Note: I did not run bats locally per the repository test policy; GitHub Actions should validate the bats suite.
