### PR TITLE
chore(herdr): set prefix to ctrl-q

### DIFF
--- a/home/dot_herdr/config.toml
+++ b/home/dot_herdr/config.toml
@@ -59,7 +59,7 @@ manifest_check = true
 # Named punctuation such as minus, comma, ampersand, plus, and backtick is also accepted.
 # Most reliable direct bindings are ctrl+letter, function keys, and explicit modified chords.
 # alt+..., cmd/super, and punctuation-with-modifiers may depend on your terminal/tmux setup.
-prefix = "ctrl+z"
+prefix = "ctrl+q"
 
 # Prefix-mode actions
 # help = "prefix+?"


### PR DESCRIPTION
Summary
- Set the Herdr prefix key to Ctrl-q so local macOS tmux can keep using Ctrl-z.
- Keep the local tmux / Herdr prefix split aligned with the existing local tmux / remote tmux setup.

Testing
- python3 -c 'import tomllib, pathlib; tomllib.loads(pathlib.Path("home/dot_herdr/config.toml").read_text()); print("TOML OK")'