### PR TITLE
Fix eza icons alias parsing

### DIFF
--- a/home/dot_config/alias/common.sh
+++ b/home/dot_config/alias/common.sh
@@ -4,7 +4,7 @@
 # These aliases wrap common repository and local workflow commands.
 
 # Use eza for ls command
-alias ls="eza --long --group --header --binary --time-style=long-iso --icons"
+alias ls="eza --long --group --header --binary --time-style=long-iso --icons=auto"
 
 # Alias for private chezmoi configuration
 # ref. https://www.chezmoi.io/user-guide/frequently-asked-questions/design/#can-chezmoi-support-multiple-sources-or-multiple-source-states


### PR DESCRIPTION
## Why

`eza` v0.23.5 treats `--icons` as an option with an optional value. When the `ls` alias is followed by a path, the path can be parsed as the icons value and trigger an invalid option value error.

## What Changed

Updated `home/dot_config/alias/common.sh` to use `--icons=auto`, which preserves automatic icon behavior while disambiguating the option from following path arguments.

## Validation

Verify the alias expansion and confirm a missing path is handled as a normal `ls` path error instead of an `--icons` value error.

```shell
zsh -f -c 'source ./home/dot_config/alias/common.sh; type ls; ls ~/hoge'\n```