### PR TITLE
Install mise tools after chezmoi apply

### DIFF
--- a/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# @file home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
+# @brief Install pinned mise tools after `chezmoi apply`.
+# @description
+#   Keeps mise-managed tools aligned with the applied pinned versions while
+#   leaving first-time mise bootstrap to the existing run-once install script.
+
+set -Eeuo pipefail
+
+readonly MISE_BIN="${HOME}/.local/bin/mise"
+readonly DEFAULT_MISE_MIN_RELEASE_AGE_DAYS=7
+
+if [ ! -x "${MISE_BIN}" ]; then
+    exit 0
+fi
+
+unset MISE_CURRENT_VERSION
+unset MISE_VERSION
+
+if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh > /dev/null 2>&1; then
+    if GITHUB_TOKEN="$(gh auth token 2> /dev/null)" && [ -n "${GITHUB_TOKEN}" ]; then
+        export GITHUB_TOKEN
+    else
+        unset GITHUB_TOKEN
+    fi
+fi
+
+"${MISE_BIN}" install --before "${DEFAULT_MISE_MIN_RELEASE_AGE_DAYS}d"

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -2,10 +2,19 @@
 
 readonly SCRIPT_PATH="./install/common/mise.sh"
 readonly TMPL_SCRIPT_GLOB="./home/.chezmoiscripts/common/run_once_after_*-install-mise.sh.tmpl"
+readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
 
 function setup() {
     export HOME="${BATS_TEST_TMPDIR}/home"
-    mkdir -p "${HOME}/.local/bin"
+    export TEST_BIN_DIR="${BATS_TEST_TMPDIR}/bin"
+    export MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_calls.txt"
+    export GH_CALLS_PATH="${BATS_TEST_TMPDIR}/gh_calls.txt"
+    PATH="${TEST_BIN_DIR}:$(getconf PATH)"
+    export PATH
+
+    mkdir -p "${HOME}/.local/bin" "${TEST_BIN_DIR}"
+    rm -f "${MISE_CALLS_PATH}" "${GH_CALLS_PATH}"
+    unset GITHUB_TOKEN
 
     source "${SCRIPT_PATH}"
 }
@@ -14,10 +23,39 @@ function teardown() {
     if [ -e "${MISE_INSTALL_PATH}" ]; then
         uninstall_mise
     fi
+}
 
-    # reset PATH
-    PATH=$(getconf PATH)
-    export PATH
+function write_mise_stub() {
+    cat > "${MISE_INSTALL_PATH}" << 'EOF'
+#!/usr/bin/env bash
+
+printf "%s\n" "$*" >> "${MISE_CALLS_PATH}"
+printf "GITHUB_TOKEN=%s\n" "${GITHUB_TOKEN:-}" >> "${MISE_CALLS_PATH}"
+EOF
+
+    chmod +x "${MISE_INSTALL_PATH}"
+}
+
+function write_gh_stub() {
+    cat > "${TEST_BIN_DIR}/gh" << 'EOF'
+#!/usr/bin/env bash
+
+printf "%s\n" "$*" >> "${GH_CALLS_PATH}"
+printf "stub-token\n"
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gh"
+}
+
+function write_failing_gh_stub() {
+    cat > "${TEST_BIN_DIR}/gh" << 'EOF'
+#!/usr/bin/env bash
+
+printf "%s\n" "$*" >> "${GH_CALLS_PATH}"
+exit 1
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gh"
 }
 
 @test "[common] mise" {
@@ -41,4 +79,64 @@ function teardown() {
     run cat "${BATS_TEST_TMPDIR}/mise_install_args.txt"
     [ "${status}" -eq 0 ]
     [ "${output}" = "install --before ${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d" ]
+}
+
+@test "[common] run_after template installs pinned mise tools after apply" {
+    write_mise_stub
+
+    run bash "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=' ]
+}
+
+@test "[common] run_after template skips when mise is not installed" {
+    write_gh_stub
+
+    run bash "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+    [ ! -e "${MISE_CALLS_PATH}" ]
+    [ ! -e "${GH_CALLS_PATH}" ]
+}
+
+@test "[common] run_after template reuses existing GITHUB_TOKEN" {
+    write_mise_stub
+    write_gh_stub
+    export GITHUB_TOKEN="existing-token"
+
+    run bash "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=existing-token' ]
+    [ ! -e "${GH_CALLS_PATH}" ]
+}
+
+@test "[common] run_after template exports gh token when GITHUB_TOKEN is unset" {
+    write_mise_stub
+    write_gh_stub
+
+    run bash "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=stub-token' ]
+    [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
+}
+
+@test "[common] run_after template continues when gh token lookup fails" {
+    write_mise_stub
+    write_failing_gh_stub
+
+    run bash "${RUN_AFTER_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=' ]
+    [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }


### PR DESCRIPTION
## Why

Fixes #496.

Pinned mise tool versions need a post-merge update path that runs during normal `chezmoi apply`, so merged Renovate bumps are installed without relying on first-time bootstrap or direct self-updaters.

## What Changed

Adds a `run_after` chezmoi script that runs after `chezmoi apply` and invokes `${HOME}/.local/bin/mise install --before 7d`.

Skips when mise is not installed, leaving first-time bootstrap to the existing run-once script.

Reuses an existing `GITHUB_TOKEN`; otherwise, it uses `gh auth token` when available. If token lookup fails, the script continues without a token.

Adds bats coverage for install invocation, missing mise skip, token reuse, gh token export, and gh failure fallback.

## Validation

Render the chezmoi template and check the rendered shell syntax.

```shell
chezmoi --source "$PWD/home" execute-template < home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl | bash -n
```

Check the template shell syntax directly.

```shell
bash -n home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Check formatting for the updated shell and bats files.

```shell
shfmt -i 4 -sr -d home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl tests/install/common/mise.bats
```

Run shellcheck on the new run_after template.

```shell
shellcheck home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Check the diff for whitespace errors.

```shell
git diff --check
```

Local bats intentionally not run per repository policy; bats validation is left to GitHub Actions CI.
