### PR TITLE
fix(npm): allow low-download mise tools

### DIFF
--- a/home/dot_npmrc
+++ b/home/dot_npmrc
@@ -1,1 +1,2 @@
 min-release-age=7
+lowDownloadThreshold=0


### PR DESCRIPTION
## Summary
- Add `lowDownloadThreshold=0` to the chezmoi-managed `.npmrc` source.
- Preserve the existing `min-release-age=7` npm release-age policy.

## Verification
- `npm config get lowDownloadThreshold --userconfig ./home/dot_npmrc` -> `0`
- `npm config get min-release-age --userconfig ./home/dot_npmrc` -> `7`
- Inspected `tests/install/common/mise.bats`; it does not assert the repository `.npmrc` fixture content.
- Did not run local `bats` per repository AGENTS.md policy.
