### PR TITLE
docs(delegate-codex): prioritize explicit skill requests

### DIFF
--- a/home/dot_config/codex/AGENTS.codex-only.md
+++ b/home/dot_config/codex/AGENTS.codex-only.md
@@ -34,6 +34,7 @@
 
 ### GitHub / PR のサブエージェント
 
+- 明示 skill gate: ユーザーが `$delegate-codex` または `delegate-codex` を明示した場合は、`gh-workflow-manager` ではなく `delegate-codex` の手順を優先してください。この場合でも PR 作成・更新と CI / required checks の完了確認は必要で、実装者は merge してはいけません。main は agent を起動する前に、どの skill / agent を使うかをユーザーへ短く宣言してください。
 - 担当: GitHub / PR workflow は custom subagent `gh-workflow-manager` が担当します。`~/.codex/agents` 経由で利用できます。
 - 起動条件: issue / PR の調査、branch / commit / push、pull request の作成・更新、CI 確認に入る前に、`gh-workflow-manager` を 1 回だけ spawn し、その後は同じスレッドを使い続けてください。
 - 起動時入力: 起動時には、タスクの要約、最初のユーザープロンプト、`codex-foo` のような `parent_owner` を渡してください。dirty な作業ツリーから差分を切り出す場合は、対象ファイル一覧も明示してください。

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -15,6 +15,8 @@ This skill is intentionally repository-agnostic. Do not encode local-only settin
 
 Use this skill for any write work in any repository, including this dotfiles repository itself. Code changes, documentation edits, configuration or dotfiles changes, commits, pushes, and pull request creation or updates all go through a disposable implementer. `main` must not commit or push directly, even for a one-line change and even when the repository is not the current project.
 
+If the user explicitly names `$delegate-codex` or `delegate-codex`, treat this skill as the controlling workflow for the turn. Do not substitute `gh-workflow-manager`, a generic worker, or any other PR agent merely because the task includes GitHub, push, pull request, or CI work. If Codex-only PR or GitHub workflow guidance appears to conflict, route the whole write and PR workflow through the disposable Codex described by this skill, and keep `main` as coordinator, reviewer, and explicit-merge executor only. Before spawning any agent for write or PR work, state the selected skill and agent in a short user-facing update.
+
 Task size never creates an exception. "Small enough to do myself" is not a valid reason to skip delegation.
 
 At the start of every new delegation, re-open this `SKILL.md` and follow the current procedure from the skill. Do not reproduce the delegation flow from memory; remembered steps drift from the source of truth.


### PR DESCRIPTION
## Summary

- Document that explicit `$delegate-codex` / `delegate-codex` requests control the turn workflow.
- Prevent substituting `gh-workflow-manager` when `$delegate-codex` is explicitly requested, even for GitHub, push, PR, or CI work.
- Add the matching Codex-only PR subagent gate while preserving PR/CI confirmation and no-merge requirements for implementers.

## Verification

- `git diff --check`
- `git diff -- home/dot_config/exact_agents/skills/delegate-codex/SKILL.md home/dot_config/codex/AGENTS.codex-only.md`
- `git status --short`