### PR TITLE
Install Herdr with mise before integrations

### DIFF
--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -36,6 +36,13 @@ function activate_mise() {
 }
 
 #
+# @description Install Herdr with `mise`.
+#
+function install_herdr() {
+    mise install herdr
+}
+
+#
 # @description Install Herdr integrations for every configured coding agent.
 #
 function install_herdr_integrations() {
@@ -60,6 +67,7 @@ function install_herdr_skill() {
 #
 function main() {
     activate_mise
+    install_herdr
     install_herdr_integrations
     install_herdr_skill
 }

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -33,6 +33,18 @@ EOF
     [ "${HERDR_TEST_MISE_ACTIVATED}" = "1" ]
 }
 
+@test "[common] install_herdr installs herdr with mise" {
+    function mise() {
+        printf '%s\n' "$*" > "${BATS_TEST_TMPDIR}/mise_args.txt"
+    }
+
+    install_herdr
+
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "install herdr" ]
+}
+
 @test "[common] install_herdr_integrations installs configured integrations" {
     function herdr() {
         printf '%s\n' "$*" >> "${BATS_TEST_TMPDIR}/herdr_args.txt"
@@ -63,8 +75,10 @@ EOF
 
     cat > "${MISE_BIN}" << 'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
 if [ "$*" = "activate bash" ]; then
     printf '%s\n' 'export HERDR_TEST_MISE_ACTIVATED=1'
+    printf '%s\n' "export PATH=\"${HOME}/.local/bin:${PATH}\""
 fi
 EOF
     chmod +x "${MISE_BIN}"
@@ -85,10 +99,16 @@ EOF
         DOTFILES_DEBUG=1 \
         HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_args.txt" \
         HOME="${HOME}" \
+        MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt" \
         NPX_CALLS_PATH="${BATS_TEST_TMPDIR}/npx_args.txt" \
         PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
         bash "${SCRIPT_PATH}"
     [ "${status}" -eq 0 ]
+
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "activate bash" ]
+    [ "${lines[1]}" = "install herdr" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

Herdr integrations are installed during the Herdr bootstrap script, but the Herdr binary itself also needs to be installed by mise before those integration commands run.

## What Changed

- Add `install_herdr()` to run `mise install herdr`.
- Call `install_herdr` immediately after mise activation and before integration setup.
- Add bats coverage for the new mise install call and the full script call order.

## Validation

Check the diff for whitespace errors.
```shell
git diff --check
```

Parse the updated Herdr installer script with bash.
```shell
bash -n install/common/herdr.sh
```

Check formatting for the touched shell and bats files.
```shell
shfmt --indent 4 --space-redirects --diff install/common/herdr.sh tests/install/common/herdr.bats
```

Run shellcheck on the updated installer script.
```shell
shellcheck install/common/herdr.sh
```

Local bats tests were not run per repository policy; GitHub Actions is the bats validation path.