### PR TITLE
fix(claude): allow explicit bypass permission mode

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -6,8 +6,7 @@
     "DISABLE_AUTOUPDATER": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_ALWAYS_ENABLE_EFFORT": "1",
-    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "3",
-    "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1"
+    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "3"
   },
   "plansDirectory": "./.agents/worklog/claude",
   "permissions": {


### PR DESCRIPTION
## Summary
- Remove `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` from the global Claude Code environment settings.
- Keep `permissions.defaultMode` as `"plan"`, so normal sessions still start in plan mode.
- Restore explicitly requested bypass launches such as `claude --dangerously-skip-permissions` and `claudex-gw --dangerously-skip-permissions` from being forced back to the default permission mode by the scrub hardening gate.

## Rationale
The reported issue was not that `claudex-gw` dropped permission flags. The wrapper forwards user arguments through to `claude`.

Local investigation found Claude Code diagnostics indicating that `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` can force permission mode back to default and advises opting out with `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0` when bypass mode is needed. A manual check also showed that starting `claudex-gw` while excluding the user settings source makes the bypass launch path work, which points back to the user-level environment setting.

This PR avoids changing the default permission mode to bypass. It only removes the global environment override so explicitly requested bypass mode can work as intended.

## Tests
- `jq -e '(.env | has("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB") | not) and .permissions.defaultMode == "plan"' home/dot_config/claude/settings.json`
- `jq -e . home/dot_config/claude/settings.json >/dev/null`
- Manual: `claudex-gw --setting-sources local --dangerously-skip-permissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
