### PR TITLE
fix(claude): add Herdr session start hook

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -50,6 +50,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/herdr-agent-state.sh\" session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Why

Claude sessions should publish Herdr agent state when a session starts without depending on a root-specific absolute path.

## What Changed

Added a `SessionStart` hook to `home/dot_config/claude/settings.json` that invokes the generated Herdr hook through `$HOME/.claude/hooks/herdr-agent-state.sh`.

## Validation

Validate the Claude settings JSON syntax.

```shell
mise exec jq@1.8.1 -- jq empty home/dot_config/claude/settings.json
```

Inspect the staged diff for whitespace errors.

```shell
git diff --check
```