### PR TITLE
Install Herdr skill non-interactively

### DIFF
--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -15,6 +15,11 @@ fi
 readonly MISE_BIN="${HOME}/.local/bin/mise"
 readonly HERDR_SKILL_REPO="ogulcancelik/herdr"
 readonly HERDR_SKILL_NAME="herdr"
+readonly HERDR_SKILL_AGENTS=(
+    claude-code
+    codex
+    antigravity-cli
+)
 
 readonly HERDR_INTEGRATIONS=(
     claude
@@ -43,7 +48,11 @@ function install_herdr_integrations() {
 # @description Install the shared Herdr skill globally.
 #
 function install_herdr_skill() {
-    npx -y skills add "${HERDR_SKILL_REPO}" --skill "${HERDR_SKILL_NAME}" -g
+    npx -y skills add "${HERDR_SKILL_REPO}" \
+        --skill "${HERDR_SKILL_NAME}" \
+        --agent "${HERDR_SKILL_AGENTS[@]}" \
+        --global \
+        --yes
 }
 
 #

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -55,7 +55,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "-y skills add ogulcancelik/herdr --skill herdr -g" ]
+    [ "${output}" = "-y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 }
 
 @test "[common] herdr script runs full installation workflow" {
@@ -97,5 +97,5 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "1|-y skills add ogulcancelik/herdr --skill herdr -g" ]
+    [ "${output}" = "1|-y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 }


### PR DESCRIPTION
## Why

The Herdr skill installation must run non-interactively and install the shared skill for each supported agent.

## What Changed

- Added the supported Herdr skill agents: `claude-code`, `codex`, and `antigravity-cli`.
- Updated the Herdr skill install command to pass `--agent` values, `--global`, and `--yes`.
- Updated the Herdr bats expectations for the new `npx skills add` arguments.

## Validation

Check the Herdr shell script syntax.
```shell
bash -n install/common/herdr.sh
```

Inspect the diff for whitespace errors.
```shell
git diff --check
```

Verify the touched shell and bats files are already shfmt-formatted.
```shell
shfmt --indent 4 --space-redirects --diff install/common/herdr.sh tests/install/common/herdr.bats
```

Confirm `install_herdr_skill` expands to the expected non-interactive `npx` arguments with a direct shell stub.

`make format` was attempted, but it stops on a pre-existing unrelated shfmt diff in `home/dot_config/exact_shell/npm-guard.sh`; this PR does not modify that file.

Local `bats` was not run per repository policy; bats validation should run in GitHub Actions.
