### PR TITLE
feat(agmsg): support Codex spawn effort args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ coverage*
 home/dot_config/exact_agents/skills/*
 !home/dot_config/exact_agents/skills/ai-slop-checklist-ja/
 !home/dot_config/exact_agents/skills/ai-slop-checklist-ja/**
+!home/dot_config/exact_agents/skills/agmsg/
+!home/dot_config/exact_agents/skills/agmsg/scripts/
+!home/dot_config/exact_agents/skills/agmsg/scripts/spawn.sh
 !home/dot_config/exact_agents/skills/convert-to-transformers/
 !home/dot_config/exact_agents/skills/convert-to-transformers/**
 !home/dot_config/exact_agents/skills/delegate-codex/

--- a/home/dot_config/exact_agents/skills/agmsg/scripts/spawn.sh
+++ b/home/dot_config/exact_agents/skills/agmsg/scripts/spawn.sh
@@ -1,0 +1,587 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# @file scripts/spawn.sh
+# @brief Launch a new agent process and have it take an actas identity.
+# @description
+#   Given an agent type and an actas name, this script pre-joins the name to a
+#   team for the target project, opens a tmux or terminal placement, and starts
+#   the agent CLI with `/agmsg actas <name>` as its initial prompt.
+#
+# @example
+#   spawn.sh <agent-type> <name> [options]
+#   spawn.sh <agent-type> <name> --boot-prompt "<initial task>" [options]
+#
+# @arg $1 agent-type Any registered spawnable type with a direct CLI or node launcher.
+# @arg $2 name Actas identity for the spawned agent.
+# @option --boot-prompt <text> An initial task for the spawned agent. When given, the
+#                      boot prompt becomes the actas slash command followed
+#                      (newline-separated) by <text>, so the new agent claims
+#                      its identity AND acts on the task in its first turn —
+#                      handy for a codex peer (no Monitor), where a message
+#                      sent after spawn would never reach the idle session.
+#                      An empty string (`--boot-prompt ""`) means no task.
+# @option --project <path> Project to launch in (default: $PWD).
+# @option --team <team> Team to join <name> into (default: auto-resolved from
+#                      the project's existing registrations; required when the
+#                      project belongs to more than one team).
+# @option --window Open a new tmux WINDOW instead of splitting the pane.
+# @option --split h|v Tmux split direction when splitting the current window.
+# @option --terminal <tmpl> Terminal command template for the non-tmux path; a
+#                      `{cmd}` placeholder is replaced with the path to the
+#                      generated boot script (an executable file the terminal
+#                      should run). Overrides $AGMSG_TERMINAL and config
+#                      `spawn.terminal`.
+# @option --no-wait Do not block on the readiness handshake after launch.
+# @option --ready-timeout N Seconds to wait for readiness before giving up.
+# @option --model <id> Launch the agent on a specific model. The id is passed
+#                      through to the CLI unchecked (the CLI rejects unknown
+#                      ids); the flag spelling comes from the type's manifest
+#                      `model_arg=`. Refused for a type with no model_arg.
+# @option --cli-arg <token> Append one extra CLI token for a direct-CLI launch. May
+#                      be repeated. Tokens are injected after spawn-options and
+#                      before the initial prompt. Refused for node launchers.
+#
+# Spawn options: extra CLI args to always pass a given type's launched
+# binary (e.g. a default permission mode or sandbox policy), configured
+# per-type in a YAML file rather than hardcoded — see
+# scripts/lib/spawn-options.sh. File: $AGMSG_SPAWN_OPTIONS_FILE, else
+# ~/.agmsg/config/spawn_options.yaml. Optional; a missing file/section is a
+# no-op.
+#
+# Readiness: by default spawn blocks until the new agent's watcher attaches and
+# is receiving (it prints `status=ready ...`), so a leader can safely send work
+# right after spawn returns without racing the agent's cold start. Codex has no
+# Monitor, so the wait is skipped for codex.
+#
+# Scope note: spawnable types are those whose manifest declares `spawnable=yes`;
+# macOS is the primary target, Linux and
+# Windows are best-effort (no guarantee — please open an issue/PR if a given
+# terminal does not work). Headless environments (no tmux and no usable
+# terminal) error out, because the agent CLIs need an interactive terminal.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" # actas-lock.sh requires SKILL_DIR
+TEAMS_DIR="$SKILL_DIR/teams"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/actas-lock.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/type-registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/storage.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/spawn-options.sh"
+
+die() {
+    echo "spawn: $*" >&2
+    exit 1
+}
+
+# --- Parse positional args ---
+AGENT_TYPE="${1:-}"
+NAME="${2:-}"
+[ -n "$AGENT_TYPE" ] || die "Usage: spawn.sh <agent-type> <name> [options]"
+[ -n "$NAME" ] || die "Usage: spawn.sh <agent-type> <name> [options]"
+shift 2 || true
+
+# A type is spawnable iff its manifest declares `spawnable=yes` (direct-CLI) OR a
+# `spawn=` node launcher. The error lists the computed spawnable set from the
+# registry — no type name is hardcoded here.
+spawnable_types() {
+    local t
+    while IFS= read -r t; do
+        [ -n "$t" ] || continue
+        # `if` (not `&& printf`) so a non-spawnable last type does not leave the loop
+        # — and thus the function — with a non-zero status, which `set -e`+pipefail
+        # would turn into a silent exit at the `SUPPORTED_LIST=$(...)` assignment.
+        if [ "$(agmsg_type_get "$t" spawnable)" = "yes" ] || [ -n "$(agmsg_type_get "$t" spawn)" ]; then
+            printf '%s\n' "$t"
+        fi
+    done << EOF
+$(agmsg_known_types | sort -u)
+EOF
+    return 0
+}
+SUPPORTED_LIST="$(spawnable_types | paste -sd, - | sed 's/,/, /g')"
+if ! agmsg_is_known_type "$AGENT_TYPE"; then
+    die "unknown agent type '$AGENT_TYPE' (supported: ${SUPPORTED_LIST})"
+elif [ "$(agmsg_type_get "$AGENT_TYPE" spawnable)" != "yes" ] && [ -z "$(agmsg_type_get "$AGENT_TYPE" spawn)" ]; then
+    # Gate must match spawnable_types(): spawnable iff `spawnable=yes` OR a `spawn=`
+    # node launcher. (Honouring only spawnable=yes here would reject a node-launcher
+    # add-on while still listing it in SUPPORTED_LIST.)
+    die "agent type '$AGENT_TYPE' is not supported by spawn yet (supported: ${SUPPORTED_LIST})"
+fi
+
+# --- Parse options ---
+PROJECT="$PWD"
+PROMPT="" # --boot-prompt: optional initial task appended to the actas prompt
+# (empty string = no task, so the `[ -n "$PROMPT" ]` guard
+#  below leaves the boot prompt unchanged)
+TEAM=""
+TMUX_TARGET="pane" # pane | window
+SPLIT="h"          # h | v
+TERMINAL_TMPL=""   # --terminal override (resolved below if empty)
+WAIT_READY=1       # block until the spawned agent's watcher attaches
+READY_TIMEOUT=90   # seconds to wait for readiness before giving up
+MODEL_ID=""        # --model: pass-through model id for the launched CLI
+CLI_ARG_TOKENS=()  # --cli-arg: extra direct-CLI tokens after spawn-options
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    # `${2?...}` (not `:?`) errors only when the arg is MISSING; an explicit
+    # empty string (`--boot-prompt ""`) is allowed through and treated as "no task"
+    # by the `[ -n "$PROMPT" ]` guard, so a scripted `--boot-prompt "$VAR"` with an
+    # empty VAR degrades to a plain spawn instead of aborting.
+    --boot-prompt)
+        PROMPT="${2?--boot-prompt needs a task}"
+        shift 2
+        ;;
+    --project)
+        PROJECT="${2:?--project needs a path}"
+        shift 2
+        ;;
+    --team)
+        TEAM="${2:?--team needs a name}"
+        shift 2
+        ;;
+    --window)
+        TMUX_TARGET="window"
+        shift
+        ;;
+    --split)
+        SPLIT="${2:?--split needs h|v}"
+        shift 2
+        ;;
+    --terminal)
+        TERMINAL_TMPL="${2:?--terminal needs a template}"
+        shift 2
+        ;;
+    --no-wait)
+        WAIT_READY=0
+        shift
+        ;;
+    --ready-timeout)
+        READY_TIMEOUT="${2:?--ready-timeout needs seconds}"
+        shift 2
+        ;;
+    --model)
+        MODEL_ID="${2:?--model needs a model id}"
+        shift 2
+        ;;
+    --cli-arg)
+        CLI_ARG_TOKENS+=("${2?--cli-arg needs a token}")
+        shift 2
+        ;;
+    *) die "unknown option: $1" ;;
+    esac
+done
+
+case "$SPLIT" in h | v) ;; *) die "--split must be 'h' or 'v'" ;; esac
+case "$READY_TIMEOUT" in '' | *[!0-9]*) die "--ready-timeout must be a whole number of seconds" ;; esac
+
+# Resolve the terminal override for the non-tmux path:
+#   --terminal  >  $AGMSG_TERMINAL  >  config spawn.terminal
+# A value containing a `{cmd}` placeholder is treated as a command template
+# on every platform. A bare value (no placeholder) is honored only on macOS,
+# as an app-name hint (e.g. "iterm"); on Linux/Windows a bare value is an
+# error, since those paths need an explicit template to know how to invoke it.
+if [ -z "$TERMINAL_TMPL" ]; then
+    TERMINAL_TMPL="${AGMSG_TERMINAL:-}"
+fi
+if [ -z "$TERMINAL_TMPL" ]; then
+    TERMINAL_TMPL="$("$SCRIPT_DIR/config.sh" get spawn.terminal "" 2> /dev/null || true)"
+fi
+
+is_terminal_template() { [[ "$1" == *"{cmd}"* ]]; }
+
+# Normalize the project path so registrations/lookups are consistent with the
+# rest of agmsg (which keys on the path as given by the caller's pwd).
+if [ ! -d "$PROJECT" ]; then
+    die "project path does not exist: $PROJECT"
+fi
+PROJECT="$(cd "$PROJECT" && pwd)"
+
+# --- Resolve the launch method from the manifest ---
+# A non-empty `spawn=` launcher means this type runs via a Node launcher (e.g. an
+# external add-on); otherwise it is a direct-CLI launch. The `cli=` binary is
+# REQUIRED for direct-CLI types and OPTIONAL for node launchers (which resolve
+# their own runtime). No per-type case — all data-driven from the manifest.
+#
+# `cli=` is trusted manifest data (agmsg ships it, not runtime user input), so
+# it may be a single binary name OR a fixed command-line prefix of several
+# space-separated tokens — a subcommand and/or fixed flags a CLI needs before
+# its own options (e.g. `opencode run --interactive`, whose message is not a
+# top-level argument). Only the first word names the actual executable to
+# resolve/check; the rest are passed through as-is in the boot script below.
+SPAWN_LAUNCHER="$(agmsg_type_get "$AGENT_TYPE" spawn)"
+CLI_BIN="$(agmsg_type_get "$AGENT_TYPE" cli)"
+CLI_BIN_EXE="${CLI_BIN%% *}"
+CLI_PATH=""
+if [ -n "$CLI_BIN" ]; then
+    command -v "$CLI_BIN_EXE" > /dev/null 2>&1 ||
+        die "'$CLI_BIN_EXE' not found on PATH — install the ${AGENT_TYPE} CLI first"
+    CLI_PATH="$(command -v "$CLI_BIN_EXE")"
+elif [ -z "$SPAWN_LAUNCHER" ]; then
+    die "agent type '$AGENT_TYPE' manifest declares neither a 'cli' binary nor a 'spawn' launcher"
+fi
+
+# --model is pass-through: the model id is handed to the CLI unchecked (the CLI
+# rejects an unknown id), so agmsg never has to track each vendor's model list.
+# The flag SPELLING differs per CLI, so it comes from the manifest `model_arg=`
+# (e.g. claude-code/grok-build use --model, codex uses -m). A type with no
+# model_arg has no known flag, so --model is refused rather than guessed.
+MODEL_ARG="$(agmsg_type_get "$AGENT_TYPE" model_arg)"
+if [ -n "$MODEL_ID" ] && [ -z "$MODEL_ARG" ]; then
+    die "agent type '$AGENT_TYPE' does not support --model (no model_arg in its manifest)"
+fi
+
+# Some CLIs don't accept the actas prompt as a bare positional argument — they
+# require it as the value of a named flag instead (e.g. antigravity's
+# `--prompt-interactive <text>`, copilot's `-i/--interactive <text>`; their
+# `-p/--prompt` equivalents are a DIFFERENT one-shot, non-interactive mode and
+# would not work here). `prompt_arg=` in the manifest names that flag; unset
+# (the default) keeps today's bare-positional behavior.
+PROMPT_ARG="$(agmsg_type_get "$AGENT_TYPE" prompt_arg)"
+
+# Extra CLI args for this type from the spawn options file (opt-in, see
+# scripts/lib/spawn-options.sh). Read line-by-line — never word-split — so a
+# value containing spaces stays a single token.
+SPAWN_OPT_TOKENS=()
+while IFS= read -r _spawn_opt_tok; do
+    SPAWN_OPT_TOKENS+=("$_spawn_opt_tok")
+done < <(agmsg_spawn_options_tokens "$AGENT_TYPE")
+
+# Resolve the node launcher path from the manifest (not hardcoded), if any.
+SPAWN_AGENT=""
+if [ -n "$SPAWN_LAUNCHER" ]; then
+    [ "${#CLI_ARG_TOKENS[@]}" -eq 0 ] ||
+        die "--cli-arg is only supported for direct CLI launch types; '$AGENT_TYPE' uses a node launcher"
+    NODE_BIN="${AGMSG_NODE_BIN:-$(command -v node 2> /dev/null || true)}"
+    [ -n "$NODE_BIN" ] || die "'node' not found on PATH — spawning '$AGENT_TYPE' requires Node.js"
+    type_dir="$(agmsg_type_dir "$AGENT_TYPE")" ||
+        die "agent type '$AGENT_TYPE' is not registered (no scripts/drivers/types/$AGENT_TYPE/type.conf)"
+    SPAWN_AGENT="$type_dir/$SPAWN_LAUNCHER"
+    [ -f "$SPAWN_AGENT" ] || die "spawn launcher not found for '$AGENT_TYPE': $SPAWN_AGENT"
+fi
+
+# --- Resolve the team to join <name> into ---
+# When --team is omitted, derive it from any team that already has an agent
+# registered for this project (any type). Zero or many → require --team.
+resolve_team() {
+    [ -d "$TEAMS_DIR" ] || return 0
+    local config_file team_name cfg_sql proj_sql count_for_project
+    local found=""
+    # Read each config via readfile() and compare with SQL string literals rather
+    # than `.param set` bindings: the sqlite3 shell's dot-command tokenizer does
+    # NOT honour SQL '' escaping, so a value containing a single quote (a project
+    # path like /tmp/pro'j) breaks `.param set`. SQL string literals do honour ''.
+    proj_sql=$(printf '%s' "$PROJECT" | sed "s/'/''/g")
+    for config_file in "$TEAMS_DIR"/*/config.json; do
+        [ -f "$config_file" ] || continue
+        cfg_sql=$(printf '%s' "$config_file" | sed "s/'/''/g")
+        team_name=$(agmsg_sqlite_mem \
+            "SELECT json_extract(CAST(readfile('$cfg_sql') AS TEXT), '\$.name');")
+        # Does any agent in this team have a registration for PROJECT (any type)?
+        count_for_project=$(agmsg_sqlite_mem "
+      WITH cfg AS (SELECT CAST(readfile('$cfg_sql') AS TEXT) AS json),
+      agents AS (
+        SELECT
+          CASE
+            WHEN json_type(json_extract(value, '\$.registrations')) = 'array' THEN json_extract(value, '\$.registrations')
+            ELSE json_array(json_object('type', json_extract(value, '\$.type'), 'project', json_extract(value, '\$.project')))
+          END AS registrations
+        FROM cfg, json_each(json_extract(cfg.json, '\$.agents'))
+      )
+      SELECT COUNT(*)
+      FROM agents, json_each(agents.registrations) AS r
+      WHERE json_extract(r.value, '\$.project') = '$proj_sql';
+    ")
+        if [ "${count_for_project:-0}" -gt 0 ]; then
+            found="${found:+$found
+}$team_name"
+        fi
+    done
+    printf '%s' "$found"
+}
+
+if [ -z "$TEAM" ]; then
+    CANDIDATES="$(resolve_team)"
+    CAND_COUNT=$(printf '%s' "$CANDIDATES" | grep -c . || true)
+    if [ "$CAND_COUNT" -eq 1 ]; then
+        TEAM="$CANDIDATES"
+    elif [ "$CAND_COUNT" -eq 0 ]; then
+        die "no team is registered for this project; pass --team <team>"
+    else
+        die "project belongs to multiple teams ($(printf '%s' "$CANDIDATES" | paste -sd, -)); pass --team <team>"
+    fi
+fi
+
+# --- Pre-flight: refuse if <name> is currently held by another live session ---
+# The child's actas flow would refuse anyway; failing here avoids launching a
+# process that immediately can't take its identity.
+STATE="$(actas_lock_state "$TEAM" "$NAME" "" 2> /dev/null || echo free)"
+case "$STATE" in
+other:*)
+    die "actas '$NAME' in team '$TEAM' is held by a live session (${STATE#other:}); drop it there first"
+    ;;
+esac
+
+# --- Pre-join so the child's actas just claims (no interactive team prompt) ---
+# PROJECT here is the explicit spawn target (--project / $PWD), which may not be
+# registered yet. Opt out of #92 pwd-resolution so join.sh registers exactly
+# this path rather than rewriting it to the spawning session's own project.
+AGMSG_RESOLVE_PROJECT=0 "$SCRIPT_DIR/join.sh" "$TEAM" "$NAME" "$AGENT_TYPE" "$PROJECT" > /dev/null
+
+# --- Build the boot script the new agent will run ---
+# Rather than embed a multiply-escaped command string into each platform's
+# terminal invocation, write the launch steps into a temp executable script
+# and have every launcher simply *run that file*. This keeps quoting sane
+# across tmux, macOS, Linux emulators, Windows Terminal, and custom templates,
+# and on macOS it lets us use `open -a` (a plain app launch) instead of
+# `osascript ... do script`, which goes through AppleEvents and triggers the
+# Automation (TCC) permission prompts users otherwise have to approve.
+#
+# The agent CLIs accept an initial prompt as a positional argument and submit
+# it as the session's first message; passing the slash command makes the new
+# agent run `/agmsg actas <name>` on boot. We cd into the project first so a
+# cross-project spawn lands in the right tree, and drop into an interactive
+# shell afterwards so the window/pane stays open with the agent's final output.
+# The slash command is named after the installed command, which the user may
+# have customized at install time (install.sh --cmd). Derive it from the skill
+# dir basename so a custom install (e.g. `/m`) spawns `/m actas <name>` rather
+# than a nonexistent `/agmsg actas <name>`.
+#
+# When --boot-prompt is given, append the task newline-separated so the agent claims
+# its identity AND acts on the task in the same first turn. This is the only way
+# to hand a one-shot goal to a codex peer, which has no Monitor and so never
+# notices a message sent after it goes idle (see docs/codex-monitor-beta.md).
+CMD_NAME="$(basename "$SKILL_DIR")"
+ACTAS_PROMPT="/${CMD_NAME} actas ${NAME}"
+if [ -n "$PROMPT" ]; then
+    ACTAS_PROMPT="${ACTAS_PROMPT}
+${PROMPT}"
+fi
+
+BOOT_DIR="${TMPDIR:-/tmp}/agmsg-spawn"
+mkdir -p "$BOOT_DIR" 2> /dev/null || true
+# Best-effort GC of boot scripts left behind by spawns whose window was closed
+# before the script could remove itself (see the trailing rm below).
+find "$BOOT_DIR" -name 'boot-*.command' -type f -mtime +1 -delete 2> /dev/null || true
+BOOT="$(mktemp "$BOOT_DIR/boot-XXXXXX")"
+mv "$BOOT" "$BOOT.command" # .command so macOS `open` runs it in Terminal
+BOOT="$BOOT.command"
+{
+    echo '#!/usr/bin/env bash'
+    printf 'cd %q || exit 1\n' "$PROJECT"
+    if [ -n "$SPAWN_AGENT" ]; then
+        # Node-launcher path: pass the universal agmsg context + the actas prompt.
+        # Type-specific config is the launcher's own default/env, so core stays
+        # generic and names no add-on. Spawn-options tokens (if any) land before
+        # --initial-input, same relative position as the direct-CLI path below.
+        printf '%q %q \\\n' "$NODE_BIN" "$SPAWN_AGENT"
+        printf '  --name %q \\\n' "$NAME"
+        printf '  --team %q \\\n' "$TEAM"
+        printf '  --project %q \\\n' "$PROJECT"
+        for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
+            printf '  %q \\\n' "$_tok"
+        done
+        printf '  --initial-input %q\n' "$ACTAS_PROMPT"
+    else
+        # Direct-CLI launch:
+        # `<cli> [<model_arg> <model_id>] [spawn-options...] [cli-args...] [<prompt_arg>] "/<cmd> actas <name>"`.
+        # cli is emitted unquoted — it is trusted fixed-prefix manifest data (see
+        # above) that may itself be several tokens (e.g. `opencode run --interactive`).
+        # model_arg/prompt_arg are the manifest flag spellings (not %q-quoted — bare
+        # flags like --model or -i); the model id, every spawn-options token, and the
+        # actas prompt are quoted. prompt_arg (when set) lands immediately before the
+        # prompt so there is no ambiguity about which token is its value.
+        printf '%s' "$CLI_BIN"
+        [ -n "$MODEL_ID" ] && printf ' %s %q' "$MODEL_ARG" "$MODEL_ID"
+        for _tok in ${SPAWN_OPT_TOKENS[@]+"${SPAWN_OPT_TOKENS[@]}"}; do
+            printf ' %q' "$_tok"
+        done
+        for _tok in ${CLI_ARG_TOKENS[@]+"${CLI_ARG_TOKENS[@]}"}; do
+            printf ' %q' "$_tok"
+        done
+        [ -n "$PROMPT_ARG" ] && printf ' %s' "$PROMPT_ARG"
+        printf ' %q\n' "$ACTAS_PROMPT"
+    fi
+    echo 'rm -f "$0" 2>/dev/null' # self-clean once the agent exits
+    echo 'exec "${SHELL:-/bin/bash}" -i'
+} > "$BOOT"
+chmod +x "$BOOT"
+
+# ============================================================================
+# Placement — every launcher just runs $BOOT.
+# ============================================================================
+
+launch_in_tmux() {
+    # $TMUX is set (we are inside a tmux pane), but the `tmux` client binary
+    # still has to be on PATH for split-window/new-window to work. In a
+    # PATH-starved environment (e.g. spawned indirectly from cron/CI into a
+    # tmux pane) it may be missing. Fail fast with a clear message rather than
+    # aborting on a raw "tmux: command not found", and don't silently fall back
+    # to an OS terminal — opening a separate window while inside tmux is more
+    # confusing than an explicit error.
+    command -v tmux > /dev/null 2>&1 ||
+        die "\$TMUX is set but the tmux binary is not on PATH; add it to PATH, or run outside tmux to use the OS-terminal path"
+
+    # Name the window/pane after the agent rather than letting tmux fall back to
+    # the boot script's filename (boot-XXXXXX). `automatic-rename off` keeps the
+    # name from being clobbered once the boot script runs the CLI / drops to a
+    # shell.
+    local target_id
+    if [ "$TMUX_TARGET" = "window" ]; then
+        target_id="$(tmux new-window -P -F '#{window_id}' -n "$NAME" -c "$PROJECT" "$BOOT")"
+        tmux set-window-option -t "$target_id" automatic-rename off 2> /dev/null || true
+    else
+        local dir="-h"
+        [ "$SPLIT" = "v" ] && dir="-v"
+        target_id="$(tmux split-window "$dir" -P -F '#{pane_id}' -c "$PROJECT" "$BOOT")"
+        tmux select-pane -t "$target_id" -T "$NAME" 2> /dev/null || true
+    fi
+    # Record placement so `despawn --force` can tear this member down even if its
+    # watcher later can't respond to ctrl:despawn. tmux ids are self-describing:
+    # %N = pane (kill-pane), @N = window (kill-window). See #109.
+    printf '%s\t%s\t%s\n' "$target_id" "$PROJECT" "$AGENT_TYPE" \
+        > "$(agmsg_spawn_path "$TEAM" "$NAME")" 2> /dev/null || true
+}
+
+launch_macos_terminal() {
+    # `open -a` is a launch, not an AppleEvent, so it does not trip the
+    # Automation (TCC) consent prompts that `osascript ... do script` does.
+    local app="${1:-Terminal}"
+    case "$app" in
+    iterm | iterm2 | iTerm | iTerm2) open -a iTerm "$BOOT" ;;
+    *) open -a Terminal "$BOOT" ;;
+    esac
+}
+
+launch_linux_terminal() {
+    local term
+    for term in x-terminal-emulator gnome-terminal konsole xfce4-terminal xterm; do
+        command -v "$term" > /dev/null 2>&1 || continue
+        case "$term" in
+        gnome-terminal) gnome-terminal --working-directory="$PROJECT" -- "$BOOT" ;;
+        konsole) konsole --workdir "$PROJECT" -e "$BOOT" ;;
+        *) "$term" -e "$BOOT" ;;
+        esac
+        return 0
+    done
+    die "no supported terminal emulator found (tried gnome-terminal/konsole/xterm/...); set AGMSG_TERMINAL or run inside tmux"
+}
+
+launch_windows_terminal() {
+    if command -v wt.exe > /dev/null 2>&1; then
+        wt.exe new-tab bash -l "$BOOT"
+        return 0
+    fi
+    if command -v wt > /dev/null 2>&1; then
+        wt new-tab bash -l "$BOOT"
+        return 0
+    fi
+    die "Windows Terminal (wt) not found; set AGMSG_TERMINAL or run inside tmux"
+}
+
+launch_with_template() {
+    # User-supplied terminal command. `{cmd}` is replaced with the path to the
+    # boot script (an executable file); if there is no placeholder, the path is
+    # appended. Quote it so a TMPDIR with spaces still works.
+    local q_boot
+    q_boot="$(printf '%q' "$BOOT")"
+    local cmd
+    if [[ "$TERMINAL_TMPL" == *"{cmd}"* ]]; then
+        cmd="${TERMINAL_TMPL//\{cmd\}/$q_boot}"
+    else
+        cmd="$TERMINAL_TMPL $q_boot"
+    fi
+    bash -c "$cmd"
+}
+
+place_and_launch() {
+    if [ -n "${TMUX:-}" ]; then
+        launch_in_tmux
+        echo "spawned ${AGENT_TYPE} '${NAME}' in tmux (${TMUX_TARGET})"
+        return 0
+    fi
+
+    # Non-tmux: open an OS terminal. A {cmd} template wins outright on any OS.
+    if [ -n "$TERMINAL_TMPL" ] && is_terminal_template "$TERMINAL_TMPL"; then
+        launch_with_template
+        echo "spawned ${AGENT_TYPE} '${NAME}' via custom terminal template"
+        return 0
+    fi
+
+    case "$(uname -s)" in
+    Darwin)
+        # Default to the terminal the user is *currently* in, so spawning from
+        # iTerm opens iTerm rather than jarringly launching Terminal.app. A bare
+        # override (no {cmd}) is an explicit app-name hint and wins, e.g. "iterm".
+        local mac_app="${TERMINAL_TMPL:-}"
+        if [ -z "$mac_app" ]; then
+            case "${TERM_PROGRAM:-}" in
+            iTerm.app) mac_app="iterm" ;;
+            *) mac_app="Terminal" ;;
+            esac
+        fi
+        launch_macos_terminal "$mac_app"
+        ;;
+    Linux)
+        if [ -n "$TERMINAL_TMPL" ]; then
+            die "AGMSG_TERMINAL/spawn.terminal must contain a {cmd} placeholder on Linux (got: $TERMINAL_TMPL)"
+        fi
+        # No display → cannot open a GUI terminal, and there is no tmux to fall
+        # back to. The agent CLI needs an interactive terminal, so error.
+        if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+            die "headless environment: no tmux session and no display available — cannot open a terminal for ${CLI_BIN}. Run inside tmux, or set a {cmd} terminal template via AGMSG_TERMINAL."
+        fi
+        launch_linux_terminal
+        ;;
+    MINGW* | MSYS* | CYGWIN*)
+        if [ -n "$TERMINAL_TMPL" ]; then
+            die "AGMSG_TERMINAL/spawn.terminal must contain a {cmd} placeholder on Windows (got: $TERMINAL_TMPL)"
+        fi
+        launch_windows_terminal
+        ;;
+    *)
+        die "unsupported platform '$(uname -s)' for the non-tmux path; run inside tmux or set a {cmd} terminal template via AGMSG_TERMINAL."
+        ;;
+    esac
+    echo "spawned ${AGENT_TYPE} '${NAME}' in a new terminal window"
+}
+
+# Readiness handshake (#108). The spawned agent's actas flow starts its watcher
+# in exclusive mode, which touches a ready sentinel once it's actually
+# receiving. Block until that appears so the leader doesn't send a job into the
+# cold-start window (before the watcher attaches) and lose it.
+#
+# Types with `monitor=no` do not produce a spawn-awaitable readiness sentinel, so
+# skip the wait. That covers types with no Monitor at all (codex) AND types whose
+# watcher attaches via the agent's own launch rather than a spawn-time sentinel
+# (grok-build, whose monitor mode is real but not awaitable here) — receive there
+# is poll-based or agent-launched anyway.
+READY_PATH="$(agmsg_ready_path "$TEAM" "$NAME")"
+if [ "$(agmsg_type_get "$AGENT_TYPE" monitor)" = "no" ] && [ "$WAIT_READY" = "1" ]; then
+    WAIT_READY=0
+    echo "spawn: '$AGENT_TYPE' has no spawn readiness handshake — skipping readiness wait (--no-wait implied)" >&2
+fi
+
+# Clear any stale sentinel before launching so we only observe THIS spawn's
+# watcher attaching.
+[ "$WAIT_READY" = "1" ] && rm -f "$READY_PATH" 2> /dev/null || true
+
+place_and_launch
+
+if [ "$WAIT_READY" = "1" ]; then
+    waited=0
+    while [ ! -e "$READY_PATH" ]; do
+        if [ "$waited" -ge "$READY_TIMEOUT" ]; then
+            echo "status=timeout name=${NAME} team=${TEAM} after=${READY_TIMEOUT}s"
+            echo "spawn: '${NAME}' did not signal ready within ${READY_TIMEOUT}s — it may still be booting; re-spawn or raise --ready-timeout" >&2
+            exit 3
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    echo "status=ready name=${NAME} team=${TEAM} after=${waited}s"
+fi

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -59,10 +59,12 @@ TEAM=$(basename -s .git "$(git remote get-url origin)")
 NAME=impl-<task-slug>
 PROJECT=<task-worktree-path>
 scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT" [boot-prompt]
+scripts/spawn-codex-tab.sh --effort xhigh "$TEAM" "$NAME" "$PROJECT" [boot-prompt]
 ```
 
 The wrapper calls `~/.agents/skills/agmsg/scripts/spawn.sh` with a Herdr terminal template. Environment-specific Codex CLI arguments are injected by agmsg from `~/.agmsg/config/spawn_options.yaml`; see `~/.agents/AGENTS-private.md` for the local values and setup steps.
 Set `HERDR_SPAWN_ENV_KEYS` to a space-separated list of environment variable names to pass selected values through to `herdr tab create` as `--env KEY=VALUE`.
+For ordinary implementation tasks, use the wrapper's default reasoning effort. For research, survey, review, professor-style, or deep investigation tasks, launch the wrapper with `--effort xhigh`; do not document or encode local profile names, provider names, or gateway details in this public skill.
 
 Before the first spawn in a new project or worktree, confirm the Codex trust settings for that path; see `~/.agents/AGENTS-private.md` for the local trust procedure. In tmux environments, agmsg `spawn.sh` also supports its standard `--split` mode, but this skill's Herdr wrapper creates a new labeled tab so it does not split the user's current pane.
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
@@ -5,17 +5,54 @@
 # @description
 #   Wraps agmsg spawn.sh with the Herdr tab terminal helper so callers can use a
 #   single command for team, role, project, and optional boot prompt wiring.
+# @option --effort medium|xhigh Select default or extra-high Codex reasoning effort.
+# @arg $1 team Agmsg team name.
+# @arg $2 name Implementer actas identity.
+# @arg $3 project Project path for the spawned Codex session.
+# @arg $4 boot-prompt Optional initial task for the spawned Codex session.
 
 set -euo pipefail
 
-TEAM="$1"
-NAME="$2"
-PROJECT="$3"
+EFFORT="medium"
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --effort)
+        EFFORT="${2:?--effort needs medium|xhigh}"
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
+    --*)
+        echo "unknown option: $1" >&2
+        exit 2
+        ;;
+    *)
+        break
+        ;;
+    esac
+done
+
+case "$EFFORT" in
+medium | xhigh) ;;
+*)
+    echo "--effort must be medium or xhigh" >&2
+    exit 2
+    ;;
+esac
+
+TEAM="${1:?TEAM is required}"
+NAME="${2:?NAME is required}"
+PROJECT="${3:?PROJECT is required}"
 PROMPT="${4:-}"
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ARGS=(codex "$NAME" --project "$PROJECT" --team "$TEAM"
     --terminal "$SELF_DIR/herdr-spawn-codex.sh {cmd}")
+if [ "$EFFORT" = "xhigh" ]; then
+    ARGS+=(--cli-arg -c --cli-arg 'model_reasoning_effort="xhigh"')
+fi
 [ -n "$PROMPT" ] && ARGS+=(--boot-prompt "$PROMPT")
 export HERDR_SPAWN_LABEL="${HERDR_SPAWN_LABEL:-impl: ${NAME#impl-}}"
 exec ~/.agents/skills/agmsg/scripts/spawn.sh "${ARGS[@]}"


### PR DESCRIPTION
## Summary\n- add a repo-managed agmsg spawn.sh with repeatable --cli-arg support for direct CLI launches\n- pass xhigh reasoning effort through the delegate Codex wrapper when requested\n- document default effort vs xhigh usage without exposing local profile details\n\n## Verification\n- bash -n home/dot_config/exact_agents/skills/agmsg/scripts/spawn.sh\n- bash -n home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh\n- parser smoke tests with temporary stubs for wrapper and spawn.sh\n- codex xhigh smoke test with codex exec