### PR TITLE
Add Herdr setup script

### DIFF
--- a/home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl
@@ -1,0 +1,1 @@
+{{ include "../install/common/herdr.sh" }}

--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# @file install/common/herdr.sh
+# @brief Install Herdr integrations and skill assets.
+# @description
+#   Activates `mise` when available, installs Herdr integrations for configured
+#   coding agents, and installs the shared Herdr skill globally.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly MISE_BIN="${HOME}/.local/bin/mise"
+readonly HERDR_SKILL_REPO="ogulcancelik/herdr"
+readonly HERDR_SKILL_NAME="herdr"
+
+readonly HERDR_INTEGRATIONS=(
+    claude
+    codex
+)
+
+#
+# @description Activate `mise` so Herdr and Node.js resolve from the configured toolchain.
+#
+function activate_mise() {
+    if [ -x "${MISE_BIN}" ]; then
+        eval "$("${MISE_BIN}" activate bash)"
+    fi
+}
+
+#
+# @description Install Herdr integrations for every configured coding agent.
+#
+function install_herdr_integrations() {
+    for integration in "${HERDR_INTEGRATIONS[@]}"; do
+        herdr integration install "${integration}"
+    done
+}
+
+#
+# @description Install the shared Herdr skill globally.
+#
+function install_herdr_skill() {
+    npx -y skills add "${HERDR_SKILL_REPO}" --skill "${HERDR_SKILL_NAME}" -g
+}
+
+#
+# @description Run the Herdr installation workflow.
+#
+function main() {
+    activate_mise
+    install_herdr_integrations
+    install_herdr_skill
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/common/herdr.sh"
+readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl"
+
+function setup() {
+    export HOME="${BATS_TEST_TMPDIR}/home"
+    mkdir -p "${HOME}/.local/bin"
+
+    source "${SCRIPT_PATH}"
+}
+
+function teardown() {
+    PATH=$(getconf PATH)
+    export PATH
+}
+
+@test "[common] herdr run-once template exists" {
+    [ -f "${TMPL_SCRIPT_PATH}" ]
+}
+
+@test "[common] activate_mise evaluates mise activation output" {
+    cat > "${MISE_BIN}" <<'EOF'
+#!/usr/bin/env bash
+if [ "$*" = "activate bash" ]; then
+    printf '%s\n' 'export HERDR_TEST_MISE_ACTIVATED=1'
+fi
+EOF
+    chmod +x "${MISE_BIN}"
+
+    activate_mise
+
+    [ "${HERDR_TEST_MISE_ACTIVATED}" = "1" ]
+}
+
+@test "[common] install_herdr_integrations installs configured integrations" {
+    function herdr() {
+        printf '%s\n' "$*" >> "${BATS_TEST_TMPDIR}/herdr_args.txt"
+    }
+
+    install_herdr_integrations
+
+    run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "integration install claude" ]
+    [ "${lines[1]}" = "integration install codex" ]
+}
+
+@test "[common] install_herdr_skill installs the shared skill globally" {
+    function npx() {
+        printf '%s\n' "$*" > "${BATS_TEST_TMPDIR}/npx_args.txt"
+    }
+
+    install_herdr_skill
+
+    run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "-y skills add ogulcancelik/herdr --skill herdr -g" ]
+}

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -20,7 +20,7 @@ function teardown() {
 }
 
 @test "[common] activate_mise evaluates mise activation output" {
-    cat > "${MISE_BIN}" <<'EOF'
+    cat > "${MISE_BIN}" << 'EOF'
 #!/usr/bin/env bash
 if [ "$*" = "activate bash" ]; then
     printf '%s\n' 'export HERDR_TEST_MISE_ACTIVATED=1'

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -57,3 +57,45 @@ EOF
     [ "${status}" -eq 0 ]
     [ "${output}" = "-y skills add ogulcancelik/herdr --skill herdr -g" ]
 }
+
+@test "[common] herdr script runs full installation workflow" {
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+if [ "$*" = "activate bash" ]; then
+    printf '%s\n' 'export HERDR_TEST_MISE_ACTIVATED=1'
+fi
+EOF
+    chmod +x "${MISE_BIN}"
+
+    cat > "${BATS_TEST_TMPDIR}/bin/herdr" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${HERDR_CALLS_PATH}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/herdr"
+
+    cat > "${BATS_TEST_TMPDIR}/bin/npx" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${HERDR_TEST_MISE_ACTIVATED:-unset}|$*" > "${NPX_CALLS_PATH}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/npx"
+
+    run env \
+        DOTFILES_DEBUG=1 \
+        HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_args.txt" \
+        HOME="${HOME}" \
+        NPX_CALLS_PATH="${BATS_TEST_TMPDIR}/npx_args.txt" \
+        PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
+        bash "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "integration install claude" ]
+    [ "${lines[1]}" = "integration install codex" ]
+
+    run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1|-y skills add ogulcancelik/herdr --skill herdr -g" ]
+}


### PR DESCRIPTION
## Why

Herdr should be configured automatically after the common mise setup runs so both Claude and Codex integrations are installed and the Herdr skill is available globally.

## What Changed

Added a common Herdr installer script that activates mise, installs the Claude and Codex Herdr integrations, and adds the Herdr skill with `npx -y skills add ogulcancelik/herdr --skill herdr -g`.

Added a chezmoi run-once hook after the mise install script to invoke the Herdr installer.

Added Bats coverage for the individual Herdr setup functions and the executable installer entrypoint so Codecov can see the full installation workflow.

## Validation

Check the Herdr install script syntax.
```shell
bash -n install/common/herdr.sh
```

Check the rendered Herdr run-once template syntax.
```shell
chezmoi --source . execute-template < home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl | bash -n
```

Check the Herdr install script with shellcheck.
```shell
shellcheck install/common/herdr.sh
```

Check the rendered Herdr run-once template with shellcheck.
```shell
chezmoi --source . execute-template < home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl | shellcheck -
```

Check formatting for the Herdr script, run-once template, and tests.
```shell
shfmt -i 4 -sr -d install/common/herdr.sh home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl tests/install/common/herdr.bats
```

Inspect the full PR diff for whitespace issues.
```shell
git diff --check origin/main...HEAD -- install/common/herdr.sh home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl tests/install/common/herdr.bats
```

Bats validation is left to GitHub Actions per repository policy.
