### PR TITLE
Disable Herdr new tab name prompts

### DIFF
--- a/home/dot_herdr/config.toml
+++ b/home/dot_herdr/config.toml
@@ -172,7 +172,6 @@ navigate_workspace_down = "ctrl+n"
 
 # Ask for a tab name before creating a new tab.
 # Set false to create tabs immediately with generated names.
-# prompt_new_tab_name = true
 prompt_new_tab_name = false
 
 # Draw borders around split panes.

--- a/home/dot_herdr/config.toml
+++ b/home/dot_herdr/config.toml
@@ -173,6 +173,7 @@ navigate_workspace_down = "ctrl+n"
 # Ask for a tab name before creating a new tab.
 # Set false to create tabs immediately with generated names.
 # prompt_new_tab_name = true
+prompt_new_tab_name = false
 
 # Draw borders around split panes.
 # pane_borders = true


### PR DESCRIPTION
## Why

Switching Herdr tabs should stay fast, and the current default prompts for a new tab name before each new tab is created.

## What Changed

Set `ui.prompt_new_tab_name = false` in `home/dot_herdr/config.toml` so new tabs are created immediately with generated names.

Remove the redundant commented default line for `prompt_new_tab_name` so the Herdr UI setting is documented by the surrounding comments and the active value only.

## Validation

Check that the TOML parses and the Herdr UI setting is disabled.

```shell
python3 - <<'PY'
import tomllib
from pathlib import Path
p = Path('home/dot_herdr/config.toml')
data = tomllib.loads(p.read_text())
assert data['ui']['prompt_new_tab_name'] is False
print('tomllib ok: ui.prompt_new_tab_name is false')
PY
```

Reload the config through Herdr and confirm it is accepted without diagnostics.

```shell
HERDR_CONFIG_PATH="$PWD/home/dot_herdr/config.toml" herdr server reload-config
```
