### PR TITLE
feat(claude): add herdr session start hook

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -50,6 +50,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '~/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Why

Claude sessions should notify the generated Herdr agent-state hook when a session starts.

## What Changed

Added a `SessionStart` hook to `home/dot_config/claude/settings.json` that runs `bash '~/.claude/hooks/herdr-agent-state.sh' session` with a 10-second timeout.\n\n## Validation\n\nValidate the Claude settings JSON syntax.\n\n```shell\njq empty home/dot_config/claude/settings.json\n```\n\nLocal `bats` tests were not run, per repository policy.