### PR TITLE
Clarify Renovate cron schedule

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 18 * * 0"
+    - cron: "0 18 * * 0" # At 18:00 on Sunday.
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The Renovate workflow has a scheduled run, but the cron expression is not self-describing at a glance.

## What Changed

Document the existing Renovate scheduled run time next to the cron expression.

Only the workflow comment changes; the schedule itself remains unchanged.

## Validation

Inspect the worktree status to confirm only the intended file changed before commit.
```shell
git status --short
```

Inspect the workflow diff to confirm the cron expression is unchanged and only the comment was added.
```shell
git diff -- .github/workflows/renovate.yaml
```

Local bats tests were not run, per repository policy.