### PR TITLE
Ignore agent skill lock file

### DIFF
--- a/home/.chezmoitemplates/chezmoiignore.d/common
+++ b/home/.chezmoitemplates/chezmoiignore.d/common
@@ -8,6 +8,7 @@ plugin.jupyterlab-settings
 .ghostty
 .tmux.conf.d/
 .agents/README.md
+.agents/.skill-lock.json
 .claude/README.md
 .codex/README.md
 .config/agents


### PR DESCRIPTION
## Why

The agent skill lock file is runtime state and should not be managed by chezmoi.

## What Changed

- Add `.agents/.skill-lock.json` to the common chezmoi ignore template.

## Validation

Confirm the skill lock file is not managed after the ignore rule is applied; this command prints the expected `not managed` diagnostic.

```shell
chezmoi -S "$PWD/home" status ~/.agents/.skill-lock.json
```

Confirm the generated ignore list includes the skill lock file.

```shell
chezmoi -S "$PWD/home" ignored | rg '^\\.agents/\\.skill-lock\\.json$|skill-lock'\n```\n\nInspect the diff for whitespace errors.\n\n```shell\ngit diff --check\n```