### PR TITLE
Enable mise shims in Bash startup

### DIFF
--- a/home/dot_config/exact_shell/mise.bash
+++ b/home/dot_config/exact_shell/mise.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# @file home/dot_config/exact_shell/mise.bash
+# @brief Activate mise shims for Bash startup files.
+# @description
+#   Makes the standalone mise binary and mise shims available in interactive
+#   non-login Bash sessions without duplicating PATH entries when this file is
+#   sourced more than once.
+
+_mise_local_bin="${HOME%/}/.local/bin"
+_mise_bin="${_mise_local_bin}/mise"
+_mise_shims="${HOME%/}/.local/share/mise/shims"
+
+if [ -x "${_mise_bin}" ]; then
+    case ":${PATH}:" in
+    *:"${_mise_local_bin}":*) ;;
+    *) export PATH="${_mise_local_bin}:${PATH}" ;;
+    esac
+
+    case ":${PATH}:" in
+    *:"${_mise_shims}":*) ;;
+    *) eval "$("${_mise_bin}" activate bash --shims)" ;;
+    esac
+fi
+
+unset _mise_bin _mise_local_bin _mise_shims

--- a/home/dot_profile
+++ b/home/dot_profile
@@ -1,3 +1,5 @@
-export PATH="$PATH:$HOME/.local/bin"
-eval "$(mise activate bash --shims)"
-
+# for mise shims
+# shellcheck source=dot_config/exact_shell/mise.bash
+if [ -f "${HOME%/}/.config/shell/mise.bash" ]; then
+    . "${HOME%/}/.config/shell/mise.bash"
+fi

--- a/home/exact_dot_bash/client/bashrc
+++ b/home/exact_dot_bash/client/bashrc
@@ -10,6 +10,12 @@ case $- in
 *) return ;;
 esac
 
+# for mise shims
+# shellcheck source=../../dot_config/exact_shell/mise.bash
+if [ -f "${HOME%/}/.config/shell/mise.bash" ]; then
+    source "${HOME%/}/.config/shell/mise.bash"
+fi
+
 # don't put duplicate lines or lines starting with space in the history.
 # See bash(1) for more options
 HISTCONTROL=ignoreboth

--- a/home/exact_dot_bash/server/bashrc
+++ b/home/exact_dot_bash/server/bashrc
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# for mise shims
+# shellcheck source=../../dot_config/exact_shell/mise.bash
+if [ -f "${HOME%/}/.config/shell/mise.bash" ]; then
+    source "${HOME%/}/.config/shell/mise.bash"
+fi
+
 if [ "$TERM" = "dumb" ]; then
     echo -n
 else

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -4,6 +4,7 @@ readonly SCRIPT_PATH="./install/common/mise.sh"
 readonly TMPL_SCRIPT_GLOB="./home/.chezmoiscripts/common/run_once_after_*-install-mise.sh.tmpl"
 readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
 readonly MISE_CONFIG_SOURCE="./home/dot_mise/config.toml"
+readonly MISE_BASH_SOURCE="./home/dot_config/exact_shell/mise.bash"
 
 function write_mise_config() {
     local version="$1"
@@ -46,10 +47,11 @@ function teardown() {
 }
 
 function render_run_after_template() {
-    local content
+    local content source_dir
 
+    source_dir="./home"
     content="$(< "${RUN_AFTER_TEMPLATE}")"
-    content="${content//'{{ .chezmoi.sourceDir }}'/.\/home}"
+    content="${content//'{{ .chezmoi.sourceDir }}'/${source_dir}}"
     printf '%s\n' "${content}" > "${RUN_AFTER_SCRIPT}"
     chmod +x "${RUN_AFTER_SCRIPT}"
 }
@@ -65,7 +67,11 @@ case "\$1" in
         printf 'mise ${version}\\n'
         ;;
     activate)
-        printf 'export PATH="%s:\$PATH"\\n' "\$(dirname "\${MISE_INSTALL_PATH}")"
+        if [ "\${2:-}" = "bash" ] && [ "\${3:-}" = "--shims" ]; then
+            printf 'export PATH="%s:\$PATH"\\n' "\${HOME}/.local/share/mise/shims"
+        else
+            printf 'export PATH="%s:\$PATH"\\n' "\$(dirname "\${MISE_INSTALL_PATH}")"
+        fi
         ;;
     install)
         printf 'install\\n' >> "\${MISE_CALLS_PATH}"
@@ -107,7 +113,11 @@ case "$1" in
         printf 'mise 2026.6.13\n'
         ;;
     activate)
-        printf 'export PATH="%s:$PATH"\n' "$(dirname "${MISE_INSTALL_PATH}")"
+        if [ "${2:-}" = "bash" ] && [ "${3:-}" = "--shims" ]; then
+            printf 'export PATH="%s:$PATH"\n' "${HOME}/.local/share/mise/shims"
+        else
+            printf 'export PATH="%s:$PATH"\n' "$(dirname "${MISE_INSTALL_PATH}")"
+        fi
         ;;
     install)
         printf 'install\n' >> "${MISE_CALLS_PATH}"
@@ -146,10 +156,65 @@ EOF
     chmod +x "${TEST_BIN_DIR}/gh"
 }
 
+function write_chezmoi_shim() {
+    local shims_dir="${HOME}/.local/share/mise/shims"
+
+    mkdir -p "${shims_dir}"
+    cat > "${shims_dir}/chezmoi" << 'EOF'
+#!/usr/bin/env bash
+
+printf 'chezmoi shim\n'
+EOF
+    chmod +x "${shims_dir}/chezmoi"
+}
+
+function run_mise_bash_startup() {
+    run env -u BASH_ENV -u BASH_XTRACEFD -u SHELLOPTS -u PS4 bash -c "$1"
+}
+
 @test "[common] mise config declares a parseable top-level min_version" {
     run get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}"
     [ "${status}" -eq 0 ]
     [[ "${output}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
+}
+
+@test "[common] mise bash startup exits cleanly when mise is absent" {
+    local expected_path="${PATH}"
+
+    run_mise_bash_startup 'source "'"${MISE_BASH_SOURCE}"'"; printf "%s\n" "${PATH}"'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "${expected_path}" ]
+}
+
+@test "[common] mise bash startup exposes mise and mise shims" {
+    write_mise_stub
+    write_chezmoi_shim
+
+    run_mise_bash_startup 'source "'"${MISE_BASH_SOURCE}"'"; command -v mise; command -v chezmoi'
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "${MISE_INSTALL_PATH}" ]
+    [ "${lines[1]}" = "${HOME}/.local/share/mise/shims/chezmoi" ]
+}
+
+@test "[common] mise bash startup avoids duplicate PATH entries" {
+    write_mise_stub
+    write_chezmoi_shim
+
+    run_mise_bash_startup '
+        count_path_entry() {
+            local entry="$1"
+
+            printf "%s" "${PATH}" | tr : "\n" | awk -v entry="${entry}" "\$0 == entry { count++ } END { print count + 0 }"
+        }
+
+        source "'"${MISE_BASH_SOURCE}"'"
+        source "'"${MISE_BASH_SOURCE}"'"
+        count_path_entry "${HOME}/.local/bin"
+        count_path_entry "${HOME}/.local/share/mise/shims"
+    '
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "1" ]
+    [ "${lines[1]}" = "1" ]
 }
 
 @test "[common] get_mise_min_version_from_config reads top-level min_version" {


### PR DESCRIPTION
## Why

Interactive non-login Bash sessions, such as `docker exec -it s.kitada /bin/bash`, do not read the login profile. That left `mise` shims such as `chezmoi` unavailable even though login shells configured them.

## What Changed

- Added a shared Bash startup helper that exposes `$HOME/.local/bin/mise` and `mise activate bash --shims` without duplicating PATH entries.
- Sourced the helper from the client and server Bash rc files as well as the login profile.
- Added Bats coverage for missing `mise`, shim exposure, and idempotent PATH behavior.
- Isolated the startup-helper Bats subprocesses from bashcov tracing environment variables so CI checks the login behavior rather than bashcov's injected shell startup state.

## Validation

Check formatting for the updated shell startup files and Bats test.

```shell
shfmt --indent 4 --space-redirects --diff home/dot_config/exact_shell/mise.bash home/dot_profile home/exact_dot_bash/client/bashrc home/exact_dot_bash/server/bashrc tests/install/common/mise.bats
```

Check Bash syntax for the updated shell startup files.

```shell
bash -n home/dot_config/exact_shell/mise.bash home/dot_profile home/exact_dot_bash/client/bashrc home/exact_dot_bash/server/bashrc
```

GitHub Actions runs the repository Bats validation for the PR.
