### PR TITLE
fix(claude): default to bypass permission mode

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -11,6 +11,7 @@
   },
   "plansDirectory": "./.agents/worklog/claude",
   "permissions": {
+    "defaultMode": "bypassPermissions",
     "deny": [
       "Bash(sudo:*)",
       "Bash(rm -rf:*)",
@@ -18,8 +19,7 @@
       "Read(id_rsa*)",
       "Read(id_ed25519*)",
       "Edit(.env*)"
-    ],
-    "defaultMode": "plan"
+    ]
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Summary
- Change Claude Code's global `permissions.defaultMode` from `"plan"` to `"bypassPermissions"`.
- Make `claudex-gw` launches start in bypass mode by default instead of plan mode.

## Tests
- `jq -e '.permissions.defaultMode == "bypassPermissions"' home/dot_config/claude/settings.json`
- `jq -e . home/dot_config/claude/settings.json >/dev/null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
