### PR TITLE
Fix Herdr install bootstrap through mise

### DIFF
--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -39,7 +39,7 @@ function activate_mise() {
 # @description Install Herdr with `mise`.
 #
 function install_herdr() {
-    mise install herdr
+    "${MISE_BIN}" install herdr
 }
 
 #
@@ -47,7 +47,7 @@ function install_herdr() {
 #
 function install_herdr_integrations() {
     for integration in "${HERDR_INTEGRATIONS[@]}"; do
-        herdr integration install "${integration}"
+        "${MISE_BIN}" exec herdr -- herdr integration install "${integration}"
     done
 }
 
@@ -55,7 +55,7 @@ function install_herdr_integrations() {
 # @description Install the shared Herdr skill globally.
 #
 function install_herdr_skill() {
-    npx -y skills add "${HERDR_SKILL_REPO}" \
+    "${MISE_BIN}" exec node -- npx -y skills add "${HERDR_SKILL_REPO}" \
         --skill "${HERDR_SKILL_NAME}" \
         --agent "${HERDR_SKILL_AGENTS[@]}" \
         --global \

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -15,6 +15,14 @@ function teardown() {
     export PATH
 }
 
+function write_mise_logger() {
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+EOF
+    chmod +x "${MISE_BIN}"
+}
+
 @test "[common] herdr run-once template exists" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
 }
@@ -34,9 +42,9 @@ EOF
 }
 
 @test "[common] install_herdr installs herdr with mise" {
-    function mise() {
-        printf '%s\n' "$*" > "${BATS_TEST_TMPDIR}/mise_args.txt"
-    }
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    export MISE_CALLS_PATH
+    write_mise_logger
 
     install_herdr
 
@@ -46,28 +54,28 @@ EOF
 }
 
 @test "[common] install_herdr_integrations installs configured integrations" {
-    function herdr() {
-        printf '%s\n' "$*" >> "${BATS_TEST_TMPDIR}/herdr_args.txt"
-    }
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    export MISE_CALLS_PATH
+    write_mise_logger
 
     install_herdr_integrations
 
-    run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${lines[0]}" = "integration install claude" ]
-    [ "${lines[1]}" = "integration install codex" ]
+    [ "${lines[0]}" = "exec herdr -- herdr integration install claude" ]
+    [ "${lines[1]}" = "exec herdr -- herdr integration install codex" ]
 }
 
 @test "[common] install_herdr_skill installs the shared skill globally" {
-    function npx() {
-        printf '%s\n' "$*" > "${BATS_TEST_TMPDIR}/npx_args.txt"
-    }
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    export MISE_CALLS_PATH
+    write_mise_logger
 
     install_herdr_skill
 
-    run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "-y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
+    [ "${output}" = "exec node -- npx -y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 }
 
 @test "[common] herdr script runs full installation workflow" {
@@ -79,6 +87,14 @@ printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
 if [ "$*" = "activate bash" ]; then
     printf '%s\n' 'export HERDR_TEST_MISE_ACTIVATED=1'
     printf '%s\n' "export PATH=\"${HOME}/.local/bin:${PATH}\""
+fi
+if [ "$1" = "exec" ]; then
+    shift
+    while [ "$1" != "--" ]; do
+        shift
+    done
+    shift
+    "$@"
 fi
 EOF
     chmod +x "${MISE_BIN}"
@@ -109,6 +125,9 @@ EOF
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "activate bash" ]
     [ "${lines[1]}" = "install herdr" ]
+    [ "${lines[2]}" = "exec herdr -- herdr integration install claude" ]
+    [ "${lines[3]}" = "exec herdr -- herdr integration install codex" ]
+    [ "${lines[4]}" = "exec node -- npx -y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

A fresh macOS `chezmoi apply` can install Herdr with mise and then immediately fail when the script calls `herdr` directly before the newly installed executable is available on `PATH`.

## What Changed

- Install Herdr via `${HOME}/.local/bin/mise` instead of depending on a shell `mise` function or command.
- Run the newly installed Herdr binary through `mise exec herdr -- herdr ...` so mise resolves it before shell `PATH` has been refreshed.
- Run the Herdr skill installer through `mise exec node -- npx ...` for the same fresh-bootstrap robustness.
- Update the Herdr installer Bats expectations to assert the mise-mediated Herdr and `npx` invocations.

## Validation

Check the updated installer script syntax.

```shell
bash -n install/common/herdr.sh
```

Check shell formatting for the installer and tests.

```shell
shfmt -i 4 -sr -d install/common/herdr.sh tests/install/common/herdr.bats
```

Check the installer with ShellCheck.

```shell
shellcheck install/common/herdr.sh
```

Render the chezmoi hook template and check the rendered script syntax.

```shell
chezmoi --source "$PWD/home" execute-template < home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl > /tmp/rendered-install-herdr.sh && bash -n /tmp/rendered-install-herdr.sh
```

A fake mise smoke test verified that the installer uses the direct mise binary and resolves Herdr / `npx` through `mise exec` during a fresh install.

Local Bats tests were not run per repository policy; GitHub Actions validates them.