### PR TITLE
chore(mise): add cliproxyapi

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -41,6 +41,7 @@ sqlite = "3.53.3"
 
 # GitHub release tools
 "github:d-kuro/gwq" = "0.1.1"
+"github:router-for-me/CLIProxyAPI" = "7.2.66"
 "github:shuntaka9576/blocc" = { version = "0.6.0", os = ["linux"] }
 
 # npm tools


### PR DESCRIPTION
## Summary
- Add CLIProxyAPI to the global mise tool config as a pinned GitHub release tool.

## Validation
- `MISE_GLOBAL_CONFIG_FILE=$PWD/home/dot_mise/config.toml mise install github:router-for-me/CLIProxyAPI@7.2.66 --dry-run`
- `MISE_GLOBAL_CONFIG_FILE=$PWD/home/dot_mise/config.toml mise which cli-proxy-api`
- `git diff --check`