### PR TITLE
Document always-delegate rule for Codex main

### DIFF
--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -11,6 +11,14 @@ Delegate implementation work to a disposable Codex implementer in a fresh Herdr 
 
 This skill is intentionally repository-agnostic. Do not encode local-only settings here. For environment-specific Codex trust, launch options, git, or GitHub behavior, read `~/.agents/AGENTS-private.md` and follow the relevant section.
 
+## Always Delegate
+
+When `main` is about to perform implementation work, repository edits, commits, pushes, PR creation or updates, or CI confirmation for any task, use this skill and delegate the work to a fresh implementer instead of doing the work directly.
+
+This applies even when the change looks small, documentation-only, or routine. `main` may inspect context, frame the task, monitor progress, review the resulting diff, and decide whether more changes are needed, but the disposable implementer owns the repository modifications and GitHub workflow.
+
+This rule is for the coordinator role. If the current agent is already acting as an `impl-<task-slug>` implementer for a delegated task, complete that assigned work in its own task worktree instead of recursively spawning another implementer.
+
 ## Roles And Naming
 
 - Team: derive the agmsg team name from the repository remote, not from the worktree directory:

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -13,9 +13,13 @@ This skill is intentionally repository-agnostic. Do not encode local-only settin
 
 ## Always Delegate
 
-When `main` is about to perform implementation work, repository edits, commits, pushes, PR creation or updates, or CI confirmation for any task, use this skill and delegate the work to a fresh implementer instead of doing the work directly.
+Use this skill for any write work in any repository, including this dotfiles repository itself. Code changes, documentation edits, configuration or dotfiles changes, commits, pushes, and pull request creation or updates all go through a disposable implementer. `main` must not commit or push directly, even for a one-line change and even when the repository is not the current project.
 
-This applies even when the change looks small, documentation-only, or routine. `main` may inspect context, frame the task, monitor progress, review the resulting diff, and decide whether more changes are needed, but the disposable implementer owns the repository modifications and GitHub workflow.
+Task size never creates an exception. "Small enough to do myself" is not a valid reason to skip delegation.
+
+At the start of every new delegation, re-open this `SKILL.md` and follow the current procedure from the skill. Do not reproduce the delegation flow from memory; remembered steps drift from the source of truth.
+
+`main` may directly perform read-only investigation, send or receive agmsg messages, monitor, nudge, or clean up Herdr-managed implementers, run GitHub read operations, and execute a merge only when the user explicitly instructs `main` to merge that specific pull request.
 
 This rule is for the coordinator role. If the current agent is already acting as an `impl-<task-slug>` implementer for a delegated task, complete that assigned work in its own task worktree instead of recursively spawning another implementer.
 


### PR DESCRIPTION
## Why

Codex main needs explicit guidance to delegate all repository write work through disposable implementers, including small documentation or dotfiles changes.

## What Changed

Updated `home/dot_config/exact_agents/skills/delegate-codex/SKILL.md` to state that any write work in any repository, including this dotfiles repository itself, must be delegated.

Clarified that task size does not create an exception, that each delegation must re-open `SKILL.md`, and that `main` may only perform read-only investigation, agmsg communication, Herdr monitor/nudge/cleanup, GitHub read operations, or an explicitly user-directed merge.

Confirmed duplicate skill documentation: repository search found only `home/dot_config/exact_agents/skills/delegate-codex/SKILL.md` as the Delegate Codex `SKILL.md`; scripts under that skill directory are not duplicate skill docs.

## Validation

Check the updated guidance assertions.
```shell
sed -n '1,260p' home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
```

Confirm only the intended Delegate Codex skill file changed.
```shell
git diff --name-only
```

Inspect the diff for whitespace and formatting errors.
```shell
git diff --check
```

Check for duplicate Delegate Codex skill docs.
```shell
rg --files -g 'SKILL.md' home/dot_config/exact_agents/skills | rg '(^|/)delegate-codex/SKILL\\.md$|delegate'
```
