### PR TITLE
Clarify Renovate cron schedule

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 18 * * 0"
+    - cron: "0 18 * * 0" # At 18:00 on Sunday.
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Document the existing Renovate scheduled run time so the cron expression is easier to read.

## What Changed

Added an inline YAML comment next to the existing Renovate schedule cron expression. This only changes the workflow comment.

## Validation

Inspect the exact workflow diff.

```shell
git diff HEAD~1 -- .github/workflows/renovate.yaml
```

Check the committed diff for whitespace errors.

```shell
git diff --check HEAD~1..HEAD
```

Confirm the updated cron comment is present.

```shell
rg -n 'cron: "0 18 \\* \\* 0" # At 18:00 on Sunday\\.' .github/workflows/renovate.yaml\n```\n\nLocal bats tests were not run per repository policy; GitHub Actions CI is the validation source for bats.