### PR TITLE
refactor(skills): move to pool + per-tool subscription layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,33 +7,6 @@ coverage*
 .agents/worklog/
 .playwright-cli/
 
-# ~/.agents/skills and ~/.claude/skills point here, so global skill installers
-# can expand generated skills into the chezmoi source tree. Ignore generated
-# skills by default and explicitly allow repo-managed skills below.
-home/dot_config/exact_agents/skills/*
-!home/dot_config/exact_agents/skills/ai-slop-checklist-ja/
-!home/dot_config/exact_agents/skills/ai-slop-checklist-ja/**
-!home/dot_config/exact_agents/skills/cgd-dev-identity/
-!home/dot_config/exact_agents/skills/cgd-dev-identity/**
-!home/dot_config/exact_agents/skills/convert-to-transformers/
-!home/dot_config/exact_agents/skills/convert-to-transformers/**
-!home/dot_config/exact_agents/skills/gh-comment-attach-files/
-!home/dot_config/exact_agents/skills/gh-comment-attach-files/**
-!home/dot_config/exact_agents/skills/high-impact-journal-publishing/
-!home/dot_config/exact_agents/skills/high-impact-journal-publishing/**
-!home/dot_config/exact_agents/skills/humanizer-ja/
-!home/dot_config/exact_agents/skills/humanizer-ja/**
-!home/dot_config/exact_agents/skills/python-uv-workflow/
-!home/dot_config/exact_agents/skills/python-uv-workflow/**
-!home/dot_config/exact_agents/skills/setup-agent-docs/
-!home/dot_config/exact_agents/skills/setup-agent-docs/**
-!home/dot_config/exact_agents/skills/shdoc-shell-docs/
-!home/dot_config/exact_agents/skills/shdoc-shell-docs/**
-
-# Keep runtime artifacts inside allowlisted skills ignored; this must stay
-# after the allowlist entries above because the last matching pattern wins.
-home/dot_config/exact_agents/skills/*/.playwright-cli/
-
 # Herdr and other integrations may generate Claude hooks here. Ignore generated
 # hooks by default and explicitly allow repo-managed hooks below.
 home/dot_config/claude/hooks/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Public source: Files under `home/` are the public source state and are applied by `chezmoi` into the user's `$HOME` directory.
 - Private source: Private dotfiles are managed separately from `~/.local/share/chezmoi-private` with config at `~/.config/chezmoi-private/chezmoi.yaml`.
 - Management boundary: Treat the public `home/` tree and the private `chezmoi` source/config as separate management domains.
-- Agent skills: `home/dot_config/exact_agents/skills/*` is ignored by default because global skill installers write through symlinked runtime paths. When adding a repo-managed skill, add an explicit `.gitignore` allowlist entry for that skill.
+- Agent skills: `~/.agents/skills` is a real directory (the shared skills pool); repo-managed skills live in `home/dot_config/exact_agents/skills/<name>/` and are exposed there through one `home/exact_dot_agents/skills/symlink_<name>.tmpl` per skill. `~/.claude/skills` is a real, Claude-only directory so `npx skills add --agent claude-code` and similar installers can write generated skills without touching the chezmoi source tree. A `run_after` script (`home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl`) links every pool entry into each tool's skills directory on every `chezmoi apply`, without overwriting locally installed (non-symlink) entries. To make an installer-added skill repo-managed, move its directory into `home/dot_config/exact_agents/skills/` and add a matching symlink template.
 
 ## Comment Policy
 

--- a/home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# @file home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl
+# @brief Subscribe each tool's skills directory to the shared skills pool.
+# @description
+#   Treats `~/.agents/skills` as the shared pool of repo-managed skills and
+#   links every pool entry into each tool-specific skills directory listed in
+#   `TOOL_DIRS`. Never overwrites a real (non-symlink) entry that a skill
+#   installer wrote directly into a tool directory, and removes dangling pool
+#   symlinks left behind after a skill is removed from the pool.
+
+{{ if ne (env "CI") "true" -}}
+set -Eeuo pipefail
+
+readonly POOL="${HOME}/.agents/skills"
+readonly TOOL_DIRS=(
+    "${HOME}/.claude/skills"
+)
+
+if [ ! -d "${POOL}" ]; then
+    echo "run_after_90-link-shared-skills: ${POOL} is not a directory, skipping" >&2
+    exit 0
+fi
+
+for tool_dir in "${TOOL_DIRS[@]}"; do
+    mkdir -p "${tool_dir}"
+
+    for entry in "${POOL}"/*; do
+        [ -e "${entry}" ] || continue
+
+        name="$(basename "${entry}")"
+        target="${tool_dir}/${name}"
+
+        if [ -e "${target}" ] && [ ! -L "${target}" ]; then
+            echo "run_after_90-link-shared-skills: ${target} is a real entry, keeping it and skipping the pool link for ${name}" >&2
+            continue
+        fi
+
+        ln -sfn "${entry}" "${target}"
+    done
+
+    while IFS= read -r -d '' link; do
+        link_target="$(readlink "${link}")"
+        case "${link_target}" in
+            "${POOL}"/*)
+                if [ ! -e "${link_target}" ]; then
+                    rm -f "${link}"
+                fi
+                ;;
+        esac
+    done < <(find "${tool_dir}" -maxdepth 1 -type l -print0)
+done
+{{ end -}}

--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -1,5 +1,6 @@
 - This directory is applied as `~/.claude`.
 - Chezmoi maps it to the canonical source in [home/dot_config/claude/](../dot_config/claude/).
 - Chezmoi maps `~/.claude/agents` to Claude wrapper agents in [home/dot_config/claude/agents/](../dot_config/claude/agents/). Those wrappers tell Claude to read shared instructions from `~/.agents/agents`.
+- `skills/` only carries a `.keep` marker so chezmoi creates `~/.claude/skills` as a real, Claude-only directory. It is not populated from this repo: `home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl` subscribes it to the shared pool at `~/.agents/skills` after every `chezmoi apply`, and skill installers may also write real skill directories there directly.
 - The design keeps the home-facing path stable while the real files live in one git-friendly source tree.
 - Edit the canonical source, not this adapter directory.

--- a/home/dot_claude/symlink_skills.tmpl
+++ b/home/dot_claude/symlink_skills.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills

--- a/home/dot_config/claude/README.md
+++ b/home/dot_config/claude/README.md
@@ -1,6 +1,7 @@
 - This directory is the canonical source for `~/.claude`.
 - [CLAUDE.md](CLAUDE.md) imports the shared guidance with `@~/.agents/AGENTS.md`; add Claude-specific guidance below that import when needed.
 - [agents/](agents/) contains Claude subagent wrappers exposed as `~/.claude/agents`. Keep long shared instructions in `~/.agents/agents`; each wrapper keeps Claude subagent frontmatter and tells Claude to read `~/.agents/agents/<name>.md` first.
+- `~/.claude/skills` is a real, Claude-only directory, not part of this canonical source: skill installers write generated skills there directly, and a `run_after` script subscribes it to the shared skills pool at `~/.agents/skills` (see [home/dot_config/exact_agents/README.md](../exact_agents/README.md#skill-pool-and-subscription-policy)).
 - [home/dot_claude/](../../dot_claude/) is only the adapter layer that exposes this source in the applied home layout.
 - The design keeps edits in one git-friendly place while preserving the familiar home path.
 - Edit files here; the adapter keeps the home path stable.

--- a/home/dot_config/exact_agents/README.md
+++ b/home/dot_config/exact_agents/README.md
@@ -4,11 +4,13 @@ In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` remov
 
 [AGENTS.md](AGENTS.md) is the shared guidance used directly by `~/.agents/AGENTS.md` and imported from `~/.claude/CLAUDE.md` with `@~/.agents/AGENTS.md`. Shared long-form agent instructions live in [agents/](agents/) and are exposed as `~/.agents/agents`; Claude Markdown wrappers explicitly tell the tool to read the same shared Markdown first. Edit files here; the adapter keeps the home path stable.
 
-## Skill Ignore Policy
+## Skill Pool and Subscription Policy
 
-`~/.agents/skills` and `~/.claude/skills` both point to `home/dot_config/exact_agents/skills`, so global skill installers can write generated skills back into the chezmoi source tree.
+`~/.agents/skills` is a real directory: the shared skills pool. Each repo-managed skill under `home/dot_config/exact_agents/skills/<name>/` is exposed there through its own `home/exact_dot_agents/skills/symlink_<name>.tmpl` adapter template, so adding a skill to the pool means adding one skill directory plus one symlink template, not editing a `.gitignore` allowlist.
 
-New skill directories under `home/dot_config/exact_agents/skills` are ignored by default. When a skill should be managed by this repository, add that skill to the `.gitignore` allowlist and keep the reason for managing it clear in the PR.
+`~/.claude/skills` is also a real directory, but it is Claude-only and unmanaged by chezmoi: `npx skills add --agent claude-code` and similar installers write generated skills directly there without touching the chezmoi source tree. On every `chezmoi apply`, [home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl](../../.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl) subscribes `~/.claude/skills` to the pool: it symlinks every pool entry into `~/.claude/skills`, skips (and warns about) any name that already exists there as a real, installer-written directory, and prunes pool symlinks whose pool entry has since been removed.
+
+To make an installer-added skill repo-managed, move its directory into `home/dot_config/exact_agents/skills/` and add a matching `home/exact_dot_agents/skills/symlink_<name>.tmpl`; the next `chezmoi apply` then relinks it as a shared pool entry.
 
 The diagram below describes this repository's source-of-truth layout, not the meaning of chezmoi's `exact_` attribute itself.
 
@@ -18,16 +20,17 @@ The diagram below describes this repository's source-of-truth layout, not the me
 flowchart LR
   subgraph RUNTIME["runtime"]
     U_CLAUDE["Claude Code"]
+    U_INSTALLER["skill installer (e.g. npx skills add)"]
   end
 
   subgraph HOME["$HOME"]
     H_CLAUDE(["~/.claude/CLAUDE.md"])
     H_CLAUDE_AGENTS(["~/.claude/agents/"])
-    H_CLAUDE_SKILLS(["~/.claude/skills/"])
+    H_CLAUDE_SKILLS(["~/.claude/skills/ (real dir)"])
 
     H_SHARED(["~/.agents/AGENTS.md"])
     H_SHARED_AGENTS(["~/.agents/agents/"])
-    H_SHARED_SKILLS(["~/.agents/skills/"])
+    H_SHARED_SKILLS(["~/.agents/skills/ (real dir, shared pool)"])
   end
 
   subgraph CHEZMOI["chezmoi source state"]
@@ -36,11 +39,10 @@ flowchart LR
     subgraph ADAPTER["adapter templates"]
       A_CLAUDE["home/dot_claude/symlink_CLAUDE.md.tmpl"]
       A_CLAUDE_AGENTS["home/dot_claude/symlink_agents.tmpl"]
-      A_CLAUDE_SKILLS["home/dot_claude/symlink_skills.tmpl"]
 
       A_SHARED["home/exact_dot_agents/symlink_AGENTS.md.tmpl"]
       A_SHARED_AGENTS["home/exact_dot_agents/symlink_agents.tmpl"]
-      A_SHARED_SKILLS["home/exact_dot_agents/symlink_skills.tmpl"]
+      A_SHARED_SKILL["home/exact_dot_agents/skills/symlink_<name>.tmpl (one per skill)"]
     end
 
     subgraph CANONICAL["canonical source"]
@@ -49,29 +51,33 @@ flowchart LR
 
       S_SHARED["home/dot_config/exact_agents/AGENTS.md"]
       S_SHARED_AGENTS["home/dot_config/exact_agents/agents/"]
-      S_SHARED_SKILLS["home/dot_config/exact_agents/skills/"]
+      S_SHARED_SKILLS["home/dot_config/exact_agents/skills/<name>/"]
     end
+
+    RUNAFTER["home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl"]
   end
 
   U_CLAUDE --> H_CLAUDE
   U_CLAUDE --> H_CLAUDE_AGENTS
   U_CLAUDE --> H_CLAUDE_SKILLS
+  U_INSTALLER --> H_CLAUDE_SKILLS
   H_CLAUDE --> H_SHARED
   H_CLAUDE_AGENTS --> H_SHARED_AGENTS
 
   H_CLAUDE --> A_CLAUDE --> S_CLAUDE
   H_CLAUDE_AGENTS --> A_CLAUDE_AGENTS --> S_CLAUDE_AGENTS
-  H_CLAUDE_SKILLS --> A_CLAUDE_SKILLS --> S_SHARED_SKILLS
 
   H_SHARED --> A_SHARED --> S_SHARED
   H_SHARED_AGENTS --> A_SHARED_AGENTS --> S_SHARED_AGENTS
-  H_SHARED_SKILLS --> A_SHARED_SKILLS --> S_SHARED_SKILLS
+  H_SHARED_SKILLS --> A_SHARED_SKILL --> S_SHARED_SKILLS
+
+  H_SHARED_SKILLS --> RUNAFTER --> H_CLAUDE_SKILLS
 
   classDef runtime fill:#f5f5f5,stroke:#444,color:#111;
   classDef agents fill:#eef7ee,stroke:#4f7a4f,color:#111;
   classDef claude fill:#eef4ff,stroke:#4a6fa5,color:#111;
 
-  class U_CLAUDE runtime;
-  class H_SHARED,H_SHARED_AGENTS,H_SHARED_SKILLS,A_SHARED,A_SHARED_AGENTS,A_SHARED_SKILLS,S_SHARED,S_SHARED_AGENTS,S_SHARED_SKILLS agents;
-  class H_CLAUDE,H_CLAUDE_AGENTS,H_CLAUDE_SKILLS,A_CLAUDE,A_CLAUDE_AGENTS,A_CLAUDE_SKILLS,S_CLAUDE,S_CLAUDE_AGENTS claude;
+  class U_CLAUDE,U_INSTALLER runtime;
+  class H_SHARED,H_SHARED_AGENTS,H_SHARED_SKILLS,A_SHARED,A_SHARED_AGENTS,A_SHARED_SKILL,S_SHARED,S_SHARED_AGENTS,S_SHARED_SKILLS,RUNAFTER agents;
+  class H_CLAUDE,H_CLAUDE_AGENTS,H_CLAUDE_SKILLS,A_CLAUDE,A_CLAUDE_AGENTS,S_CLAUDE,S_CLAUDE_AGENTS claude;
 ```

--- a/home/exact_dot_agents/README.md
+++ b/home/exact_dot_agents/README.md
@@ -1,5 +1,6 @@
 - This directory is applied as `~/.agents`.
 - Chezmoi maps it to the canonical source in [home/dot_config/exact_agents/](../dot_config/exact_agents/).
 - Chezmoi maps `~/.agents/agents` to shared agent instructions in [home/dot_config/exact_agents/agents/](../dot_config/exact_agents/agents/).
+- Chezmoi maps `~/.agents/skills`, the shared skills pool, to per-skill symlink templates in [skills/](skills/); each `symlink_<name>.tmpl` points at one skill directory under [home/dot_config/exact_agents/skills/](../dot_config/exact_agents/skills/).
 - The design keeps the home-facing path stable while the real files live in one git-friendly source tree.
 - Edit the canonical source, not this adapter directory.

--- a/home/exact_dot_agents/skills/symlink_ai-slop-checklist-ja.tmpl
+++ b/home/exact_dot_agents/skills/symlink_ai-slop-checklist-ja.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/ai-slop-checklist-ja

--- a/home/exact_dot_agents/skills/symlink_cgd-dev-identity.tmpl
+++ b/home/exact_dot_agents/skills/symlink_cgd-dev-identity.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/cgd-dev-identity

--- a/home/exact_dot_agents/skills/symlink_convert-to-transformers.tmpl
+++ b/home/exact_dot_agents/skills/symlink_convert-to-transformers.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/convert-to-transformers

--- a/home/exact_dot_agents/skills/symlink_gh-comment-attach-files.tmpl
+++ b/home/exact_dot_agents/skills/symlink_gh-comment-attach-files.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/gh-comment-attach-files

--- a/home/exact_dot_agents/skills/symlink_high-impact-journal-publishing.tmpl
+++ b/home/exact_dot_agents/skills/symlink_high-impact-journal-publishing.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/high-impact-journal-publishing

--- a/home/exact_dot_agents/skills/symlink_humanizer-ja.tmpl
+++ b/home/exact_dot_agents/skills/symlink_humanizer-ja.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/humanizer-ja

--- a/home/exact_dot_agents/skills/symlink_python-uv-workflow.tmpl
+++ b/home/exact_dot_agents/skills/symlink_python-uv-workflow.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/python-uv-workflow

--- a/home/exact_dot_agents/skills/symlink_setup-agent-docs.tmpl
+++ b/home/exact_dot_agents/skills/symlink_setup-agent-docs.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/setup-agent-docs

--- a/home/exact_dot_agents/skills/symlink_shdoc-shell-docs.tmpl
+++ b/home/exact_dot_agents/skills/symlink_shdoc-shell-docs.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shdoc-shell-docs

--- a/home/exact_dot_agents/symlink_skills.tmpl
+++ b/home/exact_dot_agents/symlink_skills.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -14,6 +14,10 @@ readonly AGENTS_README_PATH="./home/exact_dot_agents/README.md"
 readonly CLAUDE_README_PATH="./home/dot_claude/README.md"
 readonly CANONICAL_AGENTS_README_PATH="./home/dot_config/exact_agents/README.md"
 readonly CANONICAL_CLAUDE_README_PATH="./home/dot_config/claude/README.md"
+readonly SHARED_SKILLS_SYMLINK_DIR="./home/exact_dot_agents/skills"
+readonly CLAUDE_SKILLS_KEEP_PATH="./home/dot_claude/skills/.keep"
+readonly LINK_SHARED_SKILLS_SCRIPT="./home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl"
+readonly GITIGNORE_PATH="./.gitignore"
 
 @test "[common] codex guidance entrypoints are removed" {
     [ -f "${SHARED_AGENTS_PATH}" ]
@@ -275,4 +279,43 @@ readonly CANONICAL_CLAUDE_README_PATH="./home/dot_config/claude/README.md"
     [ "${status}" -eq 0 ]
     run grep -Fx ".config/agents" "${CHEZMOIIGNORE_PATH}"
     [ "${status}" -eq 0 ]
+}
+
+@test "[common] shared skills pool exposes repo-managed skills through per-skill symlink templates" {
+    [ ! -e "./home/exact_dot_agents/symlink_skills.tmpl" ]
+    [ ! -e "./home/dot_claude/symlink_skills.tmpl" ]
+    [ -d "${SHARED_SKILLS_SYMLINK_DIR}" ]
+
+    [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_humanizer-ja.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/humanizer-ja" ]
+    [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_setup-agent-docs.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/setup-agent-docs" ]
+    [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_shdoc-shell-docs.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shdoc-shell-docs" ]
+}
+
+@test "[common] Claude skills directory is a real, installer-writable directory" {
+    [ -f "${CLAUDE_SKILLS_KEEP_PATH}" ]
+    [ ! -s "${CLAUDE_SKILLS_KEEP_PATH}" ]
+}
+
+@test "[common] run_after script subscribes tool skills directories to the shared pool" {
+    [ -f "${LINK_SHARED_SKILLS_SCRIPT}" ]
+
+    run grep -F 'POOL="${HOME}/.agents/skills"' "${LINK_SHARED_SKILLS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    run grep -F '"${HOME}/.claude/skills"' "${LINK_SHARED_SKILLS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+    run grep -F '{{ if ne (env "CI") "true" -}}' "${LINK_SHARED_SKILLS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    # Never clobber a real, installer-written entry with a pool symlink.
+    run grep -F 'if [ -e "${target}" ] && [ ! -L "${target}" ]; then' "${LINK_SHARED_SKILLS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    # Prune dangling pool symlinks whose pool entry has been removed.
+    run grep -F 'if [ ! -e "${link_target}" ]; then' "${LINK_SHARED_SKILLS_SCRIPT}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] gitignore no longer allowlists repo-managed skills" {
+    run grep -F "exact_agents/skills" "${GITIGNORE_PATH}"
+    [ "${status}" -eq 1 ]
 }


### PR DESCRIPTION
## Summary

Per-agent skill installs were meaningless when every tool (`~/.claude/skills`, `~/.agents/skills`) symlinked as a whole directory to the same chezmoi-managed source tree. That also meant global skill installers (e.g. `npx skills add --agent claude-code`) wrote generated skills directly into the chezmoi source tree, which required a `.gitignore` allowlist to keep non-repo-managed skills out of version control.

This PR replaces that single shared symlink with a "pool + per-tool subscription" layout:

- `~/.agents/skills` becomes a real directory: the shared pool. Every repo-managed skill is exposed there through its own per-skill symlink template.
- `~/.claude/skills` becomes a real, Claude-only directory. Skill installers can write generated skills there directly without touching the chezmoi source tree.
- A `run_after` chezmoi script links every pool entry into each tool's skills directory on every `chezmoi apply`, without overwriting any real (installer-written) entry, and prunes dangling pool symlinks when a skill is removed from the pool.
- The `.gitignore` skills ignore + allowlist mechanism is retired; repo-managed skills are simply the ones with a symlink template.

## Changes

| Area | Change |
| --- | --- |
| `home/exact_dot_agents/symlink_skills.tmpl`, `home/dot_claude/symlink_skills.tmpl` | Deleted (the old single shared-directory symlinks) |
| `home/exact_dot_agents/skills/symlink_<name>.tmpl` | Added: one per repo-managed skill, each pointing at `home/dot_config/exact_agents/skills/<name>` |
| `home/dot_claude/skills/.keep` | Added so chezmoi creates `~/.claude/skills` as a real, unmanaged directory |
| `home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl` | Added: subscribes `~/.claude/skills` to the `~/.agents/skills` pool on every apply, CI-gated, never clobbers real entries |
| `.gitignore` | Removed the `home/dot_config/exact_agents/skills/*` ignore block and its allowlist |
| `AGENTS.md`, `home/dot_config/exact_agents/README.md`, `home/exact_dot_agents/README.md`, `home/dot_claude/README.md`, `home/dot_config/claude/README.md` | Updated prose and mermaid diagram to describe the pool + subscription model |
| `tests/install/common/agents_guidance.bats` | Added assertions for the new symlink templates, the `.keep` marker, the run_after script's never-clobber/prune logic, and the retired gitignore allowlist |

`home/dot_gemini/config/symlink_skills.tmpl` (Gemini CLI) was left untouched: it points directly at the canonical `home/dot_config/exact_agents/skills` source directory, not at the retired shared symlink, so it keeps working unchanged.

## Migration note

On existing machines, the next `chezmoi apply` replaces the two old shared-directory symlinks (`~/.agents/skills`, `~/.claude/skills`) with the new real directories described above. The private dotfiles repo has its own skills that currently rely on the old shared-directory symlink; a follow-up PR there will switch its skills to the pool symlink-template pattern.

## Validation

Rendered the modified chezmoi source tree against a scratch destination to confirm the per-skill symlinks and the Claude skills directory resolve correctly.

```shell
chezmoi apply --dry-run -v --force --source home --destination <scratch-dir>
```

Confirmed the `run_after` script's CI gate strips its executable body when `CI=true`, leaving only the header comment.

```shell
CI=true chezmoi apply --dry-run -v --force --source home --destination <scratch-dir>
```

Ran shellcheck against the rendered (template-tag-stripped) script body with no warnings.

```shell
shellcheck -s bash <rendered-run_after-script>
```

`bats` tests were not run locally per repository policy; CI will run `tests/install/common/agents_guidance.bats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
