### PR TITLE
feat(delegate-codex): add consultation mode

### DIFF
--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -31,22 +31,30 @@ Use Consultation Mode when the user wants a disposable Codex consultant for dire
 
 Create one consultant per consultation. Use `consult-<topic-slug>` for the agmsg role and `consult: <topic-slug>` for the Herdr tab label.
 
+Create a read-only anchor worktree for the consultation before spawning:
+
+```shell
+gwq add -b consult/<topic-slug>
+PROJECT=$(gwq get consult/<topic-slug>)
+```
+
 Spawn the consultant through the same Herdr wrapper used in [Spawn](#spawn):
 
 ```shell
 TEAM=$(basename -s .git "$(git remote get-url origin)")
 NAME=consult-<topic-slug>
-PROJECT=<read-only-anchor-worktree-path>
 scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT"
 ```
 
-The `PROJECT` must be a read-only anchor worktree created for the consultation with `gwq add`. A dedicated path is required even for consultation because agmsg resolves identity per `(project, type)` pair and may not handle multiple Codex identities in the same project path reliably.
+The `PROJECT` must be the dedicated read-only anchor worktree created for the consultation. A dedicated path is required even for consultation because agmsg resolves identity per `(project, type)` pair and may not handle multiple Codex identities in the same project path reliably.
 
 Send the initial task message from `main` to the consultant with agmsg:
 
 ```shell
 ~/.agents/skills/agmsg/scripts/send.sh "$TEAM" main "$NAME" "<message>"
 ```
+
+When the message contains Markdown code fences, pass it with single quotes or through a variable or heredoc; do not place triple-backtick content directly inside a Bash double-quoted string because backticks trigger command substitution.
 
 Use this template and fill in every placeholder before sending:
 
@@ -79,11 +87,13 @@ Send that summary with:
 Use team `<team>` and your role `consult-<topic-slug>`. After sending the summary, tell the user only: "結果を親エージェントに引き継ぎました". Do not show the user the words agmsg, Herdr, pane id, or any internal command.
 ````
 
-After spawning and sending the task message, nudge the consultant exactly once so it reads the briefing before the user enters the pane:
+After spawning and sending the task message, make exactly one successful pre-consultation nudge so the consultant reads the briefing before the user enters the pane:
 
 ```shell
 scripts/nudge-codex.sh <pane_id> "inbox を確認して相談準備をしてください"
 ```
+
+If this nudge exits with code 3 because Codex is still booting or not idle, follow [Nudge Rules](#nudge-rules) and retry after the pane reaches `idle` or `done` until this one pre-consultation nudge succeeds.
 
 Wait for the pane to transition to working, finish reading the briefing, print its ready message, and return to idle by using the same non-intrusive waiting pattern as [Monitoring](#monitoring). Only after this readiness confirmation, tell the user in plain language:
 
@@ -91,9 +101,14 @@ Wait for the pane to transition to working, finish reading the briefing, print i
 相談用のタブ `consult: <topic-slug>` を開きました。そちらで直接お話しください。終わったら「相談おわりました」と伝えてください。
 ```
 
-Treat the consultation pane as user-occupied from the moment this user-facing guidance is sent. Do not nudge it again, read the pane transcript, or otherwise operate it with Herdr while the consultation is active. Wait for the result through the `main` agmsg inbox as described in [Monitoring](#monitoring), then reflect the received consultation result in the next work.
+Treat the consultation pane as user-occupied from the moment this user-facing guidance is sent. Do not nudge it again, read the pane transcript, or otherwise operate it with Herdr while the consultation is active. Wait for the result through the `main` agmsg inbox as described in [Monitoring](#monitoring), then reflect the received consultation result in the next work. If the user confirms outside the pane that the consultation is finished without a summary, `main` may proceed to cleanup without waiting for a consultant summary.
 
-After receiving the consultation summary, ask the user whether they need any additional consultation before cleanup. If there is no additional consultation, close the Herdr tab, reset the consultant registration by following [Cleanup](#cleanup), and remove the read-only anchor worktree.
+After receiving the consultation summary, ask the user whether they need any additional consultation before cleanup. If there is no additional consultation, the consultation's user-occupied state ends and the normal [Cleanup](#cleanup) procedure is allowed. Close the Herdr tab and reset the consultant registration, then remove the read-only anchor worktree and delete the branch created for the anchor worktree:
+
+```shell
+gwq remove consult/<topic-slug>
+git branch -D consult/<topic-slug>
+```
 
 ## Roles And Naming
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -64,6 +64,8 @@ Use this template and fill in every placeholder before sending:
 
 The user will appear directly in this pane after startup. Your primary job is to answer and discuss with the user in this pane. Do not send intermediate status reports to main.
 
+After reading this briefing, print a short ready message in the pane such as "相談の準備ができました。どうぞお話しください" and wait for the user. Do not send an agmsg reply to main for this readiness signal.
+
 ## Completion Protocol
 
 When the user says "相談おわりました" or any close variant or synonym, summarize the consultation for main. Include the conclusion, decisions, unresolved questions, and recommended actions in a structured message.
@@ -77,13 +79,19 @@ Send that summary with:
 Use team `<team>` and your role `consult-<topic-slug>`. After sending the summary, tell the user only: "結果を親エージェントに引き継ぎました". Do not show the user the words agmsg, Herdr, pane id, or any internal command.
 ````
 
-Immediately after spawning the consultant, tell the user in plain language:
+After spawning and sending the task message, nudge the consultant exactly once so it reads the briefing before the user enters the pane:
+
+```shell
+scripts/nudge-codex.sh <pane_id> "inbox を確認して相談準備をしてください"
+```
+
+Wait for the pane to transition to working, finish reading the briefing, print its ready message, and return to idle by using the same non-intrusive waiting pattern as [Monitoring](#monitoring). Only after this readiness confirmation, tell the user in plain language:
 
 ```text
 相談用のタブ `consult: <topic-slug>` を開きました。そちらで直接お話しください。終わったら「相談おわりました」と伝えてください。
 ```
 
-Treat the consultation pane as user-occupied from spawn onward. Do not nudge it, read the pane transcript, or otherwise operate it with Herdr while the consultation is active. Wait for the result through the `main` agmsg inbox as described in [Monitoring](#monitoring), then reflect the received consultation result in the next work.
+Treat the consultation pane as user-occupied from the moment this user-facing guidance is sent. Do not nudge it again, read the pane transcript, or otherwise operate it with Herdr while the consultation is active. Wait for the result through the `main` agmsg inbox as described in [Monitoring](#monitoring), then reflect the received consultation result in the next work.
 
 After receiving the consultation summary, ask the user whether they need any additional consultation before cleanup. If there is no additional consultation, close the Herdr tab, reset the consultant registration by following [Cleanup](#cleanup), and remove the read-only anchor worktree.
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegate-codex
-description: 実装タスクを herdr の新しいラベル付き tab 上の使い捨て実装者 Codex に agmsg 経由で委譲する。どのリポジトリでも、実装・修正・コミット・push・PR 作成を任せるとき、「codex にやらせて」「実装者に依頼」「委譲して」のとき、および main が自分でコードを書き始めそうなときに必ず使う。
+description: 実装タスクを herdr の新しいラベル付き tab 上の使い捨て実装者 Codex に agmsg 経由で委譲する。どのリポジトリでも、実装・修正・コミット・push・PR 作成を任せるとき、「codex にやらせて」「実装者に依頼」「委譲して」のとき、および main が自分でコードを書き始めそうなときに必ず使う。相談相手を立てて、壁打ち用に codex を立てて、などユーザー相談用 Codex が必要なときにも使う。
 ---
 
 # Delegate Codex
@@ -24,6 +24,68 @@ At the start of every new delegation, re-open this `SKILL.md` and follow the cur
 `main` may directly perform read-only investigation, send or receive agmsg messages, monitor, nudge, or clean up Herdr-managed implementers, run GitHub read operations, and execute a merge only when the user explicitly instructs `main` to merge that specific pull request.
 
 This rule is for the coordinator role. If the current agent is already acting as an `impl-<task-slug>` implementer for a delegated task, complete that assigned work in its own task worktree instead of recursively spawning another implementer.
+
+## Consultation Mode
+
+Use Consultation Mode when the user wants a disposable Codex consultant for direct discussion instead of write work. Consultation Mode does not replace the implementer flow because it has no write authority; if the consultation produces implementation work, delegate that follow-up work to an implementer with the standard workflow.
+
+Create one consultant per consultation. Use `consult-<topic-slug>` for the agmsg role and `consult: <topic-slug>` for the Herdr tab label.
+
+Spawn the consultant through the same Herdr wrapper used in [Spawn](#spawn):
+
+```shell
+TEAM=$(basename -s .git "$(git remote get-url origin)")
+NAME=consult-<topic-slug>
+PROJECT=<read-only-anchor-worktree-path>
+scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT"
+```
+
+The `PROJECT` must be a read-only anchor worktree created for the consultation with `gwq add`. A dedicated path is required even for consultation because agmsg resolves identity per `(project, type)` pair and may not handle multiple Codex identities in the same project path reliably.
+
+Send the initial task message from `main` to the consultant with agmsg:
+
+```shell
+~/.agents/skills/agmsg/scripts/send.sh "$TEAM" main "$NAME" "<message>"
+```
+
+Use this template and fill in every placeholder before sending:
+
+````markdown
+## Consultation Topic
+
+<topic and the background summary already known by main>
+
+## Constraints
+
+- Treat this repository as read-only. Do not make repository changes, commits, pushes, pull requests, GitHub write operations, or any other write operation.
+- Read-only investigation, local file inspection, and search are allowed when they help the discussion.
+
+## Conversation Policy
+
+The user will appear directly in this pane after startup. Your primary job is to answer and discuss with the user in this pane. Do not send intermediate status reports to main.
+
+## Completion Protocol
+
+When the user says "相談おわりました" or any close variant or synonym, summarize the consultation for main. Include the conclusion, decisions, unresolved questions, and recommended actions in a structured message.
+
+Send that summary with:
+
+```shell
+~/.agents/skills/agmsg/scripts/send.sh <team> consult-<topic-slug> main "<summary>"
+```
+
+Use team `<team>` and your role `consult-<topic-slug>`. After sending the summary, tell the user only: "結果を親エージェントに引き継ぎました". Do not show the user the words agmsg, Herdr, pane id, or any internal command.
+````
+
+Immediately after spawning the consultant, tell the user in plain language:
+
+```text
+相談用のタブ `consult: <topic-slug>` を開きました。そちらで直接お話しください。終わったら「相談おわりました」と伝えてください。
+```
+
+Treat the consultation pane as user-occupied from spawn onward. Do not nudge it, read the pane transcript, or otherwise operate it with Herdr while the consultation is active. Wait for the result through the `main` agmsg inbox as described in [Monitoring](#monitoring), then reflect the received consultation result in the next work.
+
+After receiving the consultation summary, ask the user whether they need any additional consultation before cleanup. If there is no additional consultation, close the Herdr tab, reset the consultant registration by following [Cleanup](#cleanup), and remove the read-only anchor worktree.
 
 ## Roles And Naming
 


### PR DESCRIPTION
## Summary

- Add Consultation Mode guidance to `delegate-codex` for spawning disposable read-only Codex consultants in Herdr tabs.
- Document consultant naming, read-only anchor worktree usage, initial task message requirements, completion summary protocol, and cleanup.
- Extend the skill description so consultation requests such as asking for a discussion partner or wall-clock Codex trigger this skill.

## User flow example

1. Main opens a consultation tab named `consult: <topic-slug>`.
2. Main tells the user: `相談用のタブ consult: <topic-slug> を開きました。そちらで直接お話しください。終わったら「相談おわりました」と伝えてください。`
3. The user talks directly with the consultant.
4. When the user says `相談おわりました`, the consultant sends main a structured summary with conclusions, decisions, unresolved questions, and recommended actions.
5. Main reflects the summary into follow-up work and cleans up the consultant after confirming no additional consultation is needed.

## Verification

- `git diff --check`
- Reviewed Markdown fence structure manually; no pre-commit configuration was present in this repository.

## Notes

- No script changes were needed; the existing spawn, monitoring, and cleanup mechanisms are referenced as shared infrastructure.
- Consultation Mode is read-only and does not replace implementer delegation for write work.