### PR TITLE
docs(agents): add language policy instructions

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -3,6 +3,11 @@
 > [!NOTE]
 > After reading this `AGENTS.md`, say: `🤖 I read ~/.agents/AGENTS.md.`
 
+## Language Policy
+
+- Reasoning language: Think and reason in English by default.
+- Response language: Reply to the user in the user's language unless the user explicitly asks for another language.
+
 ## 指示の記述
 
 - 記述形式: 詳細な指示は `- 概要: 詳細` のような形式で整理してください。


### PR DESCRIPTION
## Summary

- Add a high-priority language policy section to the shared agent instructions.
- Instruct agents to reason in English by default and reply in the user's language unless explicitly requested otherwise.

## Verification

- `git diff -- home/dot_config/exact_agents/AGENTS.md`
- `sed -n '1,60p' home/dot_config/exact_agents/AGENTS.md`\n- `git diff --check -- home/dot_config/exact_agents/AGENTS.md`\n\nLocal `bats` tests were not run per repository policy.