### PR TITLE
Accept CLIProxyAPI SSH environment variables

### DIFF
--- a/install/ubuntu/server/ssh_server.sh
+++ b/install/ubuntu/server/ssh_server.sh
@@ -13,6 +13,9 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 declare -r SSH_PORT="${DOTFILES_SERVER_SSH_PORT:-22}"
+declare -r SSHD_CONFIG_PATH="${DOTFILES_SSHD_CONFIG_PATH:-/etc/ssh/sshd_config}"
+declare -r SSH_SERVICE_COMMAND="${DOTFILES_SSH_SERVICE_COMMAND:-/usr/sbin/service}"
+declare -r SSH_SERVICE_NAME="${DOTFILES_SSH_SERVICE_NAME:-ssh}"
 
 #
 # @description Install the Ubuntu OpenSSH server package and its prerequisites.
@@ -25,23 +28,35 @@ function install_openssh_server() {
 }
 
 #
-# @description Merge proxy-related variables into `AcceptEnv` in `sshd_config`.
+# @description Merge proxy and CLIProxyAPI variables into `AcceptEnv` in `sshd_config`.
 #
 function configure_accept_env() {
-    local current add merged
+    local merged value
+    local -a add values
 
-    # Get existing AcceptEnv values (empty if not set)
-    current=$(grep '^AcceptEnv' /etc/ssh/sshd_config | sed 's/^AcceptEnv //')
+    add=(
+        HTTP_PROXY
+        HTTPS_PROXY
+        NO_PROXY
+        http_proxy
+        https_proxy
+        no_proxy
+        CLI_PROXY_API_CALLBACK_PORT
+        CLI_PROXY_API_PROXY_URL
+    )
+    values=()
 
-    # Variables to append
-    add="HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy"
+    while IFS= read -r value; do
+        if [ -n "${value}" ]; then
+            values+=("${value}")
+        fi
+    done < <(awk '/^[[:space:]]*AcceptEnv[[:space:]]/ { for (i = 2; i <= NF; i++) print $i }' "${SSHD_CONFIG_PATH}")
 
-    # Merge and remove duplicates
-    merged=$(echo "$current $add" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    values+=("${add[@]}")
+    merged=$(printf '%s\n' "${values[@]}" | awk 'NF && !seen[$0]++ { printf "%s%s", sep, $0; sep = " " }')
 
-    # Remove existing entries and keep a single AcceptEnv line
-    sudo sed -i '/^AcceptEnv/d' /etc/ssh/sshd_config
-    echo "AcceptEnv $merged" | sudo tee -a /etc/ssh/sshd_config
+    sudo sed -i '/^[[:space:]]*AcceptEnv[[:space:]]/d' "${SSHD_CONFIG_PATH}"
+    printf 'AcceptEnv %s\n' "${merged}" | sudo tee -a "${SSHD_CONFIG_PATH}" > /dev/null
 }
 
 #
@@ -51,27 +66,29 @@ function setup_sshd() {
     sudo mkdir -p /var/run/sshd
     mkdir -p ${HOME}/.ssh
 
-    sudo sed -i 's/^#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config &&
-        sudo sed -i "s/^#\?Port .*/Port ${SSH_PORT}/" /etc/ssh/sshd_config &&
-        sudo sed -i 's/^#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' /etc/ssh/sshd_config &&
-        sudo sed -i 's/^#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config &&
+    sudo sed -i 's/^#PermitRootLogin prohibit-password/PermitRootLogin yes/' "${SSHD_CONFIG_PATH}" &&
+        sudo sed -i "s/^#\?Port .*/Port ${SSH_PORT}/" "${SSHD_CONFIG_PATH}" &&
+        sudo sed -i 's/^#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' "${SSHD_CONFIG_PATH}" &&
+        sudo sed -i 's/^#PubkeyAuthentication yes/PubkeyAuthentication yes/' "${SSHD_CONFIG_PATH}" &&
         sudo sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
     configure_accept_env
 
-    # check the /etc/ssh/sshd_config
     sudo /usr/sbin/sshd -t
 
-    # create .ssh/authorized_keys if not exists
     touch ${HOME}/.ssh/authorized_keys
 }
 
 #
-# @description Start the SSH service after configuration has been validated.
+# @description Reload the SSH service when it is running, otherwise start it.
 #
 function run_sshd() {
-    # run sshd
-    sudo /usr/sbin/service ssh start
+    if sudo "${SSH_SERVICE_COMMAND}" "${SSH_SERVICE_NAME}" status > /dev/null 2>&1; then
+        sudo "${SSH_SERVICE_COMMAND}" "${SSH_SERVICE_NAME}" reload || sudo "${SSH_SERVICE_COMMAND}" "${SSH_SERVICE_NAME}" restart
+        return
+    fi
+
+    sudo "${SSH_SERVICE_COMMAND}" "${SSH_SERVICE_NAME}" start
 }
 
 #

--- a/tests/install/ubuntu/common/ssh_server_unit.bats
+++ b/tests/install/ubuntu/common/ssh_server_unit.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/ubuntu/server/ssh_server.sh"
+
+function run_ssh_server_function() {
+    run env \
+        DOTFILES_DEBUG= \
+        DOTFILES_SSHD_CONFIG_PATH="${SSHD_CONFIG_PATH}" \
+        DOTFILES_SSH_SERVICE_COMMAND=service_stub \
+        DOTFILES_SSH_SERVICE_NAME=ssh \
+        SCRIPT_PATH="${SCRIPT_PATH}" \
+        SERVICE_CALLS_PATH="${SERVICE_CALLS_PATH}" \
+        SERVICE_STATUS="${SERVICE_STATUS:-stopped}" \
+        SERVICE_RELOAD_STATUS="${SERVICE_RELOAD_STATUS:-0}" \
+        bash -c '
+            source "${SCRIPT_PATH}"
+
+            sudo() {
+                "$@"
+            }
+
+            tee() {
+                if [ "$1" = "-a" ]; then
+                    shift
+                    command tee -a "$@"
+                    return
+                fi
+
+                command tee "$@"
+            }
+
+            service_stub() {
+                printf "%s\n" "$*" >> "${SERVICE_CALLS_PATH}"
+
+                case "$2" in
+                    status)
+                        [ "${SERVICE_STATUS}" = "running" ]
+                        ;;
+                    reload)
+                        return "${SERVICE_RELOAD_STATUS}"
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            }
+
+            "$1"
+        ' bash "$1"
+}
+
+function setup() {
+    SSHD_CONFIG_PATH="${BATS_TEST_TMPDIR}/sshd_config"
+    SERVICE_CALLS_PATH="${BATS_TEST_TMPDIR}/service_calls.txt"
+    export SSHD_CONFIG_PATH SERVICE_CALLS_PATH
+    : > "${SERVICE_CALLS_PATH}"
+}
+
+@test "[ubuntu-common] configure_accept_env adds CLIProxyAPI variables" {
+    cat > "${SSHD_CONFIG_PATH}" << 'EOF'
+Port 22
+AcceptEnv LANG LC_*
+EOF
+
+    run_ssh_server_function configure_accept_env
+    [ "${status}" -eq 0 ]
+
+    run grep '^AcceptEnv ' "${SSHD_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"CLI_PROXY_API_CALLBACK_PORT"* ]]
+    [[ "${output}" == *"CLI_PROXY_API_PROXY_URL"* ]]
+}
+
+@test "[ubuntu-common] configure_accept_env preserves existing env vars and deduplicates" {
+    cat > "${SSHD_CONFIG_PATH}" << 'EOF'
+AcceptEnv LANG HTTP_PROXY
+AcceptEnv CLI_PROXY_API_PROXY_URL NO_PROXY
+EOF
+
+    run_ssh_server_function configure_accept_env
+    [ "${status}" -eq 0 ]
+
+    run awk '
+        /^AcceptEnv / {
+            lines++
+            for (i = 2; i <= NF; i++) counts[$i]++
+        }
+        END {
+            if (lines != 1) exit 1
+            if (counts["LANG"] != 1) exit 2
+            if (counts["HTTP_PROXY"] != 1) exit 3
+            if (counts["NO_PROXY"] != 1) exit 4
+            if (counts["CLI_PROXY_API_PROXY_URL"] != 1) exit 5
+            if (counts["CLI_PROXY_API_CALLBACK_PORT"] != 1) exit 6
+        }
+    ' "${SSHD_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[ubuntu-common] run_sshd reloads running ssh service" {
+    export SERVICE_STATUS="running"
+
+    run_ssh_server_function run_sshd
+    [ "${status}" -eq 0 ]
+
+    run cat "${SERVICE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "ssh status" ]
+    [ "${lines[1]}" = "ssh reload" ]
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "[ubuntu-common] run_sshd restarts running ssh service when reload fails" {
+    export SERVICE_STATUS="running"
+    export SERVICE_RELOAD_STATUS="1"
+
+    run_ssh_server_function run_sshd
+    [ "${status}" -eq 0 ]
+
+    run cat "${SERVICE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "ssh status" ]
+    [ "${lines[1]}" = "ssh reload" ]
+    [ "${lines[2]}" = "ssh restart" ]
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "[ubuntu-common] run_sshd starts stopped ssh service" {
+    export SERVICE_STATUS="stopped"
+
+    run_ssh_server_function run_sshd
+    [ "${status}" -eq 0 ]
+
+    run cat "${SERVICE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "ssh status" ]
+    [ "${lines[1]}" = "ssh start" ]
+    [ "${#lines[@]}" -eq 2 ]
+}


### PR DESCRIPTION
## Why

SSH sessions into GPU containers need to pass CLIProxyAPI connection metadata through `AcceptEnv` so Claude OAuth traffic can use the SSH `RemoteForward` proxy without requiring a global default proxy URL.

## What Changed

- Merge `CLI_PROXY_API_CALLBACK_PORT` and `CLI_PROXY_API_PROXY_URL` into the generated `AcceptEnv` line while preserving and deduplicating existing entries.
- Add configurable sshd config and service command variables so the SSH setup script can be unit-tested without touching system files.
- Reload a running SSH service after configuration changes, restart it only when reload fails, and start it when it is stopped.
- Add Bats coverage for the `AcceptEnv` merge and SSH service reload, restart, and start paths.

## Validation

Check shell formatting for the updated script and test file.

```shell
shfmt --indent 4 --space-redirects --diff install/ubuntu/server/ssh_server.sh tests/install/ubuntu/common/ssh_server_unit.bats
```

Check Bash syntax for the SSH setup script.

```shell
bash -n install/ubuntu/server/ssh_server.sh
```

Inspect the scoped diff for whitespace errors.

```shell
git diff --check -- install/ubuntu/server/ssh_server.sh tests/install/ubuntu/common/ssh_server_unit.bats
```

Ran a stubbed shell behavior check for `configure_accept_env` and `run_sshd`.

Local Bats was not run because this repository validates Bats tests in GitHub Actions.

## Notes

The change was motivated by a live ex-LINE GPU container test where `SetEnv` worked after sshd accepted `CLI_PROXY_API_CALLBACK_PORT` and `CLI_PROXY_API_PROXY_URL`.
