### PR TITLE
chore(renovate): add self-hosted workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "branchPrefix": "renovate/",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "mise": {
+    "managerFilePatterns": [
+      "/(^|/)home/dot_mise/config\\.toml$/"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["mise"],
+      "matchPackageNames": [
+        "npm:@anthropic-ai/claude-code",
+        "npm:@openai/codex"
+      ],
+      "groupName": "agent CLIs"
+    },
+    {
+      "matchManagers": ["mise"],
+      "groupName": "mise tools",
+      "matchPackageNames": [
+        "!npm:@anthropic-ai/claude-code",
+        "!npm:@openai/codex"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,30 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MY_SELF_HOSTED_RENOVATE_CLIENT_ID }}
+          private-key: ${{ secrets.MY_SELF_HOSTED_RENOVATE_APP_PRIVATE_KEY }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.17
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_LEVEL: info
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- add a self-hosted Renovate workflow authenticated with the configured GitHub App client ID and private key
- add `.github/renovate.json` for mise-managed tool updates under `home/dot_mise/config.toml`
- group agent CLI updates separately from the rest of mise-managed tools and apply a 7-day release age gate

## Notes
- Tracks https://github.com/shunk031/dotfiles/issues/496
- This should be most useful after https://github.com/shunk031/dotfiles/pull/494 lands, because the current default branch still contains many `latest` mise values that Renovate treats as invalid values.

## Testing
- `python3 -m json.tool .github/renovate.json`
- `node -e 'JSON.parse(require("fs").readFileSync(".github/renovate.json", "utf8")); console.log("renovate.json ok")'`\n- `npx --yes --package renovate renovate-config-validator .github/renovate.json`\n- `mise exec actionlint@1.7.12 -- actionlint -ignore 'missing input "app-id"' -ignore 'input "client-id" is not defined' .github/workflows/renovate.yaml`\n- `git diff --check`