### PR TITLE
chore(herdr): document generated skill ignore policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,28 @@ coverage*
 .agents/worklog/
 .playwright-cli/
 
-home/dot_config/exact_agents/skills/skill-creator
+# ~/.agents/skills and ~/.claude/skills point here, so global skill installers
+# can expand generated skills into the chezmoi source tree. Ignore generated
+# skills by default and explicitly allow repo-managed skills below.
+home/dot_config/exact_agents/skills/*
+!home/dot_config/exact_agents/skills/ai-slop-checklist-ja/
+!home/dot_config/exact_agents/skills/ai-slop-checklist-ja/**
+!home/dot_config/exact_agents/skills/convert-to-transformers/
+!home/dot_config/exact_agents/skills/convert-to-transformers/**
+!home/dot_config/exact_agents/skills/gh-comment-attach-files/
+!home/dot_config/exact_agents/skills/gh-comment-attach-files/**
+!home/dot_config/exact_agents/skills/high-impact-journal-publishing/
+!home/dot_config/exact_agents/skills/high-impact-journal-publishing/**
+!home/dot_config/exact_agents/skills/humanizer-ja/
+!home/dot_config/exact_agents/skills/humanizer-ja/**
+!home/dot_config/exact_agents/skills/python-uv-workflow/
+!home/dot_config/exact_agents/skills/python-uv-workflow/**
+!home/dot_config/exact_agents/skills/shdoc-shell-docs/
+!home/dot_config/exact_agents/skills/shdoc-shell-docs/**
+!home/dot_config/exact_agents/skills/worklog-manager/
+!home/dot_config/exact_agents/skills/worklog-manager/**
 
 home/dot_config/claude/commands/agmsg.md
-home/dot_config/exact_agents/skills/agmsg/
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Public source: Files under `home/` are the public source state and are applied by `chezmoi` into the user's `$HOME` directory.
 - Private source: Private dotfiles are managed separately from `~/.local/share/chezmoi-private` with config at `~/.config/chezmoi-private/chezmoi.yaml`.
 - Management boundary: Treat the public `home/` tree and the private `chezmoi` source/config as separate management domains.
+- Agent skills: `home/dot_config/exact_agents/skills/*` is ignored by default because global skill installers write through symlinked runtime paths. When adding a repo-managed skill, add an explicit `.gitignore` allowlist entry for that skill.
 
 ## Comment Policy
 

--- a/home/dot_config/exact_agents/README.md
+++ b/home/dot_config/exact_agents/README.md
@@ -4,6 +4,12 @@ In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` remov
 
 [AGENTS.md](AGENTS.md) is the shared guidance used directly by `~/.agents/AGENTS.md`, imported from `~/.claude/CLAUDE.md` with `@~/.agents/AGENTS.md`, and read first from `~/.codex/AGENTS.md` before `~/.codex/AGENTS.codex-only.md`. Edit files here; the adapter keeps the home path stable.
 
+## Skill Ignore Policy
+
+`~/.agents/skills` and `~/.claude/skills` both point to `home/dot_config/exact_agents/skills`, so global skill installers can write generated skills back into the chezmoi source tree.
+
+New skill directories under `home/dot_config/exact_agents/skills` are ignored by default. When a skill should be managed by this repository, add that skill to the `.gitignore` allowlist and keep the reason for managing it clear in the PR.
+
 The diagram below describes this repository's source-of-truth layout, not the meaning of chezmoi's `exact_` attribute itself.
 
 ## Layout Overview

--- a/home/dot_herdr/config.toml
+++ b/home/dot_herdr/config.toml
@@ -1,3 +1,4 @@
+onboarding = false
 # herdr configuration
 # Place this file at ~/.config/herdr/config.toml
 


### PR DESCRIPTION
## Summary
- disable Herdr onboarding in the checked-in config
- default-ignore generated shared agent skills and allowlist repo-managed skills
- document why global skill installers can write through symlinked runtime skill paths

## Testing
- python3 tomllib parse check for home/dot_herdr/config.toml
- git check-ignore for generated and repo-managed skill paths
- GitHub Actions: changes, macOS/Ubuntu tests, and Codecov all passed

## Notes
- local bats was not run per repository policy
- local shfmt --indent 4 --space-redirects --diff . reports an existing formatting diff in home/dot_config/exact_shell/npm-guard.sh, which is unrelated to this PR; GitHub Actions passed