### PR TITLE
Ignore generated Claude hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ home/dot_config/exact_agents/skills/*
 # after the allowlist entries above because the last matching pattern wins.
 home/dot_config/exact_agents/skills/*/.playwright-cli/
 
+# Herdr and other integrations may generate Claude hooks here. Ignore generated
+# hooks by default and explicitly allow repo-managed hooks below.
+home/dot_config/claude/hooks/*
+!home/dot_config/claude/hooks/enforce-uv.sh
+
 home/dot_config/claude/commands/agmsg.md
 
 ### Python ###


### PR DESCRIPTION
## Why
Generated Claude hooks can be written into `home/dot_config/claude/hooks/` by local integrations, but only repo-managed hooks should be tracked.

## What Changed
Ignored generated files under `home/dot_config/claude/hooks/` by default.

Allowed the repo-managed `home/dot_config/claude/hooks/enforce-uv.sh` hook to remain trackable.

## Validation
Verify GitHub CLI authentication before creating the pull request.
```shell
gh api user --jq '{login: .login, id: .id}'
```

Inspect that only `.gitignore` changed in the commit.
```shell
git diff --name-status HEAD~1..HEAD
```

Check the `.gitignore` diff for whitespace errors.
```shell
git diff --check -- .gitignore
```