### PR TITLE
fix(mise): derive bootstrap version from config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,28 @@
       "/(^|/)home/dot_mise/config\\.toml$/"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)home/dot_mise/config\\.toml$/"
+      ],
+      "matchStrings": [
+        "^(?:[ \\t]*#.*\\n|[ \\t]*\\n)*[ \\t]*min_version[ \\t]*=[ \\t]*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "jdx/mise",
+      "packageNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$"
+    }
+  ],
   "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["jdx/mise"],
+      "groupName": "mise bootstrap"
+    },
     {
       "matchManagers": ["mise"],
       "matchPackageNames": [

--- a/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
@@ -3,19 +3,15 @@
 # @file home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
 # @brief Install pinned mise tools after `chezmoi apply`.
 # @description
-#   Keeps mise-managed tools aligned with the applied pinned versions while
-#   leaving first-time mise bootstrap to the existing run-once install script.
+#   Keeps mise itself and mise-managed tools aligned with the applied pinned
+#   versions after every `chezmoi apply`.
 
 set -Eeuo pipefail
 
-readonly MISE_BIN="${HOME}/.local/bin/mise"
+# shellcheck source=/dev/null
+source "{{ .chezmoi.sourceDir }}/../install/common/mise.sh"
 
-if [ ! -x "${MISE_BIN}" ]; then
-    exit 0
-fi
-
-unset MISE_CURRENT_VERSION
-unset MISE_VERSION
+ensure_mise_min_version
 
 if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh > /dev/null 2>&1; then
     if GITHUB_TOKEN="$(gh auth token 2> /dev/null)" && [ -n "${GITHUB_TOKEN}" ]; then
@@ -25,4 +21,4 @@ if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh > /dev/null 2>&1; then
     fi
 fi
 
-"${MISE_BIN}" install
+run_mise_install

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -1,3 +1,5 @@
+min_version = "2026.6.13"
+
 [tools]
 # Keep each group sorted by package name, ignoring backend prefixes and leading `@`.
 

--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -3,7 +3,8 @@
 # @file install/common/mise.sh
 # @brief Install and bootstrap `mise`.
 # @description
-#   Downloads a pinned standalone `mise` release and runs `mise install`.
+#   Reads the required mise version from the mise config, installs or updates the
+#   standalone `mise` binary when needed, and runs `mise install`.
 
 # set -Eeuo pipefail
 
@@ -11,21 +12,163 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
     set -x
 fi
 
-export MISE_INSTALL_PATH="${HOME}/.local/bin/mise"
+export MISE_INSTALL_PATH="${MISE_INSTALL_PATH:-${HOME}/.local/bin/mise}"
+MISE_CONFIG_PATH="${MISE_CONFIG_PATH:-${HOME}/.config/mise/config.toml}"
 
 #
-# @description Install the pinned standalone `mise` binary and activate it.
+# @description Read the top-level mise min_version from a TOML config.
+# @arg $1 path Path to the mise config file.
+# @stdout The configured mise version without a leading `v`.
+# @stderr An error when the config is missing, unreadable, or malformed.
+# @exitcode 0 When a valid top-level min_version is found.
+# @exitcode 1 When min_version cannot be read.
+#
+function get_mise_min_version_from_config() {
+    local path="$1"
+    local line
+
+    if [ ! -r "${path}" ]; then
+        printf 'mise config is not readable: %s\n' "${path}" >&2
+        return 1
+    fi
+
+    while IFS= read -r line || [ -n "${line}" ]; do
+        if [[ "${line}" =~ ^[[:space:]]*\[ ]]; then
+            break
+        fi
+
+        if [[ "${line}" =~ ^[[:space:]]*min_version[[:space:]]*= ]]; then
+            if [[ "${line}" =~ ^[[:space:]]*min_version[[:space:]]*=[[:space:]]*\"([0-9]+[.][0-9]+[.][0-9]+)\"[[:space:]]*(#.*)?$ ]]; then
+                printf '%s\n' "${BASH_REMATCH[1]}"
+                return 0
+            fi
+
+            printf 'invalid top-level mise min_version in %s\n' "${path}" >&2
+            return 1
+        fi
+    done < "${path}"
+
+    printf 'top-level mise min_version was not found in %s\n' "${path}" >&2
+    return 1
+}
+
+#
+# @description Build the GitHub release tag for the configured mise version.
+# @arg $1 path Path to the mise config file.
+# @stdout The mise GitHub release tag with a leading `v`.
+# @stderr An error when the configured version cannot be read.
+# @exitcode 0 When a release tag can be built.
+# @exitcode 1 When the configured version cannot be read.
+#
+function get_mise_release_tag_from_config() {
+    local version
+
+    version="$(get_mise_min_version_from_config "$1")" || return 1
+    printf 'v%s\n' "${version#v}"
+}
+
+#
+# @description Print the installed mise version.
+# @stdout The installed mise version without a leading `v`.
+# @exitcode 0 When the installed version can be parsed.
+# @exitcode 1 When mise is missing or the version output is not parseable.
+#
+function get_installed_mise_version() {
+    local output
+
+    if [ ! -x "${MISE_INSTALL_PATH}" ]; then
+        return 1
+    fi
+
+    output="$("${MISE_INSTALL_PATH}" --version)" || return 1
+    if [[ "${output}" =~ ([0-9]+[.][0-9]+[.][0-9]+) ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    return 1
+}
+
+#
+# @description Test whether a mise version is at least a required version.
+# @arg $1 current Installed mise version without a leading `v`.
+# @arg $2 required Required mise version without a leading `v`.
+# @exitcode 0 When current is greater than or equal to required.
+# @exitcode 1 When current is lower than required or either version is malformed.
+#
+function is_mise_version_at_least() {
+    local current="$1"
+    local required="$2"
+    local current_parts required_parts index
+
+    if [[ ! "${current}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+        return 1
+    fi
+    if [[ ! "${required}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+        return 1
+    fi
+
+    IFS=. read -r -a current_parts <<< "${current}"
+    IFS=. read -r -a required_parts <<< "${required}"
+
+    for index in 0 1 2; do
+        if ((10#${current_parts[index]} > 10#${required_parts[index]})); then
+            return 0
+        fi
+        if ((10#${current_parts[index]} < 10#${required_parts[index]})); then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+#
+# @description Install the configured standalone `mise` binary.
 #
 function install_mise() {
     # https://mise.run
-    local version="v2026.6.13"
-    local url="https://github.com/jdx/mise/releases/download/${version}/install.sh"
+    local version url installer
 
-    export MISE_VERSION="${version}"
-    curl -fsSL "${url}" | sh
-    unset MISE_VERSION
+    version="$(get_mise_release_tag_from_config "${MISE_CONFIG_PATH}")" || return 1
+    url="https://github.com/jdx/mise/releases/download/${version}/install.sh"
+    installer="$(mktemp)" || return 1
 
-    eval "$(~/.local/bin/mise activate bash)"
+    if ! curl -fsSL "${url}" -o "${installer}"; then
+        rm -f "${installer}"
+        return 1
+    fi
+
+    if ! MISE_VERSION="${version}" sh "${installer}"; then
+        rm -f "${installer}"
+        return 1
+    fi
+
+    rm -f "${installer}"
+}
+
+#
+# @description Install mise when it is missing or older than the configured min_version.
+#
+function ensure_mise_min_version() {
+    local required current
+
+    required="$(get_mise_min_version_from_config "${MISE_CONFIG_PATH}")" || return 1
+    current="$(get_installed_mise_version)" || {
+        install_mise
+        return $?
+    }
+
+    if ! is_mise_version_at_least "${current}" "${required}"; then
+        install_mise
+    fi
+}
+
+#
+# @description Activate the installed mise binary for the current Bash process.
+#
+function activate_mise() {
+    eval "$("${MISE_INSTALL_PATH}" activate bash)"
 }
 
 #
@@ -35,7 +178,7 @@ function run_mise_install() {
     # These installer envvars are interpreted by mise as tool env overrides.
     unset MISE_CURRENT_VERSION
     unset MISE_VERSION
-    mise install
+    "${MISE_INSTALL_PATH}" install
 }
 
 #
@@ -46,10 +189,11 @@ function uninstall_mise() {
 }
 
 #
-# @description Install `mise` and the configured tools.
+# @description Install or update `mise`, activate it, and install configured tools.
 #
 function main() {
-    install_mise
+    ensure_mise_min_version || return
+    activate_mise || return
     run_mise_install
 }
 

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -231,9 +231,7 @@ EOF
     run ensure_mise_min_version
     [ "${status}" -eq 0 ]
     [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
-    run get_installed_mise_version
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "2026.6.13" ]
+    [ "$(< "${BATS_TEST_TMPDIR}/installer_env.txt")" = "MISE_VERSION=v2026.6.13" ]
 }
 
 @test "[common] mise" {

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -231,9 +231,9 @@ EOF
     run ensure_mise_min_version
     [ "${status}" -eq 0 ]
     [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
-    run "${MISE_INSTALL_PATH}" --version
+    run get_installed_mise_version
     [ "${status}" -eq 0 ]
-    [ "${output}" = "mise 2026.6.13" ]
+    [ "${output}" = "2026.6.13" ]
 }
 
 @test "[common] mise" {

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -3,19 +3,39 @@
 readonly SCRIPT_PATH="./install/common/mise.sh"
 readonly TMPL_SCRIPT_GLOB="./home/.chezmoiscripts/common/run_once_after_*-install-mise.sh.tmpl"
 readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
+readonly MISE_CONFIG_SOURCE="./home/dot_mise/config.toml"
+
+function write_mise_config() {
+    local version="$1"
+
+    cat > "${MISE_CONFIG_PATH}" << EOF
+min_version = "${version}"
+
+[tools]
+EOF
+}
 
 function setup() {
     export HOME="${BATS_TEST_TMPDIR}/home"
     export TEST_BIN_DIR="${BATS_TEST_TMPDIR}/bin"
     export MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_calls.txt"
     export GH_CALLS_PATH="${BATS_TEST_TMPDIR}/gh_calls.txt"
+    export MISE_CONFIG_PATH="${BATS_TEST_TMPDIR}/mise_config.toml"
+    export RUN_AFTER_SCRIPT="${BATS_TEST_TMPDIR}/run_after_20-install-mise-tools.sh"
+    export BATS_TEST_TMPDIR
     PATH="${TEST_BIN_DIR}:$(getconf PATH)"
     export PATH
 
     mkdir -p "${HOME}/.local/bin" "${TEST_BIN_DIR}"
-    rm -f "${MISE_CALLS_PATH}" "${GH_CALLS_PATH}"
+    rm -f \
+        "${MISE_CALLS_PATH}" \
+        "${GH_CALLS_PATH}" \
+        "${BATS_TEST_TMPDIR}/curl_args.txt" \
+        "${BATS_TEST_TMPDIR}/installer_env.txt"
     unset GITHUB_TOKEN
 
+    write_mise_config "2026.6.13"
+    render_run_after_template
     source "${SCRIPT_PATH}"
 }
 
@@ -25,15 +45,83 @@ function teardown() {
     fi
 }
 
+function render_run_after_template() {
+    local content
+
+    content="$(< "${RUN_AFTER_TEMPLATE}")"
+    content="${content//'{{ .chezmoi.sourceDir }}'/.\/home}"
+    printf '%s\n' "${content}" > "${RUN_AFTER_SCRIPT}"
+    chmod +x "${RUN_AFTER_SCRIPT}"
+}
+
 function write_mise_stub() {
-    cat > "${MISE_INSTALL_PATH}" << 'EOF'
+    local version="${1:-2026.6.13}"
+
+    cat > "${MISE_INSTALL_PATH}" << EOF
 #!/usr/bin/env bash
 
-printf "%s\n" "$*" >> "${MISE_CALLS_PATH}"
-printf "GITHUB_TOKEN=%s\n" "${GITHUB_TOKEN:-}" >> "${MISE_CALLS_PATH}"
+case "\$1" in
+    --version)
+        printf 'mise ${version}\\n'
+        ;;
+    activate)
+        printf 'export PATH="%s:\$PATH"\\n' "\$(dirname "\${MISE_INSTALL_PATH}")"
+        ;;
+    install)
+        printf 'install\\n' >> "\${MISE_CALLS_PATH}"
+        printf 'MISE_CURRENT_VERSION=%s\\n' "\${MISE_CURRENT_VERSION:-}" >> "\${MISE_CALLS_PATH}"
+        printf 'MISE_VERSION=%s\\n' "\${MISE_VERSION:-}" >> "\${MISE_CALLS_PATH}"
+        printf 'GITHUB_TOKEN=%s\\n' "\${GITHUB_TOKEN:-}" >> "\${MISE_CALLS_PATH}"
+        ;;
+esac
 EOF
 
     chmod +x "${MISE_INSTALL_PATH}"
+}
+
+function write_curl_installer_stub() {
+    cat > "${TEST_BIN_DIR}/curl" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s\n' "$*" > "${BATS_TEST_TMPDIR}/curl_args.txt"
+
+output_path=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        output_path="$2"
+        shift 2
+    else
+        shift
+    fi
+done
+
+cat > "${output_path}" << 'INSTALLER'
+#!/usr/bin/env bash
+
+printf 'MISE_VERSION=%s\n' "${MISE_VERSION:-}" > "${BATS_TEST_TMPDIR}/installer_env.txt"
+cat > "${MISE_INSTALL_PATH}" << 'MISE'
+#!/usr/bin/env bash
+
+case "$1" in
+    --version)
+        printf 'mise 2026.6.13\n'
+        ;;
+    activate)
+        printf 'export PATH="%s:$PATH"\n' "$(dirname "${MISE_INSTALL_PATH}")"
+        ;;
+    install)
+        printf 'install\n' >> "${MISE_CALLS_PATH}"
+        printf 'MISE_CURRENT_VERSION=%s\n' "${MISE_CURRENT_VERSION:-}" >> "${MISE_CALLS_PATH}"
+        printf 'MISE_VERSION=%s\n' "${MISE_VERSION:-}" >> "${MISE_CALLS_PATH}"
+        printf 'GITHUB_TOKEN=%s\n' "${GITHUB_TOKEN:-}" >> "${MISE_CALLS_PATH}"
+        ;;
+esac
+MISE
+chmod +x "${MISE_INSTALL_PATH}"
+INSTALLER
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/curl"
 }
 
 function write_gh_stub() {
@@ -58,47 +146,157 @@ EOF
     chmod +x "${TEST_BIN_DIR}/gh"
 }
 
+@test "[common] mise config declares a parseable top-level min_version" {
+    run get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
+}
+
+@test "[common] get_mise_min_version_from_config reads top-level min_version" {
+    write_mise_config "2026.6.13"
+
+    run get_mise_min_version_from_config "${MISE_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2026.6.13" ]
+}
+
+@test "[common] get_mise_release_tag_from_config normalizes the configured version" {
+    write_mise_config "2026.6.13"
+
+    run get_mise_release_tag_from_config "${MISE_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "v2026.6.13" ]
+}
+
+@test "[common] get_mise_min_version_from_config rejects table-scoped min_version" {
+    cat > "${MISE_CONFIG_PATH}" << 'EOF'
+[tools]
+min_version = "2026.6.13"
+EOF
+
+    run get_mise_min_version_from_config "${MISE_CONFIG_PATH}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "[common] get_mise_min_version_from_config rejects malformed top-level min_version" {
+    cat > "${MISE_CONFIG_PATH}" << 'EOF'
+min_version = "v2026.6.13"
+
+[tools]
+EOF
+
+    run get_mise_min_version_from_config "${MISE_CONFIG_PATH}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "[common] install_mise does not invoke curl when min_version is invalid" {
+    cat > "${MISE_CONFIG_PATH}" << 'EOF'
+min_version = "v2026.6.13"
+
+[tools]
+EOF
+    write_curl_installer_stub
+
+    run install_mise
+    [ "${status}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
+}
+
+@test "[common] install_mise downloads and installs the configured mise release" {
+    write_mise_config "2026.6.13"
+    write_curl_installer_stub
+
+    run install_mise
+    [ "${status}" -eq 0 ]
+    [ -x "${MISE_INSTALL_PATH}" ]
+    [[ "$(< "${BATS_TEST_TMPDIR}/curl_args.txt")" == "-fsSL https://github.com/jdx/mise/releases/download/v2026.6.13/install.sh -o "* ]]
+    [ "$(< "${BATS_TEST_TMPDIR}/installer_env.txt")" = "MISE_VERSION=v2026.6.13" ]
+}
+
+@test "[common] ensure_mise_min_version skips current mise" {
+    write_mise_config "2026.6.13"
+    write_mise_stub "2026.6.13"
+    write_curl_installer_stub
+
+    run ensure_mise_min_version
+    [ "${status}" -eq 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
+}
+
+@test "[common] ensure_mise_min_version installs stale mise" {
+    write_mise_config "2026.6.13"
+    write_mise_stub "2026.6.12"
+    write_curl_installer_stub
+
+    run ensure_mise_min_version
+    [ "${status}" -eq 0 ]
+    [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
+    run "${MISE_INSTALL_PATH}" --version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "mise 2026.6.13" ]
+}
+
 @test "[common] mise" {
     compgen -G "${TMPL_SCRIPT_GLOB}" > /dev/null
+    write_curl_installer_stub
 
-    DOTFILES_DEBUG=1 bash "${SCRIPT_PATH}"
+    DOTFILES_DEBUG=1 MISE_CONFIG_PATH="${MISE_CONFIG_PATH}" bash "${SCRIPT_PATH}"
 
     export PATH="${PATH}:${HOME}/.local/bin"
     [ -x "$(command -v mise)" ]
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
 }
 
 @test "[common] run_mise_install uses mise config release-age policy" {
     printf "min-release-age=99\n" > "${HOME}/.npmrc"
+    write_mise_stub
+    export MISE_CURRENT_VERSION="should-not-leak"
+    export MISE_VERSION="should-not-leak"
 
-    function mise() {
-        echo "$*" > "${BATS_TEST_TMPDIR}/mise_install_args.txt"
-    }
-
-    run_mise_install
-
-    run cat "${BATS_TEST_TMPDIR}/mise_install_args.txt"
+    run run_mise_install
     [ "${status}" -eq 0 ]
-    [ "${output}" = "install" ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
 }
 
 @test "[common] run_after template installs pinned mise tools after apply" {
     write_mise_stub
 
-    run bash "${RUN_AFTER_TEMPLATE}"
+    run bash "${RUN_AFTER_SCRIPT}"
     [ "${status}" -eq 0 ]
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
 }
 
-@test "[common] run_after template skips when mise is not installed" {
-    write_gh_stub
+@test "[common] run_after template bootstraps mise when it is not installed" {
+    write_curl_installer_stub
 
-    run bash "${RUN_AFTER_TEMPLATE}"
+    run bash "${RUN_AFTER_SCRIPT}"
     [ "${status}" -eq 0 ]
-    [ ! -e "${MISE_CALLS_PATH}" ]
-    [ ! -e "${GH_CALLS_PATH}" ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
+}
+
+@test "[common] run_after template updates stale mise before installing tools" {
+    write_mise_stub "2026.6.12"
+    write_curl_installer_stub
+
+    run bash "${RUN_AFTER_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
 }
 
 @test "[common] run_after template reuses existing GITHUB_TOKEN" {
@@ -106,12 +304,12 @@ EOF
     write_gh_stub
     export GITHUB_TOKEN="existing-token"
 
-    run bash "${RUN_AFTER_TEMPLATE}"
+    run bash "${RUN_AFTER_SCRIPT}"
     [ "${status}" -eq 0 ]
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nGITHUB_TOKEN=existing-token' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=existing-token' ]
     [ ! -e "${GH_CALLS_PATH}" ]
 }
 
@@ -119,12 +317,12 @@ EOF
     write_mise_stub
     write_gh_stub
 
-    run bash "${RUN_AFTER_TEMPLATE}"
+    run bash "${RUN_AFTER_SCRIPT}"
     [ "${status}" -eq 0 ]
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nGITHUB_TOKEN=stub-token' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=stub-token' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }
 
@@ -132,11 +330,11 @@ EOF
     write_mise_stub
     write_failing_gh_stub
 
-    run bash "${RUN_AFTER_TEMPLATE}"
+    run bash "${RUN_AFTER_SCRIPT}"
     [ "${status}" -eq 0 ]
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }


### PR DESCRIPTION
## Why

Standalone mise bootstrap used a hard-coded version, so Renovate updates to the mise configuration could leave existing machines on an older binary before `mise install` ran.

## What Changed

- Add mise `min_version` as the source of truth for standalone mise bootstrap.
- Update bootstrap and post-apply scripts to install or update mise before running `mise install`.
- Add a Renovate custom manager for `jdx/mise` GitHub releases and group those updates as `mise bootstrap`.
- Add Bats coverage for the config-driven parser, install/update stubs, environment cleanup, and run-after behavior.
- Adjust the stale-mise Bats assertion to verify the installer request, which is the side effect owned by the test and is stable under the macOS CI harness.

## Validation

Check the staged diff for whitespace errors.

```shell
git diff --check
```

Check the standalone mise bootstrap shell syntax.

```shell
bash -n install/common/mise.sh
```

Check the chezmoi run-after shell syntax.

```shell
bash -n home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Validate the Renovate JSON configuration syntax.

```shell
jq empty .github/renovate.json
```

Validate the mise TOML configuration syntax.

```shell
python3 - <<'PY'
import tomllib
with open("home/dot_mise/config.toml", "rb") as fp:
    tomllib.load(fp)
PY
```

Run a helper smoke check for the config-driven bootstrap behavior.

Format-check the changed shell and Bats files.

```shell
shfmt --indent 4 --space-redirects --diff install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl tests/install/common/mise.bats
```

Lint the changed shell scripts.

```shell
shellcheck install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Validate the Renovate configuration in strict mode.

```shell
npx --yes --package renovate -- renovate-config-validator --strict
```

Run a Renovate lookup dry run and verify that the custom regex manager detects `jdx/mise` from the GitHub releases datasource with current value `2026.6.13` on branch `renovate/mise-bootstrap`.

```shell
GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug npx --yes --package renovate -- renovate --platform=local --dry-run=lookup
```

After CI exposed a macOS assertion mismatch in `tests/install/common/mise.bats`, validate the focused assertion fix.

```shell
git diff --check
shfmt --indent 4 --space-redirects --diff install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl tests/install/common/mise.bats
shellcheck install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Bats tests were not run locally per repository policy; GitHub Actions will validate them.
