### PR TITLE
fix(skills): allow installer reruns

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -27,9 +27,6 @@ function activate_mise() {
 # @description Install upstream skills managed by tool-specific installers.
 #
 function install_skills() {
-    [ ! -e "${HOME}/.claude/skills/skill-creator" ] || return 0
-    [ -x "${MISE_BIN}" ] || return 0
-
     "${MISE_BIN}" exec npm:skills -- skills add anthropics/skills \
         --skill skill-creator \
         --agent claude-code \

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -53,23 +53,6 @@ EOF
     [ "${output}" = "exec npm:skills -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
 }
 
-@test "[common] install_skills skips when mise is unavailable" {
-    install_skills
-
-    [ ! -e "${BATS_TEST_TMPDIR}/mise_args.txt" ]
-}
-
-@test "[common] install_skills keeps an existing local skill" {
-    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
-    export MISE_CALLS_PATH
-    write_mise_logger
-    mkdir -p "${HOME}/.claude/skills/skill-creator"
-
-    install_skills
-
-    [ ! -e "${BATS_TEST_TMPDIR}/mise_args.txt" ]
-}
-
 @test "[common] skills script runs full installation workflow" {
     mkdir -p "${BATS_TEST_TMPDIR}/bin"
 


### PR DESCRIPTION
## Why

PR #559 added guards that skipped the skills installer when `~/.claude/skills/skill-creator` already exists or when `mise` is unavailable. The installer should rerun because reinstalling the skill is acceptable, so the skip guards are unnecessary.

## What Changed

- Removed the existing local skill guard from `install_skills()`.
- Removed the executable `mise` guard from `install_skills()`.
- Removed the skip-behavior tests that covered those guards.

## Validation

Check the shell syntax for the updated installer script.

```shell
bash -n install/common/skills.sh
```

Inspect the diff for whitespace and conflict marker issues.

```shell
git diff --check
```

Check the updated shell script with ShellCheck.

```shell
shellcheck install/common/skills.sh
```

Bats was not run locally per repository policy.
