### PR TITLE
Configure Python runtime Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,8 +22,21 @@
     },
     {
       "matchManagers": ["mise"],
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["minor", "major"],
+      "groupName": "Python runtime"
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["mise"],
       "groupName": "mise tools",
       "matchPackageNames": [
+        "!python",
         "!npm:@anthropic-ai/claude-code",
         "!npm:@openai/codex"
       ]


### PR DESCRIPTION
## Why

Python runtime-line updates such as 3.11 to 3.12 are larger than patch updates and should be reviewed separately from the generic mise tools group.

## What Changed

- Added a Python-specific Renovate package rule for mise minor and major updates.
- Disabled Python patch update PRs.
- Excluded Python from the generic mise tools group.

## Validation

- `jq . .github/renovate.json >/dev/null`
- `npx --yes --package renovate -- renovate-config-validator`