### PR TITLE
chore(mise): add ruby runtime

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -7,6 +7,7 @@ min_version = "2026.6.13"
 go = "1.26.5"
 node = "lts"
 python = "3.14.6"
+ruby = "4.0.6"
 rust = "1.97.1"
 
 # CLI tools
@@ -54,6 +55,7 @@ sqlite = "3.53.3"
 [settings]
 idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"
+ruby.compile = false
 minimum_release_age_excludes = [
   "aqua:anthropics/claude-code",
   "aqua:google-antigravity/antigravity-cli",


### PR DESCRIPTION
## Summary

- Add Ruby 4.0.6 to the mise-managed language runtimes.
- Set `ruby.compile = false` in mise settings so Ruby installs use prebuilt packages when available.

## Validation

Check that only the mise config file was modified before commit.

```shell
git status --short --branch
```

Inspect the diff for whitespace issues.

```shell
git diff --check
```

Confirm the TOML parses and contains the expected Ruby tool and setting values.

```shell
python3 - <<'PY'
from pathlib import Path
import tomllib
path = Path('home/dot_mise/config.toml')
data = tomllib.loads(path.read_text())
assert data['tools']['ruby'] == '4.0.6'
assert data['settings']['ruby']['compile'] is False
print('TOML parse check passed')
PY
```

Confirm mise can resolve the requested Ruby version.

```shell
mise --no-config ls-remote ruby@4.0.6
```

`ruby.compile = false` was validated through the TOML parse check. An additional isolated `mise settings ruby.compile` check was not completed, so no user-global mise state was changed for that check.

Local `bats` was not run per repository instructions. A prior attempted run failed in existing run_after-template tests that render unchanged scripts sourcing `./home/../install/common/mise.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
