### PR TITLE
Use aqua backends for supported mise tools

### DIFF
--- a/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
@@ -9,7 +9,6 @@
 set -Eeuo pipefail
 
 readonly MISE_BIN="${HOME}/.local/bin/mise"
-readonly DEFAULT_MISE_MIN_RELEASE_AGE_DAYS=7
 
 if [ ! -x "${MISE_BIN}" ]; then
     exit 0
@@ -26,4 +25,4 @@ if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh > /dev/null 2>&1; then
     fi
 fi
 
-"${MISE_BIN}" install --before "${DEFAULT_MISE_MIN_RELEASE_AGE_DAYS}d"
+"${MISE_BIN}" install

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -8,47 +8,53 @@ python = "3.11"
 rust = "1.96.0"
 
 # CLI tools
-age = "1.3.1"
-aws-cli = "2.35.15"
-bats = "1.13.0"
 bun = "1.3.14"
-chezmoi = "2.70.5"
-dotenvx = "2.1.4"
-dust = "1.2.4"
 eza = "0.23.4"
-fd = "10.4.2"
 gcloud = "575.0.0"
 herdr = "0.7.1"
-jq = "1.8.2"
-kubectx = "0.11.0"
-rg = "15.1.0"
-shellcheck = "0.11.0"
-shfmt = "3.13.1"
 sqlite = "3.53.3"
-uv = "0.11.26"
-yazi = "26.5.6"
-yq = "4.53.3"
 
 # Aqua tools
+"aqua:FiloSottile/age" = "1.3.1"
 "aqua:google-antigravity/antigravity-cli" = "1.0.16"
+"aqua:aws/aws-cli" = "2.35.15"
+"aqua:bats-core/bats-core" = "1.13.0"
+"aqua:twpayne/chezmoi" = "2.70.5"
+"aqua:anthropics/claude-code" = "2.1.201"
+"aqua:openai/codex" = "0.142.5"
+"aqua:dotenvx/dotenvx" = "2.1.4"
+"aqua:bootandy/dust" = "1.2.4"
+"aqua:sharkdp/fd" = "10.4.2"
+"aqua:cli/cli" = "2.96.0"
+"aqua:x-motemen/ghq" = "1.10.1"
+"aqua:jqlang/jq" = "1.8.2"
+"aqua:ahmetb/kubectx" = "0.11.0"
+"aqua:BurntSushi/ripgrep" = "15.1.0"
+"aqua:koalaman/shellcheck" = "0.11.0"
+"aqua:mvdan/sh" = "3.13.1"
+"aqua:astral-sh/uv" = "0.11.26"
+"aqua:sxyazi/yazi" = "26.5.6"
+"aqua:mikefarah/yq" = "4.53.3"
 
 # Cargo tools
 "cargo:pueue" = "4.0.4"
 
 # GitHub release tools
-"github:cli/cli" = "2.96.0"
 "github:d-kuro/gwq" = "0.1.1"
 "github:shuntaka9576/blocc" = { version = "0.6.0", os = ["linux"] }
-"github:x-motemen/ghq" = "1.10.1"
 
 # npm tools
 "npm:agmsg" = "1.1.5"
-"npm:@anthropic-ai/claude-code" = "2.1.201"
 "npm:bash-language-server" = "5.6.0"
 "npm:fast-cli" = "5.2.0"
-"npm:@openai/codex" = "0.142.5"
 "npm:pyright" = "1.1.411"
 "npm:skills" = "1.5.14"
 
 [settings]
 idiomatic_version_file_enable_tools = ["python"]
+minimum_release_age = "7d"
+minimum_release_age_excludes = [
+  "aqua:anthropics/claude-code",
+  "aqua:openai/codex",
+  "aqua:google-antigravity/antigravity-cli",
+]

--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -12,7 +12,6 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 export MISE_INSTALL_PATH="${HOME}/.local/bin/mise"
-readonly DEFAULT_NPM_MIN_RELEASE_AGE_DAYS=7
 
 #
 # @description Install the pinned standalone `mise` binary and activate it.
@@ -30,13 +29,13 @@ function install_mise() {
 }
 
 #
-# @description Run `mise install` with the repository npm age gate.
+# @description Run `mise install` with release-age policy from the mise config.
 #
 function run_mise_install() {
     # These installer envvars are interpreted by mise as tool env overrides.
     unset MISE_CURRENT_VERSION
     unset MISE_VERSION
-    mise install --before "${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d"
+    mise install
 }
 
 #

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -67,7 +67,7 @@ EOF
     [ -x "$(command -v mise)" ]
 }
 
-@test "[common] run_mise_install uses hardcoded min-release-age days" {
+@test "[common] run_mise_install uses mise config release-age policy" {
     printf "min-release-age=99\n" > "${HOME}/.npmrc"
 
     function mise() {
@@ -78,7 +78,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/mise_install_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "install --before ${DEFAULT_NPM_MIN_RELEASE_AGE_DAYS}d" ]
+    [ "${output}" = "install" ]
 }
 
 @test "[common] run_after template installs pinned mise tools after apply" {
@@ -89,7 +89,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nGITHUB_TOKEN=' ]
 }
 
 @test "[common] run_after template skips when mise is not installed" {
@@ -111,7 +111,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=existing-token' ]
+    [ "${output}" = $'install\nGITHUB_TOKEN=existing-token' ]
     [ ! -e "${GH_CALLS_PATH}" ]
 }
 
@@ -124,7 +124,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=stub-token' ]
+    [ "${output}" = $'install\nGITHUB_TOKEN=stub-token' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }
 
@@ -137,6 +137,6 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install --before 7d\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nGITHUB_TOKEN=' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }


### PR DESCRIPTION
## Summary
- move mise-managed tools with aqua registry support to explicit `aqua:` backend entries
- move Claude Code and Codex from npm backend to their aqua registry entries
- keep tools without aqua registry mappings on their current backends
- move the 7-day release-age gate into mise settings and exclude fast-moving agent tools with full aqua backend IDs

## Validation
- `python3 - <<'PY' ... tomllib.loads(...) ... PY`
- `MISE_GLOBAL_CONFIG_FILE="$PWD/home/dot_mise/config.toml" ~/.local/bin/mise settings ls --all --json-extended | jq '{minimum_release_age, minimum_release_age_excludes}'`
- `bash -n install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl`
- `shellcheck install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl`
- `git diff --check`
- `MISE_GLOBAL_CONFIG_FILE="$PWD/home/dot_mise/config.toml" ~/.local/bin/mise install --dry-run --yes`

Note: local Bats tests were not run per repository policy; GitHub Actions covers them.
