### PR TITLE
fix(delegate-codex): support done nudges and env passthrough

### DIFF
--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -91,8 +91,8 @@ In `## 変更対象`, list concrete file paths and ownership boundaries. In `## 
   scripts/nudge-codex.sh <pane_id> "inbox を確認して着手してください"
   ```
 
-- Do not force-queue messages into a working pane with `herdr pane send-keys <pane_id> tab`. agmsg messages remain in the recipient's inbox, so wait until the Codex pane is idle and nudge then.
-- If `nudge-codex.sh` exits with code 3, the pane is not idle. Wait until the pane's `agent_status` is no longer `working`, then retry the nudge.
+- Do not force-queue messages into a working pane with `herdr pane send-keys <pane_id> tab`. agmsg messages remain in the recipient's inbox, so wait until the Codex pane is idle or done and nudge then.
+- If `nudge-codex.sh` exits with code 3, the pane is not idle or done. Wait until the pane's `agent_status` is `idle` or `done`, then retry the nudge.
 - Always run the occupancy check before a nudge. If the pane has become user-occupied, stop operating it and spawn a fresh implementer.
 
 ## Monitoring
@@ -109,7 +109,7 @@ Check the coordinator inbox for reports:
 ~/.agents/skills/agmsg/scripts/inbox.sh "$TEAM" main
 ```
 
-For long-running work, repeat non-intrusive checks: wait for the pane status, read the inbox, review reported progress, and nudge only when the pane is idle and still owned by `main`.
+For long-running work, repeat non-intrusive checks: wait for the pane status, read the inbox, review reported progress, and nudge only when the pane is idle or done and still owned by `main`.
 
 ## Review Split
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -50,6 +50,7 @@ scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT" [boot-prompt]
 ```
 
 The wrapper calls `~/.agents/skills/agmsg/scripts/spawn.sh` with a Herdr terminal template. Environment-specific Codex CLI arguments are injected by agmsg from `~/.agmsg/config/spawn_options.yaml`; see `~/.agents/AGENTS-private.md` for the local values and setup steps.
+Set `HERDR_SPAWN_ENV_KEYS` to a space-separated list of environment variable names to pass selected values through to `herdr tab create` as `--env KEY=VALUE`.
 
 Before the first spawn in a new project or worktree, confirm the Codex trust settings for that path; see `~/.agents/AGENTS-private.md` for the local trust procedure. In tmux environments, agmsg `spawn.sh` also supports its standard `--split` mode, but this skill's Herdr wrapper creates a new labeled tab so it does not split the user's current pane.
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
@@ -13,7 +13,16 @@ BOOT="$1"
 LABEL="${HERDR_SPAWN_LABEL:-impl}"
 WS="${HERDR_WORKSPACE_ID:?not inside herdr}"
 
-TAB=$(herdr tab create --workspace "$WS" --label "$LABEL" --no-focus |
+ENV_ARGS=()
+for KEY in ${HERDR_SPAWN_ENV_KEYS:-}; do
+    if [[ ! "$KEY" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "invalid HERDR_SPAWN_ENV_KEYS entry: $KEY" >&2
+        exit 2
+    fi
+    ENV_ARGS+=(--env "${KEY}=${!KEY-}")
+done
+
+TAB=$(herdr tab create --workspace "$WS" --label "$LABEL" "${ENV_ARGS[@]}" --no-focus |
     uv run --no-project python -c 'import sys,json;print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
 PANE=$(herdr pane list --workspace "$WS" | TAB="$TAB" uv run --no-project python -c '
 import sys, json, os

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
@@ -13,11 +13,11 @@ MSG="$2"
 STATUS=$(herdr pane get "$PANE" |
     uv run --no-project python -c 'import sys, json; print(json.load(sys.stdin)["result"]["pane"]["agent_status"])')
 case "$STATUS" in
-    idle|done) ;;
-    *)
-        echo "SKIP: pane $PANE is '$STATUS' (not idle or done). Message stays in agmsg inbox; retry when idle or done." >&2
-        exit 3
-        ;;
+idle | done) ;;
+*)
+    echo "SKIP: pane $PANE is '$STATUS' (not idle or done). Message stays in agmsg inbox; retry when idle or done." >&2
+    exit 3
+    ;;
 esac
 herdr pane run "$PANE" "$MSG"
 echo "nudged $PANE"

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # @file nudge-codex.sh
-# @brief Safely nudge an idle Codex TUI pane through Herdr.
+# @brief Safely nudge an available Codex TUI pane through Herdr.
 # @description
 #   Refuses to send text to panes that are working or whose status cannot be
-#   confirmed as idle.
+#   confirmed as idle or done.
 
 set -euo pipefail
 
@@ -12,9 +12,12 @@ PANE="$1"
 MSG="$2"
 STATUS=$(herdr pane get "$PANE" |
     uv run --no-project python -c 'import sys, json; print(json.load(sys.stdin)["result"]["pane"]["agent_status"])')
-if [ "$STATUS" != "idle" ]; then
-    echo "SKIP: pane $PANE is '$STATUS' (not idle). Message stays in agmsg inbox; retry when idle." >&2
-    exit 3
-fi
+case "$STATUS" in
+    idle|done) ;;
+    *)
+        echo "SKIP: pane $PANE is '$STATUS' (not idle or done). Message stays in agmsg inbox; retry when idle or done." >&2
+        exit 3
+        ;;
+esac
 herdr pane run "$PANE" "$MSG"
 echo "nudged $PANE"


### PR DESCRIPTION
## Why

`nudge-codex.sh` should be able to resume Codex panes that Herdr reports as `done`, not only panes reported as `idle`.

Some Codex spawns also need a narrow, explicit way to pass selected environment values through `herdr tab create` without hardcoding secret names or values in the delegate-codex skill.

## What Changed

- Allow `nudge-codex.sh` to send nudges when `agent_status` is `idle` or `done`.
- Update delegate-codex nudge guidance to describe the same `idle` or `done` retry rule.
- Add `HERDR_SPAWN_ENV_KEYS` handling to `herdr-spawn-codex.sh`, passing listed variables to `herdr tab create` as `--env KEY=VALUE` after validating variable names.
- Document `HERDR_SPAWN_ENV_KEYS` in the delegate-codex spawn guidance.
- Apply repository shfmt formatting to the updated nudge script.

## Validation

Check shell syntax for the nudge script.

```shell
bash -n home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh
```

Check shell syntax for the Herdr spawn script.

```shell
bash -n home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
```

Check repository shfmt formatting for the updated scripts.

```shell
shfmt -i 4 -sr -d home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
```

Check the diff for whitespace errors.

```shell
git diff --check
```

Confirm both scripts remain executable.

```shell
stat -c '%a %n' home/dot_config/exact_agents/skills/delegate-codex/scripts/nudge-codex.sh home/dot_config/exact_agents/skills/delegate-codex/scripts/herdr-spawn-codex.sh
```
