### PR TITLE
feat(claude): enable agent teams env

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -2,7 +2,11 @@
   "model": "opusplan",
   "alwaysThinkingEnabled": true,
   "env": {
-    "DISABLE_AUTOUPDATER": "1"
+    "DISABLE_AUTOUPDATER": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ALWAYS_ENABLE_EFFORT": "1",
+    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "3",
+    "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1"
   },
   "plansDirectory": "./.agents/worklog/claude",
   "permissions": {


### PR DESCRIPTION
## Summary

This PR updates the Claude Code environment settings to enable experimental agent teams and related non-secret runtime controls that are already used safely by the private gateway wrapper.

The change intentionally keeps gateway credentials and local proxy routing out of the public settings file.

## Verification

```bash
jq -e '.env.DISABLE_AUTOUPDATER == "1" and .env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS == "1" and .env.CLAUDE_CODE_ALWAYS_ENABLE_EFFORT == "1" and .env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY == "3" and .env.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB == "1"' home/dot_config/claude/settings.json
```

Result: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
