### PR TITLE
Ignore Playwright CLI artifacts

### DIFF
--- a/home/dot_config/exact_agents/agents/gh-workflow-manager.md
+++ b/home/dot_config/exact_agents/agents/gh-workflow-manager.md
@@ -47,6 +47,8 @@ You are the dedicated GitHub workflow manager for agent sessions in this reposit
   - `## What Changed`
   - `## Validation`
 - In either case, describe the full current PR, not only the latest delta.
+- Write multi-line GitHub issue, pull request, and comment bodies to a temporary Markdown file with a single-quoted heredoc, then submit them with `--body-file`.
+- Do not pass multi-line Markdown through `--body "...\n..."`; escaped newlines can be published literally instead of becoming Markdown line breaks.
 - Keep the `Validation` section repo-relative and never include local absolute paths.
 - In the `Validation` section, prefer repeated command-based steps instead of bullet lists.
 - For each command-based validation step, write one short natural-language line that explains what the command verified, then place the exact command in a fenced `shell` block.
@@ -54,6 +56,8 @@ You are the dedicated GitHub workflow manager for agent sessions in this reposit
 - Repeat that pattern for each command-based validation step.
 - If a validation item is not command-based, keep it as one short prose line without forcing a code block.
 - After any additional push, inspect the updated commits/diff and refresh the PR description so it matches the full current PR.
+- After creating or editing repository-facing GitHub text, read it back with `gh pr view`, `gh issue view`, or equivalent JSON output before reporting completion.
+- The read-back check must reject or report literal escaped newlines (`\n`) and local absolute paths such as `/Users/`, and confirm the expected Markdown headings and content are present.
 - Do not treat "PR created" or "PR updated" as task completion when CI verification is still pending.
 - After pushing, check GitHub Actions / checks and continue until all required checks pass or a failure requires parent/user intervention.
 - For a "create/update the PR" request, stay responsible until the required checks reach a terminal state and report that result explicitly.

--- a/home/dot_config/exact_git/ignore
+++ b/home/dot_config/exact_git/ignore
@@ -5,6 +5,7 @@
 *fuga*
 
 **/.claude/settings.local.json
+.playwright-cli/
 
 ### Linux ###
 *~

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -378,6 +378,12 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     run grep -F 'In either case, describe the full current PR, not only the latest delta.' "${SHARED_GH_AGENT_PATH}"
     [ "${status}" -eq 0 ]
 
+    run grep -F 'Write multi-line GitHub issue, pull request, and comment bodies to a temporary Markdown file with a single-quoted heredoc, then submit them with `--body-file`.' "${SHARED_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Do not pass multi-line Markdown through `--body "...\n..."`; escaped newlines can be published literally instead of becoming Markdown line breaks.' "${SHARED_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
     run grep -F 'Keep the `Validation` section repo-relative and never include local absolute paths.' "${SHARED_GH_AGENT_PATH}"
     [ "${status}" -eq 0 ]
 
@@ -394,6 +400,12 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
 
     run grep -F 'If a validation item is not command-based, keep it as one short prose line without forcing a code block.' "${SHARED_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'After creating or editing repository-facing GitHub text, read it back with `gh pr view`, `gh issue view`, or equivalent JSON output before reporting completion.' "${SHARED_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'The read-back check must reject or report literal escaped newlines (`\n`) and local absolute paths such as `/Users/`, and confirm the expected Markdown headings and content are present.' "${SHARED_GH_AGENT_PATH}"
     [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## Why

Playwright CLI stores runtime and browser-profile data under `.playwright-cli/`, so the global Git ignore file should prevent those local artifacts from appearing in dotfiles worktrees.

The PR description workflow also needs durable guardrails because repository-facing Markdown can be corrupted when multi-line bodies are passed through shell strings instead of a Markdown file.

## What Changed

- Added `.playwright-cli/` to the repo-managed global Git ignore file.
- Updated `gh-workflow-manager` guidance to write multi-line GitHub issue, pull request, and comment bodies through temporary Markdown files submitted with `--body-file`.
- Required read-back checks after creating or editing repository-facing GitHub text so literal escaped newlines, local absolute paths, and missing expected Markdown content are caught before completion is reported.
- Added focused install guidance assertions to keep the new GitHub body-formatting rules pinned.

## Validation

Inspect the diff for whitespace and patch formatting issues.

```shell
git diff --check
```

Check the updated GitHub workflow guidance assertions.

```shell
grep -F 'Write multi-line GitHub issue, pull request, and comment bodies to a temporary Markdown file with a single-quoted heredoc, then submit them with `--body-file`.' home/dot_config/exact_agents/agents/gh-workflow-manager.md
grep -F 'After creating or editing repository-facing GitHub text, read it back with `gh pr view`, `gh issue view`, or equivalent JSON output before reporting completion.' home/dot_config/exact_agents/agents/gh-workflow-manager.md
grep -F 'The read-back check must reject or report literal escaped newlines' home/dot_config/exact_agents/agents/gh-workflow-manager.md
```

Check the new Bats guidance assertions without running local Bats.

```shell
grep -F 'Write multi-line GitHub issue, pull request, and comment bodies to a temporary Markdown file with a single-quoted heredoc, then submit them with `--body-file`.' tests/install/common/agents_guidance.bats
grep -F 'After creating or editing repository-facing GitHub text, read it back with `gh pr view`, `gh issue view`, or equivalent JSON output before reporting completion.' tests/install/common/agents_guidance.bats
grep -F 'The read-back check must reject or report literal escaped newlines' tests/install/common/agents_guidance.bats
```

Verify the global ignore rule in a temporary repository with `core.excludesFile` pointed at the repo-managed ignore file.

```shell
tmp_repo="$(mktemp -d)"
git -C "${tmp_repo}" init --quiet
mkdir -p "${tmp_repo}/.playwright-cli"
git -c core.excludesFile="$(pwd)/home/dot_config/exact_git/ignore" -C "${tmp_repo}" check-ignore -v --no-index .playwright-cli/
```
