### PR TITLE
feat(claude): disable claude.ai connectors

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -1,6 +1,7 @@
 {
   "model": "opusplan",
   "alwaysThinkingEnabled": true,
+  "disableClaudeAiConnectors": true,
   "env": {
     "DISABLE_AUTOUPDATER": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
## Summary

MCP connectors hosted on claude.ai (Google Drive, Slack, etc.) consume context and are unwanted in default sessions; MCP usage should instead be opt-in via a dedicated launcher.

## Changes

| File                                   | Change                                  |
| -------------------------------------- | --------------------------------------- |
| `home/dot_config/claude/settings.json` | Add `"disableClaudeAiConnectors": true` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
