### PR TITLE
chore(mise): install skills cli with mise

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -49,6 +49,7 @@ yq = "latest"
 "npm:fast-cli" = "latest"
 "npm:@openai/codex" = "latest"
 "npm:pyright" = "latest"
+"npm:skills" = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]

--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -27,7 +27,7 @@ readonly HERDR_INTEGRATIONS=(
 )
 
 #
-# @description Activate `mise` so Herdr and Node.js resolve from the configured toolchain.
+# @description Activate `mise` so Herdr and skills resolve from the configured toolchain.
 #
 function activate_mise() {
     if [ -x "${MISE_BIN}" ]; then
@@ -55,7 +55,7 @@ function install_herdr_integrations() {
 # @description Install the shared Herdr skill globally.
 #
 function install_herdr_skill() {
-    "${MISE_BIN}" exec node -- npx -y skills add "${HERDR_SKILL_REPO}" \
+    "${MISE_BIN}" exec npm:skills -- skills add "${HERDR_SKILL_REPO}" \
         --skill "${HERDR_SKILL_NAME}" \
         --agent "${HERDR_SKILL_AGENTS[@]}" \
         --global \

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -75,7 +75,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec node -- npx -y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
+    [ "${output}" = "exec npm:skills -- skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 }
 
 @test "[common] herdr script runs full installation workflow" {
@@ -105,18 +105,18 @@ printf '%s\n' "$*" >> "${HERDR_CALLS_PATH}"
 EOF
     chmod +x "${BATS_TEST_TMPDIR}/bin/herdr"
 
-    cat > "${BATS_TEST_TMPDIR}/bin/npx" << 'EOF'
+    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "${HERDR_TEST_MISE_ACTIVATED:-unset}|$*" > "${NPX_CALLS_PATH}"
+printf '%s\n' "${HERDR_TEST_MISE_ACTIVATED:-unset}|$*" > "${SKILLS_CALLS_PATH}"
 EOF
-    chmod +x "${BATS_TEST_TMPDIR}/bin/npx"
+    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
 
     run env \
         DOTFILES_DEBUG=1 \
         HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_args.txt" \
         HOME="${HOME}" \
         MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt" \
-        NPX_CALLS_PATH="${BATS_TEST_TMPDIR}/npx_args.txt" \
+        SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt" \
         PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
         bash "${SCRIPT_PATH}"
     [ "${status}" -eq 0 ]
@@ -127,14 +127,14 @@ EOF
     [ "${lines[1]}" = "install herdr" ]
     [ "${lines[2]}" = "exec herdr -- herdr integration install claude" ]
     [ "${lines[3]}" = "exec herdr -- herdr integration install codex" ]
-    [ "${lines[4]}" = "exec node -- npx -y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
+    [ "${lines[4]}" = "exec npm:skills -- skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "integration install claude" ]
     [ "${lines[1]}" = "integration install codex" ]
 
-    run cat "${BATS_TEST_TMPDIR}/npx_args.txt"
+    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "1|-y skills add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
+    [ "${output}" = "1|add ogulcancelik/herdr --skill herdr --agent claude-code codex antigravity-cli --global --yes" ]
 }


### PR DESCRIPTION
## Summary
- add the npm `skills` CLI to the mise-managed tool list
- run Herdr skill installation through `mise exec npm:skills -- skills` instead of `npx`
- update Herdr installer tests to expect the mise-managed `skills` binary

## Validation
- `python3 -c 'import tomllib; tomllib.load(open("home/dot_mise/config.toml", "rb"))'`
- `shfmt -i 4 -sr -d install/common/herdr.sh`
- `shellcheck install/common/herdr.sh`
- `bash -n install/common/herdr.sh`
- rendered `run_once_after_03-install-herdr.sh.tmpl` with chezmoi and checked it with `bash -n`
- `git diff --check`
- manual stub run for the Herdr install workflow