### PR TITLE
Warm up GPG signing cache during install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -159,8 +159,19 @@ jobs:
             exit 1
           fi
 
-      - name: Upload coverage to Codecov
+      - name: Check coverage report
+        id: coverage-report
         if: ${{ needs.changes.outputs.should_test == 'true' && github.actor != 'dependabot[bot]' }}
+        run: |
+          if [ -f ./coverage/coverage.xml ]; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::coverage/coverage.xml was not generated; skipping Codecov upload."
+          fi
+
+      - name: Upload coverage to Codecov
+        if: ${{ needs.changes.outputs.should_test == 'true' && github.actor != 'dependabot[bot]' && steps.coverage-report.outputs.exists == 'true' }}
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/home/.chezmoiscripts/common/run_once_after_98-warmup-gpg-signing-cache.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_once_after_98-warmup-gpg-signing-cache.sh.tmpl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Keep this run-once script near the end of the install flow because it may
+# prompt for the GPG signing passphrase. It intentionally runs after chezmoi
+# has applied ~/.gnupg/gpg-agent.conf, private keys, and git config, and just
+# before the existing run_once_after_99-install-gh-extensions.sh.tmpl step.
+# The later run_after_99-refresh-chezmoi-notify-cache.sh.tmpl is lightweight
+# and runs on every apply, so the interactive GPG warm-up stays in this
+# run-once step instead.
+
+{{ include "../install/common/gpg.sh" }}

--- a/install/common/gpg.sh
+++ b/install/common/gpg.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# @file install/common/gpg.sh
+# @brief Warm up the GPG signing cache for git commits.
+# @description
+#   Prompts for the GPG signing passphrase in interactive installs so later
+#   signed git commits can reuse the long-lived gpg-agent cache.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+#
+# @description Check whether the script is running in CI.
+#
+function is_ci() {
+    [ "${CI:-false}" = "true" ]
+}
+
+#
+# @description Check whether stdin is an interactive terminal.
+#
+function is_interactive_tty() {
+    [ -t 0 ]
+}
+
+#
+# @description Check whether git commit signing is enabled.
+#
+function is_git_commit_signing_enabled() {
+    local gpgsign
+
+    if ! command -v git > /dev/null 2>&1; then
+        return 1
+    fi
+
+    if ! gpgsign="$(git config --get --bool commit.gpgsign 2> /dev/null)"; then
+        return 1
+    fi
+
+    [ "${gpgsign}" = "true" ]
+}
+
+#
+# @description Print the configured git signing key when one is available.
+#
+function get_git_signing_key() {
+    if ! command -v git > /dev/null 2>&1; then
+        return 0
+    fi
+
+    git config --get user.signingkey 2> /dev/null || true
+}
+
+#
+# @description Reload gpg-agent so the applied gpg-agent config is active.
+#
+function reload_gpg_agent() {
+    if command -v gpgconf > /dev/null 2>&1; then
+        gpgconf --reload gpg-agent > /dev/null 2>&1 || true
+    fi
+}
+
+#
+# @description Run a small signing operation to populate the gpg-agent cache.
+#
+function warmup_gpg_signing_cache() {
+    local signing_key
+    signing_key="$(get_git_signing_key)"
+
+    reload_gpg_agent
+
+    if [ -t 0 ]; then
+        export GPG_TTY
+        GPG_TTY="$(tty)"
+    fi
+
+    if [ -n "${signing_key}" ]; then
+        printf "dotfiles gpg signing cache warm-up\n" |
+            gpg --local-user "${signing_key}" --clearsign > /dev/null
+    else
+        printf "dotfiles gpg signing cache warm-up\n" |
+            gpg --clearsign > /dev/null
+    fi
+}
+
+#
+# @description Run the GPG signing cache warm-up when the environment supports it.
+#
+function main() {
+    if is_ci; then
+        echo "Skipping GPG signing cache warm-up in CI."
+        return 0
+    fi
+
+    if ! is_interactive_tty; then
+        echo "Skipping GPG signing cache warm-up because stdin is not a TTY."
+        return 0
+    fi
+
+    if ! command -v gpg > /dev/null 2>&1; then
+        echo "Warning: gpg is not installed. Skipping GPG signing cache warm-up." >&2
+        return 0
+    fi
+
+    if ! is_git_commit_signing_enabled; then
+        echo "Skipping GPG signing cache warm-up because commit.gpgsign is not true."
+        return 0
+    fi
+
+    echo "Warming up GPG signing cache. This may prompt for your GPG passphrase."
+    if ! warmup_gpg_signing_cache; then
+        echo "Warning: Failed to warm up GPG signing cache. Continuing install." >&2
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/tests/install/common/gpg.bats
+++ b/tests/install/common/gpg.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/common/gpg.sh"
+readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_once_after_98-warmup-gpg-signing-cache.sh.tmpl"
+
+function setup() {
+    export HOME="${BATS_TEST_TMPDIR}/home"
+    export TEST_BIN_DIR="${BATS_TEST_TMPDIR}/bin"
+    export GIT_CONFIG_PATH="${BATS_TEST_TMPDIR}/git_config.txt"
+    export GPG_CALLS_PATH="${BATS_TEST_TMPDIR}/gpg_calls.txt"
+    export GPGCONF_CALLS_PATH="${BATS_TEST_TMPDIR}/gpgconf_calls.txt"
+    PATH="${TEST_BIN_DIR}:$(getconf PATH)"
+    export PATH
+
+    mkdir -p "${HOME}" "${TEST_BIN_DIR}"
+    rm -f "${GIT_CONFIG_PATH}" "${GPG_CALLS_PATH}" "${GPGCONF_CALLS_PATH}"
+    unset CI
+
+    source "${SCRIPT_PATH}"
+}
+
+function write_git_stub() {
+    cat > "${TEST_BIN_DIR}/git" << 'EOF'
+#!/usr/bin/env bash
+
+if [ "$1" = "config" ] && [ "$2" = "--get" ] && [ "$3" = "--bool" ] && [ "$4" = "commit.gpgsign" ]; then
+    sed -n 's/^commit.gpgsign=//p' "${GIT_CONFIG_PATH}"
+    exit 0
+fi
+
+if [ "$1" = "config" ] && [ "$2" = "--get" ] && [ "$3" = "user.signingkey" ]; then
+    sed -n 's/^user.signingkey=//p' "${GIT_CONFIG_PATH}"
+    exit 0
+fi
+
+exit 1
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/git"
+}
+
+function write_gpg_stub() {
+    cat > "${TEST_BIN_DIR}/gpg" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s\n' "$*" >> "${GPG_CALLS_PATH}"
+cat > /dev/null
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gpg"
+}
+
+function write_failing_gpg_stub() {
+    cat > "${TEST_BIN_DIR}/gpg" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s\n' "$*" >> "${GPG_CALLS_PATH}"
+cat > /dev/null
+exit 1
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gpg"
+}
+
+function write_gpgconf_stub() {
+    cat > "${TEST_BIN_DIR}/gpgconf" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s\n' "$*" >> "${GPGCONF_CALLS_PATH}"
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gpgconf"
+}
+
+@test "[common] gpg warm-up run-once template exists" {
+    [ -f "${TMPL_SCRIPT_PATH}" ]
+}
+
+@test "[common] gpg warm-up template documents install ordering" {
+    grep -F "run_once_after_99-install-gh-extensions.sh.tmpl" "${TMPL_SCRIPT_PATH}"
+    grep -F "run_after_99-refresh-chezmoi-notify-cache.sh.tmpl" "${TMPL_SCRIPT_PATH}"
+    grep -F "gpg-agent.conf" "${TMPL_SCRIPT_PATH}"
+    grep -F "private keys" "${TMPL_SCRIPT_PATH}"
+    grep -F "git config" "${TMPL_SCRIPT_PATH}"
+}
+
+@test "[common] gpg warm-up skips when commit signing is disabled" {
+    write_git_stub
+    write_gpg_stub
+    printf '%s\n' "commit.gpgsign=false" > "${GIT_CONFIG_PATH}"
+
+    function is_interactive_tty() {
+        return 0
+    }
+
+    run main
+    [ "${status}" -eq 0 ]
+    [ ! -e "${GPG_CALLS_PATH}" ]
+}
+
+@test "[common] gpg warm-up uses configured signing key" {
+    write_git_stub
+    write_gpg_stub
+    write_gpgconf_stub
+    {
+        printf '%s\n' "commit.gpgsign=true"
+        printf '%s\n' "user.signingkey=D55D775A7951407C"
+    } > "${GIT_CONFIG_PATH}"
+
+    function is_interactive_tty() {
+        return 0
+    }
+
+    run main
+    [ "${status}" -eq 0 ]
+
+    run cat "${GPG_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "--local-user D55D775A7951407C --clearsign" ]
+
+    run cat "${GPGCONF_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "--reload gpg-agent" ]
+}
+
+@test "[common] gpg warm-up signs without local user when signing key is unset" {
+    write_git_stub
+    write_gpg_stub
+    printf '%s\n' "commit.gpgsign=true" > "${GIT_CONFIG_PATH}"
+
+    function is_interactive_tty() {
+        return 0
+    }
+
+    run main
+    [ "${status}" -eq 0 ]
+
+    run cat "${GPG_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "--clearsign" ]
+}
+
+@test "[common] gpg warm-up continues when signing fails" {
+    write_git_stub
+    write_failing_gpg_stub
+    printf '%s\n' "commit.gpgsign=true" > "${GIT_CONFIG_PATH}"
+
+    function is_interactive_tty() {
+        return 0
+    }
+
+    run main
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Warning: Failed to warm up GPG signing cache. Continuing install."* ]]
+}
+
+@test "[common] gpg warm-up skips in CI" {
+    write_git_stub
+    write_gpg_stub
+    export CI=true
+
+    function is_interactive_tty() {
+        return 0
+    }
+
+    run main
+    [ "${status}" -eq 0 ]
+    [ ! -e "${GPG_CALLS_PATH}" ]
+}


### PR DESCRIPTION
## Summary
- add an install/common/gpg.sh helper that warms up the GPG signing cache for signed git commits
- run it once near the end of chezmoi apply with comments explaining the ordering
- cover skip, signing-key, failure, CI, and template-comment behavior with bats tests
- skip Codecov upload when bashcov does not generate coverage/coverage.xml

## Testing
- bash -n install/common/gpg.sh
- git diff --check
- GitHub Actions CI