### PR TITLE
chore(claude): add Herdr session start hook

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -50,6 +50,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/herdr-agent-state.sh session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Why

Claude Code should report session state to Herdr when a session starts.

## What Changed

Added a `hooks.SessionStart` command to `home/dot_config/claude/settings.json` that runs the repo-managed Herdr agent state hook with the existing `~/.claude/hooks/...` path style.

Preserved the existing settings order and the upstream `env.DISABLE_AUTOUPDATER` setting.

## Validation

Validate the Claude settings JSON syntax.

```shell
python -m json.tool home/dot_config/claude/settings.json >/dev/null
```

Check the diff for whitespace errors.

```shell
git diff --check
```

Bats tests were not run locally per repository policy; CI will validate them.