### PR TITLE
Guard GitHub body workflows

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -40,6 +40,9 @@
 - 口調: GitHub comment には「訂正します」「すみません」「そういう意味ではなく」「I misunderstood」などの会話上の修復表現や、ユーザー向けの meta commentary を含めないでください。
 - 内容: GitHub comment は中立的・事実ベース・監査可能で、あとから読む repository maintainer に役立つ内容にしてください。
 - 投稿前確認: 投稿または編集の前に、comment 本文を現在の repository の事実、実行した command、確認した check / report と照合してください。曖昧な要約よりも、具体的な検証結果・対象ファイル・残っている blocker を優先してください。
+- 本文の渡し方: GitHub issue body / PR description / PR comment のような multi-line Markdown は、必ず一時 Markdown file を single-quoted heredoc で作り、`gh ... --body-file <file>` で投稿・更新してください。
+- 禁止: `gh ... --body "...\n..."` や shell-escaped multi-line body の直渡しは、literal `\n` が公開されるため使わないでください。
+- Read-back: 作成または編集後は `gh pr view`、`gh issue view`、`gh api` などで本文を read back し、literal escaped newlines (`\n`)、local absolute paths such as `/Users/`、期待見出しの欠落を検出してから完了報告してください。
 - 詳細の畳み込み: 長い診断ログや調査詳細は、短い summary を付けた `<details>` に入れて、comment の先頭では結論と必要な action が読めるようにしてください。
 - 誤投稿時の対応: 不適切な comment を投稿した場合は、可能な限り既存 comment を編集して修正してください。悪い comment を残したまま、重複する訂正 comment を新規投稿しないでください。
 

--- a/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
+++ b/home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
@@ -195,6 +195,10 @@ Use this template:
 
 In `## 変更対象`, list concrete file paths and ownership boundaries. In `## 完了条件`, list the exact verification commands or CI expectations, and always include that completion means PR creation plus green CI only: the implementer must not merge; `main` reviews and leaves the merge decision to the user. In `## 報告`, ask the implementer to reply with the PR URL, CI state, and any review notes. The implementer's own GitHub workflow guidance is responsible for commit, push, PR, and CI discipline.
 
+Task messages that ask the implementer to create or update GitHub PR, issue, or comment bodies must require temp-file body handling: write multi-line Markdown to a temporary file with a single-quoted heredoc and pass it with `gh ... --body-file <file>`, never with `--body "...\n..."` or shell-escaped inline strings.
+
+Before reporting completion, the implementer must read body content back with `gh pr view ... --json body --jq .body`, `gh issue view`, or equivalent, reject/report literal `\n` and `/Users/`, and report body read-back pass together with the PR URL and CI state.
+
 ## Nudge Rules
 
 - Nudge only through the bundled helper:
@@ -264,6 +268,8 @@ For long-running work, repeat non-intrusive checks: wait for the pane status, re
 - Merge execution: merge only when the user explicitly instructs `main` to merge that specific PR. Do not carry forward an apparent blanket approval from prior context to a new PR, and do not let `main` or the implementer self-merge because the change looks small or routine.
 
 Keep push, PR creation or update, and CI confirmation on the implementer side. The implementer Codex should use its own GitHub workflow guidance for git and GitHub write operations.
+
+When the implementer directly creates or updates a PR, issue, or comment body, the same temp-file body and read-back guard is part of the implementer's completion criteria. A PR URL alone is not enough; the report must include body read-back pass and CI state.
 
 ## Cleanup
 

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -15,6 +15,7 @@ readonly CODEX_WORKLOG_AUDIT_SCRIPT_PATH="./home/dot_config/exact_agents/skills/
 readonly CODEX_GH_AGENT_PATH="./home/dot_config/codex/agents/gh-workflow-manager.toml"
 readonly SHARED_GH_AGENT_PATH="./home/dot_config/exact_agents/agents/gh-workflow-manager.md"
 readonly LEGACY_GH_FIRST_SKILL_PATH="./home/dot_config/exact_agents/skills/gh-first-workflow"
+readonly DELEGATE_CODEX_SKILL_PATH="./home/dot_config/exact_agents/skills/delegate-codex/SKILL.md"
 readonly AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS.md.tmpl"
 readonly SHARED_AGENT_DIR_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_agents.tmpl"
 readonly CLAUDE_MD_PATH="./home/dot_config/claude/CLAUDE.md"
@@ -406,6 +407,26 @@ readonly CANONICAL_CODEX_README_PATH="./home/dot_config/codex/README.md"
     [ "${status}" -eq 0 ]
 
     run grep -F 'The read-back check must reject or report literal escaped newlines (`\n`) and local absolute paths such as `/Users/`, and confirm the expected Markdown headings and content are present.' "${SHARED_GH_AGENT_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] shared and delegate guidance reject inline multi-line GitHub bodies" {
+    run grep -F 'GitHub issue body / PR description / PR comment のような multi-line Markdown は、必ず一時 Markdown file を single-quoted heredoc で作り、`gh ... --body-file <file>` で投稿・更新してください。' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F '`gh ... --body "...\n..."` や shell-escaped multi-line body の直渡しは、literal `\n` が公開されるため使わないでください。' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'literal escaped newlines (`\n`)、local absolute paths such as `/Users/`、期待見出しの欠落を検出してから完了報告してください。' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Task messages that ask the implementer to create or update GitHub PR, issue, or comment bodies must require temp-file body handling: write multi-line Markdown to a temporary file with a single-quoted heredoc and pass it with `gh ... --body-file <file>`, never with `--body "...\n..."` or shell-escaped inline strings.' "${DELEGATE_CODEX_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Before reporting completion, the implementer must read body content back with `gh pr view ... --json body --jq .body`, `gh issue view`, or equivalent, reject/report literal `\n` and `/Users/`, and report body read-back pass together with the PR URL and CI state.' "${DELEGATE_CODEX_SKILL_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'A PR URL alone is not enough; the report must include body read-back pass and CI state.' "${DELEGATE_CODEX_SKILL_PATH}"
     [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## Why

A private dotfiles PR description was published with escaped newline text after an implementer used an inline shell string for a multi-line GitHub body. The existing guardrail covered gh-workflow-manager, but not shared AGENTS guidance or delegate-codex implementers.

## What Changed

Added shared AGENTS guidance requiring GitHub issue bodies, PR descriptions, and comments to use temporary Markdown files plus `--body-file` for multi-line content.

Updated delegate-codex instructions so implementers must use the same body-file flow, read bodies back before completion, and report body read-back pass together with the PR URL and CI state.

Extended the agents guidance Bats assertions to lock the shared AGENTS and delegate-codex guardrails in place.

## Validation

Checked the new shared AGENTS body-file guidance assertion text.

```shell
grep -F -- '--body-file <file>' home/dot_config/exact_agents/AGENTS.md
```

Checked the delegate-codex body-file and completion-report guidance.

```shell
grep -F -- 'body read-back pass together with the PR URL and CI state' home/dot_config/exact_agents/skills/delegate-codex/SKILL.md
```

Checked the Bats guidance assertions added for shared AGENTS and delegate-codex.

```shell
grep -F -- 'shared and delegate guidance reject inline multi-line GitHub bodies' tests/install/common/agents_guidance.bats
```

Inspected the repository diff for whitespace issues.

```shell
git diff --check
```

Updated and read back `shunk031/dotfiles-private#106`; the body now has the expected headings and no corrupted newline text or local absolute-path text.

```shell
gh pr view 106 --repo shunk031/dotfiles-private --json body --jq .body
```

Local Bats execution was intentionally skipped per repository policy.
