### PR TITLE
feat(delegate-codex): add global delegation skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ home/dot_config/exact_agents/skills/*
 !home/dot_config/exact_agents/skills/ai-slop-checklist-ja/**
 !home/dot_config/exact_agents/skills/convert-to-transformers/
 !home/dot_config/exact_agents/skills/convert-to-transformers/**
+!home/dot_config/exact_agents/skills/delegate-codex/
+!home/dot_config/exact_agents/skills/delegate-codex/**
 !home/dot_config/exact_agents/skills/gh-comment-attach-files/
 !home/dot_config/exact_agents/skills/gh-comment-attach-files/**
 !home/dot_config/exact_agents/skills/high-impact-journal-publishing/

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: delegate-codex
+description: 実装タスクを herdr の新しいラベル付き tab 上の使い捨て実装者 Codex に agmsg 経由で委譲する。どのリポジトリでも、実装・修正・コミット・push・PR 作成を任せるとき、「codex にやらせて」「実装者に依頼」「委譲して」のとき、および main が自分でコードを書き始めそうなときに必ず使う。
+---
+
+# Delegate Codex
+
+## Overview
+
+Delegate implementation work to a disposable Codex implementer in a fresh Herdr tab and coordinate through agmsg. Keep repository changes, push, PR creation, and CI confirmation on the implementer side while `main` stays focused on task framing, monitoring, review, approval, merge decisions, and cleanup.
+
+This skill is intentionally repository-agnostic. Do not encode local-only settings here. For environment-specific Codex trust, launch options, git, or GitHub behavior, read `~/.agents/AGENTS-private.md` and follow the relevant section.
+
+## Roles And Naming
+
+- Team: derive the agmsg team name from the repository remote, not from the worktree directory:
+
+  ```shell
+  basename -s .git "$(git remote get-url origin)"
+  ```
+
+  Worktree directories managed by `gwq` may include `=branch` suffixes, so directory names are not stable team names.
+- Coordinator role: `main`.
+- Implementer role: `impl-<task-slug>`.
+- Herdr tab label: `impl: <task-slug>`.
+- Use a short, descriptive task slug such as `fix-ci`, `add-login-test`, or `delegate-codex-global`.
+
+## Ownership Rules
+
+- Disposable implementer: create a fresh implementer for each task. Use one task, one implementer, one worktree, and one Herdr tab. Do not keep or share a long-lived generic `impl` role.
+- Worktree boundary: use one worktree for one implementer. Do not join multiple Codex identities to the same project path because agmsg inbox polling may select only one matching identity for a `(project, type)` pair.
+- User ownership: if the user starts giving direct instructions in an implementer's pane, treat that instance as user-occupied. From that point, `main` must not operate that pane with Herdr and must not send agmsg tasks to that role. Spawn a new implementer for any new task.
+- Occupancy check: before nudging a pane, inspect the recent transcript:
+
+  ```shell
+  herdr pane read <pane_id> --source recent-unwrapped
+  ```
+
+  If the transcript shows a task, plan, or conversation that `main` does not remember assigning, treat the pane as user-occupied and spawn a new implementer instead of nudging it.
+
+## Spawn
+
+Use the bundled wrapper to create the implementer in a new Herdr tab:
+
+```shell
+TEAM=$(basename -s .git "$(git remote get-url origin)")
+NAME=impl-<task-slug>
+PROJECT=<task-worktree-path>
+scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT" [boot-prompt]
+```
+
+The wrapper calls `~/.agents/skills/agmsg/scripts/spawn.sh` with a Herdr terminal template. Environment-specific Codex CLI arguments are injected by agmsg from `~/.agmsg/config/spawn_options.yaml`; see `~/.agents/AGENTS-private.md` for the local values and setup steps.
+
+Before the first spawn in a new project or worktree, confirm the Codex trust settings for that path; see `~/.agents/AGENTS-private.md` for the local trust procedure. In tmux environments, agmsg `spawn.sh` also supports its standard `--split` mode, but this skill's Herdr wrapper creates a new labeled tab so it does not split the user's current pane.
+
+Before launching the implementer, inspect the worktree's messaging identity:
+
+```shell
+~/.agents/skills/agmsg/scripts/whoami.sh "$PROJECT" codex
+```
+
+If another Codex identity is already registered for this project path, do not reuse that worktree for a new implementer. Create a fresh worktree or clean up the stale registration first.
+
+## Task Message
+
+Send the task from `main` to the implementer with agmsg:
+
+```shell
+~/.agents/skills/agmsg/scripts/send.sh "$TEAM" main "$NAME" "<message>"
+```
+
+Use this template:
+
+```markdown
+## 背景
+
+## 変更対象
+
+## 完了条件
+
+## 報告
+```
+
+In `## 変更対象`, list concrete file paths and ownership boundaries. In `## 完了条件`, list the exact verification commands or CI expectations. In `## 報告`, ask the implementer to reply with the PR URL, CI state, and any review notes. The implementer's own GitHub workflow guidance is responsible for commit, push, PR, and CI discipline.
+
+## Nudge Rules
+
+- Nudge only through the bundled helper:
+
+  ```shell
+  scripts/nudge-codex.sh <pane_id> "inbox を確認して着手してください"
+  ```
+
+- Do not force-queue messages into a working pane with `herdr pane send-keys <pane_id> tab`. agmsg messages remain in the recipient's inbox, so wait until the Codex pane is idle and nudge then.
+- If `nudge-codex.sh` exits with code 3, the pane is not idle. Wait until the pane's `agent_status` is no longer `working`, then retry the nudge.
+- Always run the occupancy check before a nudge. If the pane has become user-occupied, stop operating it and spawn a fresh implementer.
+
+## Monitoring
+
+Wait for the implementer's current turn to finish with:
+
+```shell
+scripts/wait-pane.sh <pane_id>
+```
+
+Check the coordinator inbox for reports:
+
+```shell
+~/.agents/skills/agmsg/scripts/inbox.sh "$TEAM" main
+```
+
+For long-running work, repeat non-intrusive checks: wait for the pane status, read the inbox, review reported progress, and nudge only when the pane is idle and still owned by `main`.
+
+## Review Split
+
+- Implementer: make the repository changes, run local verification, commit, confirm HTTPS push configuration when required by the environment, push, open or update the PR, and monitor CI until it is green or clearly blocked.
+- `main`: frame the task, monitor progress, review the diff and CI report, request follow-up changes when needed, approve or make the merge decision, and clean up the disposable implementer after the work is accepted.
+
+Keep push, PR creation or update, and CI confirmation on the implementer side. The implementer Codex should use its own GitHub workflow guidance for git and GitHub write operations.
+
+## Cleanup
+
+After the task is complete, reviewed, and no further changes are needed:
+
+1. Close the Herdr tab created for the implementer:
+
+   ```shell
+   herdr tab close <tab_id>
+   ```
+
+2. Remove the disposable Codex agmsg registration:
+
+   ```shell
+   ~/.agents/skills/agmsg/scripts/reset.sh "$PROJECT" codex "$NAME"
+   ```
+
+Do not use `~/.agents/skills/agmsg/scripts/despawn.sh --force` for Herdr-launched implementers. The Herdr tab is created outside agmsg's spawn placement record, so `despawn.sh --force` has no reliable placement to tear down.
+
+Do not clean up user-occupied instances. Leave their tab and agmsg registration intact.

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# @file herdr-spawn-codex.sh
+# @brief Create a labeled Herdr tab and run the agmsg Codex boot command in it.
+# @description
+#   This script is used as the agmsg spawn terminal template target. It creates
+#   a new tab in the current Herdr workspace, starts the provided boot command,
+#   and prints the created pane id for monitoring.
+
+set -euo pipefail
+
+BOOT="$1"
+LABEL="${HERDR_SPAWN_LABEL:-impl}"
+WS="${HERDR_WORKSPACE_ID:?not inside herdr}"
+
+TAB=$(herdr tab create --workspace "$WS" --label "$LABEL" --no-focus |
+    uv run --no-project python -c 'import sys,json;print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
+PANE=$(herdr pane list --workspace "$WS" | TAB="$TAB" uv run --no-project python -c '
+import sys, json, os
+tab = os.environ["TAB"]
+print(next(p["pane_id"] for p in json.load(sys.stdin)["result"]["panes"] if p["tab_id"] == tab))')
+herdr pane rename "$PANE" "$LABEL" > /dev/null
+herdr pane run "$PANE" "$BOOT" > /dev/null
+printf '%s\n' "$PANE"

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# @file nudge-codex.sh
+# @brief Safely nudge an idle Codex TUI pane through Herdr.
+# @description
+#   Refuses to send text to panes that are working or whose status cannot be
+#   confirmed as idle.
+
+set -euo pipefail
+
+PANE="$1"
+MSG="$2"
+STATUS=$(herdr pane get "$PANE" |
+    uv run --no-project python -c 'import sys, json; print(json.load(sys.stdin)["result"]["pane"]["agent_status"])')
+if [ "$STATUS" != "idle" ]; then
+    echo "SKIP: pane $PANE is '$STATUS' (not idle). Message stays in agmsg inbox; retry when idle." >&2
+    exit 3
+fi
+herdr pane run "$PANE" "$MSG"
+echo "nudged $PANE"

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# @file spawn-codex-tab.sh
+# @brief Spawn a disposable Codex implementer in a new labeled Herdr tab.
+# @description
+#   Wraps agmsg spawn.sh with the Herdr tab terminal helper so callers can use a
+#   single command for team, role, project, and optional boot prompt wiring.
+
+set -euo pipefail
+
+TEAM="$1"
+NAME="$2"
+PROJECT="$3"
+PROMPT="${4:-}"
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+ARGS=(codex "$NAME" --project "$PROJECT" --team "$TEAM"
+    --terminal "$SELF_DIR/herdr-spawn-codex.sh {cmd}")
+[ -n "$PROMPT" ] && ARGS+=(--boot-prompt "$PROMPT")
+export HERDR_SPAWN_LABEL="${HERDR_SPAWN_LABEL:-impl: ${NAME#impl-}}"
+exec ~/.agents/skills/agmsg/scripts/spawn.sh "${ARGS[@]}"

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/wait-pane.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/wait-pane.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# @file wait-pane.sh
+# @brief Wait until a Herdr pane is no longer in a working or unknown state.
+# @description
+#   Polls Herdr for a pane's Codex agent status and prints the first terminal or
+#   idle state observed. If the pane disappears, prints "gone".
+
+set -euo pipefail
+
+PANE="$1"
+INT="${2:-15}"
+
+while true; do
+    S=$(herdr pane get "$PANE" 2> /dev/null |
+        uv run --no-project python -c 'import sys,json;print(json.load(sys.stdin)["result"]["pane"]["agent_status"])' \
+            2> /dev/null || echo gone)
+    case "$S" in
+    working | unknown) sleep "$INT" ;;
+    *)
+        printf '%s\n' "$S"
+        exit 0
+        ;;
+    esac
+done


### PR DESCRIPTION
## Why

Add a repo-managed global skill for delegating implementation work to disposable Codex implementers from any repository.

## What Changed

- Allowlist `delegate-codex` under `home/dot_config/exact_agents/skills/` so the global skill is tracked by this chezmoi repository.
- Add `delegate-codex` guidance for spawning one-task Codex implementers through Herdr and agmsg.
- Add helper scripts for creating a labeled Herdr tab, nudging idle Codex panes, spawning via agmsg, and waiting for pane status.

## Validation

Check shell syntax for all helper scripts.
```shell
bash -n home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/wait-pane.sh
```

Check shell formatting with the same flags used by CI.
```shell
shfmt -i 4 -sr -d home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/wait-pane.sh
```

Confirm all helper scripts are executable.
```shell
test -x home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh && test -x home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh && test -x home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh && test -x home/dot_config/exact_agents/skills/delegate-codex/scripts/wait-pane.sh
```

Inspect the working tree and staged diff for whitespace and conflict-marker issues.
```shell
git diff --check && git diff --cached --check
```

Search the new skill directory for private or internal launch strings before publishing it publicly.
```shell
! rg -n "(flava-dev|yahoo|社内|GEN_AI_PROXY|ly-chatai|codex-dev)" home/dot_config/exact_agents/skills/delegate-codex
```

`bats` was not run locally per repository policy; GitHub Actions is used for bats validation.