### PR TITLE
fix(delegate-codex): inject Codex spawn options

### DIFF
--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -74,6 +74,7 @@ If it prints `spawned ... in tmux`, `spawned ... in a new terminal window`, or a
 
 The wrapper creates the Herdr tab directly and pre-registers the Codex identity with agmsg. It intentionally does not call `~/.agents/skills/agmsg/scripts/spawn.sh`, because `spawn.sh` prefers tmux placement when `$TMUX` is set and can silently create a narrow pane instead of the required Herdr tab.
 
+The wrapper injects environment-specific Codex CLI arguments from agmsg's per-type `spawn_options.yaml` using the same `codex:` semantics as `~/.agents/skills/agmsg/scripts/spawn.sh`; a missing file or missing `codex:` section is a no-op.
 Set `HERDR_CODEX_BIN` when the local environment needs a Codex wrapper instead of the plain `codex` executable.
 Set `HERDR_SPAWN_ENV_KEYS` to a space-separated list of environment variable names to pass selected values through to `herdr tab create` as `--env KEY=VALUE`.
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh
@@ -43,6 +43,7 @@ WS="${HERDR_WORKSPACE_ID:?not inside herdr}"
 CODEX_BIN="${HERDR_CODEX_BIN:-codex}"
 AGMSG_SCRIPTS_DIR="${AGMSG_SCRIPTS_DIR:-$HOME/.agents/skills/agmsg/scripts}"
 JOIN_SCRIPT="$AGMSG_SCRIPTS_DIR/join.sh"
+SPAWN_OPTIONS_SCRIPT="$AGMSG_SCRIPTS_DIR/lib/spawn-options.sh"
 
 [ -d "$PROJECT" ] || {
     echo "spawn-codex-tab: project path does not exist: $PROJECT" >&2
@@ -62,6 +63,12 @@ command -v "$CODEX_BIN" > /dev/null 2>&1 || {
     echo "spawn-codex-tab: agmsg join.sh not found: $JOIN_SCRIPT" >&2
     exit 1
 }
+[ -r "$SPAWN_OPTIONS_SCRIPT" ] || {
+    echo "spawn-codex-tab: agmsg spawn-options.sh not found: $SPAWN_OPTIONS_SCRIPT" >&2
+    exit 1
+}
+# shellcheck disable=SC1090
+source "$SPAWN_OPTIONS_SCRIPT"
 
 ENV_ARGS=()
 for KEY in ${HERDR_SPAWN_ENV_KEYS:-}; do
@@ -74,6 +81,11 @@ done
 
 AGMSG_RESOLVE_PROJECT=0 "$JOIN_SCRIPT" "$TEAM" "$NAME" codex "$PROJECT" > /dev/null
 
+CODEX_ARGS=()
+while IFS= read -r _spawn_opt_tok; do
+    CODEX_ARGS+=("$_spawn_opt_tok")
+done < <(agmsg_spawn_options_tokens codex)
+
 BOOT_DIR="${TMPDIR:-/tmp}/delegate-codex-spawn"
 mkdir -p "$BOOT_DIR"
 find "$BOOT_DIR" -name 'boot-*.sh' -type f -mtime +1 -delete 2> /dev/null || true
@@ -84,7 +96,11 @@ mv "$BOOT_BASE" "$BOOT"
     echo '#!/usr/bin/env bash'
     echo 'set -euo pipefail'
     printf 'cd %q\n' "$PROJECT"
-    printf 'exec %q %q\n' "$CODEX_BIN" "/agmsg actas $NAME"
+    printf 'exec %q' "$CODEX_BIN"
+    for ARG in "${CODEX_ARGS[@]}"; do
+        printf ' %q' "$ARG"
+    done
+    printf ' %q\n' "/agmsg actas $NAME"
 } > "$BOOT"
 chmod +x "$BOOT"
 


### PR DESCRIPTION
## Summary

- Source agmsg `lib/spawn-options.sh` from the Herdr tab wrapper.
- Inject `codex:` spawn option tokens into the generated boot script before the `/agmsg actas ...` prompt.
- Document that the wrapper now follows agmsg `spawn_options.yaml` semantics.

## Verification

- `shfmt -i 4 -sr -d home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh`
- `shellcheck home/dot_config/exact_agents/skills/delegate-codex/scripts/spawn-codex-tab.sh`
- `make format`
- Dry-run spawn with stubbed `herdr`, `codex`, and agmsg scripts:

```text
with-config: exec codex --profile flava-dev /agmsg\ actas\ impl-profile
without-config: exec codex /agmsg\ actas\ impl-none
```

Local `bats` tests were not run, following the repository policy that bats validation should run in GitHub Actions.