### PR TITLE
Disable Claude Code auto-updater

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -1,6 +1,9 @@
 {
   "model": "opusplan",
   "alwaysThinkingEnabled": true,
+  "env": {
+    "DISABLE_AUTOUPDATER": "1"
+  },
   "plansDirectory": "./.agents/worklog/claude",
   "permissions": {
     "deny": [


### PR DESCRIPTION
## Summary
- Disable the Claude Code auto-updater through the shared Claude settings file.
- Keep manual updates available by using DISABLE_AUTOUPDATER instead of DISABLE_UPDATES.

## Testing
- python3 -m json.tool home/dot_config/claude/settings.json >/dev/null
- git diff --check