### PR TITLE
fix(claude): preserve local settings after conflict

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opusplan",
+  "model": "claude-fable-5",
   "alwaysThinkingEnabled": true,
   "env": {
     "DISABLE_AUTOUPDATER": "1"
@@ -68,6 +68,7 @@
     "type": "command",
     "command": "npx ccstatusline@latest"
   },
+  "skipDangerousModePermissionPrompt": true,
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true,
     "claude-mem@thedotmack": true


### PR DESCRIPTION
## Summary
- switch the Claude Code model setting to claude-fable-5
- preserve skipDangerousModePermissionPrompt in the shared Claude settings
- keep the existing SessionStart hook command unchanged to avoid noisy conflict-prone rewrites

## Tests
- python3 -m json.tool home/dot_config/claude/settings.json >/dev/null
- git diff --check