### PR TITLE
Guard skill installer apply

### DIFF
--- a/home/dot_config/exact_agents/README.md
+++ b/home/dot_config/exact_agents/README.md
@@ -12,8 +12,6 @@ In chezmoi, `dot_` changes a target name to start with `.`, while `exact_` remov
 
 To make an installer-added skill repo-managed, move its directory into `home/dot_config/exact_agents/skills/` and add a matching `home/exact_dot_agents/skills/symlink_<name>.tmpl`; the next `chezmoi apply` then relinks it as a shared pool entry.
 
-Installer-managed skills should stay in their tool-specific skills directories unless they are intentionally reviewed and promoted to the shared pool with that directory-plus-template pair.
-
 The diagram below describes this repository's source-of-truth layout, not the meaning of chezmoi's `exact_` attribute itself.
 
 ## Layout Overview

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -27,6 +27,9 @@ function activate_mise() {
 # @description Install upstream skills managed by tool-specific installers.
 #
 function install_skills() {
+    [ ! -e "${HOME}/.claude/skills/skill-creator" ] || return 0
+    [ -x "${MISE_BIN}" ] || return 0
+
     "${MISE_BIN}" exec npm:skills -- skills add anthropics/skills \
         --skill skill-creator \
         --agent claude-code \

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -53,6 +53,23 @@ EOF
     [ "${output}" = "exec npm:skills -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
 }
 
+@test "[common] install_skills skips when mise is unavailable" {
+    install_skills
+
+    [ ! -e "${BATS_TEST_TMPDIR}/mise_args.txt" ]
+}
+
+@test "[common] install_skills keeps an existing local skill" {
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    export MISE_CALLS_PATH
+    write_mise_logger
+    mkdir -p "${HOME}/.claude/skills/skill-creator"
+
+    install_skills
+
+    [ ! -e "${BATS_TEST_TMPDIR}/mise_args.txt" ]
+}
+
 @test "[common] skills script runs full installation workflow" {
     mkdir -p "${BATS_TEST_TMPDIR}/bin"
 


### PR DESCRIPTION
## Why

PR #558 changed shared skill installation, but late review found that the installer could still invoke `mise` when it was unavailable and could overwrite an existing local Claude skill installation.

## What Changed

- Skip `install_skills()` when `~/.claude/skills/skill-creator` already exists.
- Skip `install_skills()` when `MISE_BIN` is not executable.
- Add bats coverage for the missing-`mise` and existing-local-skill skip cases.
- Remove the extra general installer-managed skill guidance from `home/dot_config/exact_agents/README.md`.

## Validation

Check the updated shell script syntax.

```shell
bash -n install/common/skills.sh
```

Inspect the current diff for whitespace errors.

```shell
git diff --check
```

Run ShellCheck on the updated installer script.

```shell
shellcheck install/common/skills.sh
```

Local bats was not run per repository policy; bats validation is left to GitHub Actions CI.
