### PR TITLE
feat(delegate-codex): sweep stale codex lanes

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -59,6 +59,11 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/herdr-agent-state.sh session",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/skills/delegate-codex/scripts/sweep-codex-lanes.sh --hook",
+            "timeout": 10
           }
         ]
       }

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -207,6 +207,40 @@ In `## 変更対象`, list concrete file paths and ownership boundaries. In `## 
 - If `nudge-codex.sh` exits with code 3, the pane is not idle or done. Wait until the pane's `agent_status` is `idle` or `done`, then retry the nudge.
 - Always run the occupancy check before a nudge. If the pane has become user-occupied, stop operating it and spawn a fresh implementer.
 
+## Restart Recovery
+
+At the start of a session after a host, shell, or Herdr restart, run the lane sweep before operating existing implementers:
+
+```shell
+~/.claude/skills/delegate-codex/scripts/sweep-codex-lanes.sh
+```
+
+The sweep scans `impl:` and `consult:` Herdr tabs and classifies each lane as `ALIVE`, `DEAD`, or `ZOMBIE`. Treat `DEAD` and `ZOMBIE` lanes as unavailable for new work until they are recovered or removed. Treat Codex lanes that were started before the restart as suspect even when the sweep reports `ALIVE`; verify recent transcript ownership and progress before nudging them.
+
+Recover a stale implementer with the same worktree and role:
+
+1. Close the stale Herdr tab:
+
+   ```shell
+   herdr tab close <tab_id>
+   ```
+
+2. Remove the stale Codex agmsg registration:
+
+   ```shell
+   ~/.agents/skills/agmsg/scripts/reset.sh "$PROJECT" codex "$NAME"
+   ```
+
+3. Spawn a replacement in the same worktree:
+
+   ```shell
+   ~/.claude/skills/delegate-codex/scripts/spawn-codex-tab.sh "$TEAM" "$NAME" "$PROJECT"
+   ```
+
+4. Resend the task context through agmsg and nudge the new pane with the standard [Nudge Rules](#nudge-rules).
+
+Use the plain `codex` executable for `spawn-codex-tab.sh` unless the local environment instructions explicitly require another executable. The wrapper already injects profile options from agmsg spawn options; setting `HERDR_CODEX_BIN=codex-dev` in an environment where spawn options also provide `--profile` can duplicate profile arguments and fail startup.
+
 ## Monitoring
 
 Wait for the implementer's current turn to finish with:

--- a/home/dot_config/exact_agents/skills/delegate-codex/scripts/sweep-codex-lanes.sh
+++ b/home/dot_config/exact_agents/skills/delegate-codex/scripts/sweep-codex-lanes.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# @file sweep-codex-lanes.sh
+# @brief Classify Herdr-hosted Codex delegate lanes after a restart.
+# @description
+#   Scans Herdr tabs labeled impl:* or consult:* and reports whether each lane
+#   looks alive, dead at a shell prompt, or stuck in a disconnected Codex TUI.
+
+set -euo pipefail
+
+find_python() {
+    if command -v python3 > /dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    command -v python
+}
+
+emit_hook_context() {
+    local output
+    local status
+    set +e
+    output="$("$0" 2>&1)"
+    status=$?
+    set -e
+
+    [ -n "$output" ] || exit 0
+
+    local python
+    python="$(find_python)" || exit 0
+    LANE_SWEEP_OUTPUT="$output" LANE_SWEEP_STATUS="$status" "$python" - << 'PY'
+import json
+import os
+
+output = os.environ["LANE_SWEEP_OUTPUT"]
+status = int(os.environ.get("LANE_SWEEP_STATUS", "0"))
+summary = (
+    "Codex lane sweep found DEAD/ZOMBIE lanes."
+    if status
+    else "Codex lane sweep found no stale lanes."
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": f"{summary}\n{output}",
+    }
+}))
+PY
+}
+
+usage() {
+    cat << 'EOF'
+Usage: sweep-codex-lanes.sh [--hook]
+
+Reports one line per Herdr tab labeled impl:* or consult:*. Exits 1 when any
+lane is classified as DEAD or ZOMBIE. With --hook, emits Claude Code hook JSON
+for SessionStart additionalContext and exits 0.
+EOF
+}
+
+case "${1:-}" in
+-h | --help)
+    usage
+    exit 0
+    ;;
+--hook)
+    emit_hook_context
+    exit 0
+    ;;
+"") ;;
+*)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+command -v herdr > /dev/null 2>&1 || exit 0
+
+PYTHON="$(find_python)" || exit 0
+TMPDIR_SWEEP="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SWEEP"' EXIT
+
+HERDR_ARGS=()
+if [ -n "${HERDR_WORKSPACE_ID:-}" ]; then
+    HERDR_ARGS=(--workspace "$HERDR_WORKSPACE_ID")
+fi
+
+TABS_JSON="$TMPDIR_SWEEP/tabs.json"
+PANES_JSON="$TMPDIR_SWEEP/panes.json"
+LANES_TSV="$TMPDIR_SWEEP/lanes.tsv"
+
+herdr tab list "${HERDR_ARGS[@]}" > "$TABS_JSON" 2> /dev/null || exit 0
+herdr pane list "${HERDR_ARGS[@]}" > "$PANES_JSON" 2> /dev/null || exit 0
+
+"$PYTHON" - "$TABS_JSON" "$PANES_JSON" > "$LANES_TSV" << 'PY'
+import json
+import sys
+
+tabs_path, panes_path = sys.argv[1:3]
+with open(tabs_path, encoding="utf-8") as fh:
+    tabs = json.load(fh)["result"]["tabs"]
+with open(panes_path, encoding="utf-8") as fh:
+    panes = json.load(fh)["result"]["panes"]
+
+panes_by_tab = {}
+for pane in panes:
+    panes_by_tab.setdefault(pane.get("tab_id"), []).append(pane)
+
+for tab in tabs:
+    label = tab.get("label") or ""
+    if not (label.startswith("impl:") or label.startswith("consult:")):
+        continue
+    tab_id = tab["tab_id"]
+    for pane in panes_by_tab.get(tab_id, []):
+        print("\t".join([
+            label,
+            tab_id,
+            pane["pane_id"],
+            pane.get("agent_status") or tab.get("agent_status") or "unknown",
+        ]))
+PY
+
+classify_transcript() {
+    local agent_status="$1"
+    local transcript_path="$2"
+
+    "$PYTHON" - "$agent_status" "$transcript_path" << 'PY'
+import re
+import sys
+
+agent_status, transcript_path = sys.argv[1:3]
+with open(transcript_path, encoding="utf-8", errors="replace") as fh:
+    text = fh.read()
+
+ansi = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+clean = ansi.sub("", text)
+lines = [line.rstrip() for line in clean.splitlines()]
+nonempty = [line for line in lines if line.strip()]
+last = nonempty[-1].strip() if nonempty else ""
+
+if "No saved session found" in clean:
+    print("DEAD\tNo saved session found")
+    raise SystemExit
+
+shell_prompt = re.compile(
+    r"^(?:[A-Za-z0-9._-]+@[^:]+:.+[#$]|[^ ]+@[^ ]+\s+.+[#$]|[#$%]|❯)\s*$"
+)
+if last and shell_prompt.match(last):
+    print(f"DEAD\tshell prompt: {last}")
+    raise SystemExit
+
+if "stream disconnected before completion" in clean:
+    print("ZOMBIE\tstream disconnected before completion")
+    raise SystemExit
+
+def elapsed_seconds(value):
+    total = 0
+    for amount, unit in re.findall(r"(\d+)\s*([hms])", value):
+        amount = int(amount)
+        if unit == "h":
+            total += amount * 3600
+        elif unit == "m":
+            total += amount * 60
+        else:
+            total += amount
+    return total
+
+working_ages = [
+    (match.group(1), elapsed_seconds(match.group(1)))
+    for match in re.finditer(r"Working \(([^)]*)\)", clean)
+]
+if working_ages:
+    label, seconds = max(working_ages, key=lambda item: item[1])
+    if seconds > 1800:
+        print(f"ZOMBIE\tWorking {label} (>30m)")
+        raise SystemExit
+    print(f"ALIVE\t{agent_status}; Working {label}")
+    raise SystemExit
+
+print(f"ALIVE\t{agent_status}")
+PY
+}
+
+has_stale=0
+while IFS=$'\t' read -r label tab_id pane_id agent_status; do
+    [ -n "$pane_id" ] || continue
+    transcript="$TMPDIR_SWEEP/$pane_id.txt"
+    herdr pane read "$pane_id" --source recent-unwrapped > "$transcript" 2>&1 || true
+    result="$(classify_transcript "$agent_status" "$transcript")"
+    state="${result%%$'\t'*}"
+    reason="${result#*$'\t'}"
+    printf '%s label="%s" tab=%s pane=%s status=%s reason="%s"\n' \
+        "$state" "$label" "$tab_id" "$pane_id" "$agent_status" "$reason"
+    case "$state" in
+    DEAD | ZOMBIE) has_stale=1 ;;
+    esac
+done < "$LANES_TSV"
+
+exit "$has_stale"


### PR DESCRIPTION
## Summary

- Add `sweep-codex-lanes.sh` to classify Herdr `impl:` and `consult:` Codex lanes as `ALIVE`, `DEAD`, or `ZOMBIE`.
- Inject the sweep result into Claude Code `SessionStart` additional context through the existing settings hook structure.
- Document restart recovery steps for stale delegate-codex lanes.

## Validation

- `shellcheck home/dot_config/exact_agents/skills/delegate-codex/scripts/sweep-codex-lanes.sh`
- `bash -n home/dot_config/exact_agents/skills/delegate-codex/scripts/sweep-codex-lanes.sh`
- `jq empty home/dot_config/claude/settings.json`
- `git diff --check`
- `home/dot_config/exact_agents/skills/delegate-codex/scripts/sweep-codex-lanes.sh`
- fake Herdr fixture verified `DEAD`/`ZOMBIE` return exit 1

## Sweep Sample

```text
ALIVE label="impl: dlt-repro" tab=wA:t5N pane=wA:p69 status=idle reason="idle"
ALIVE label="impl: object-guard" tab=wA:t5P pane=wA:p6A status=idle reason="idle"
ALIVE label="impl: merge-warden" tab=wA:t5Q pane=wA:p6B status=idle reason="idle"
ALIVE label="impl: radm" tab=wA:t50 pane=wA:p6N status=idle reason="idle"
ALIVE label="impl: posterllava" tab=wA:t61 pane=wA:p6P status=working reason="working; Working 3s • esc to interrupt"
ALIVE label="impl: posterllama" tab=wA:t62 pane=wA:p6Q status=idle reason="idle"
ALIVE label="impl: training-docs" tab=wA:t63 pane=wA:p6R status=idle reason="idle"
ALIVE label="impl: layoutflow-training" tab=wA:t64 pane=wA:p6S status=working reason="working; Working 7m 25s • esc to interrupt"
ALIVE label="impl: dlt" tab=wA:t65 pane=wA:p6T status=working reason="working"
ALIVE label="impl: cgb-dm" tab=wA:t66 pane=wA:p6V status=working reason="working; Working 7m 04s • esc to interrupt"
ALIVE label="impl: gallery" tab=wA:t67 pane=wA:p6W status=working reason="working; Working 7m 06s • esc to interrupt"
ALIVE label="impl: jaxbd-a" tab=wA:t68 pane=wA:p6X status=working reason="working; Working 7m 25s • esc to interrupt"
ALIVE label="impl: jaxbd-b" tab=wA:t69 pane=wA:p6Y status=working reason="working; Working 7m 25s • esc to interrupt"
ALIVE label="impl: jaxbd-c" tab=wA:t6A pane=wA:p6Z status=working reason="working; Working 7m 25s • esc to interrupt"
ALIVE label="impl: lane-recovery" tab=wA:t6B pane=wA:p60 status=working reason="working; Working 4m 03s • esc to interrupt"
exit=0
```

## Chezmoi Diff Note

`chezmoi --source "$PWD/home" diff` from this separate worktree shows symlink target movement from the live source directory to the worktree source directory for symlink-managed paths. The repository diff is limited to the intended three files, and `chezmoi apply` was not run.
