### PR TITLE
Validate managed skill symlink adapters

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -58,6 +58,7 @@
 
 - 共有指示: 複数ツールで使う subagent / custom agent の長い共通指示は `~/.agents/agents/<name>.md` を source of truth にしてください。
 - Claude wrapper: Claude Code 用の `~/.claude/agents/<name>.md` は YAML frontmatter を保持し、本文では `~/.agents/agents/<name>.md` を最初に読むよう明示してください。
+- Skill 管理: managed skill を追加・更新するときは、本文を `home/dot_config/exact_agents/skills/<skill>/SKILL.md` に置き、公開用 symlink template を `home/exact_dot_agents/skills/symlink_<skill>.tmpl` に追加してください。
 - 重複回避: 同じ長文指示を wrapper にコピーしないでください。
 - 単純さ: Markdown を Python などでパースして TOML / Markdown を生成する仕組みは、明示的に必要になるまで追加しないでください。
 

--- a/tests/install/common/agent_skill_symlinks.bats
+++ b/tests/install/common/agent_skill_symlinks.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+readonly SKILL_ROOT="./home/dot_config/exact_agents/skills"
+readonly SYMLINK_ROOT="./home/exact_dot_agents/skills"
+
+@test "[common] every managed skill has a matching symlink template" {
+    while IFS= read -r -d '' skill_file; do
+        skill_name="$(basename -- "$(dirname -- "${skill_file}")")"
+        template_file="${SYMLINK_ROOT}/symlink_${skill_name}.tmpl"
+        expected_target="{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/${skill_name}"
+
+        [ -f "${template_file}" ]
+        [ "$(< "${template_file}")" = "${expected_target}" ]
+    done < <(find "${SKILL_ROOT}" -mindepth 2 -maxdepth 2 -name SKILL.md -print0 | sort -z)
+}


### PR DESCRIPTION
## Why

Public managed skills need a recurrence-prevention check so a new skill body cannot be added without its public `~/.agents/skills` symlink adapter.

## What Changed

- Added a Bats test that scans `home/dot_config/exact_agents/skills/*/SKILL.md` and requires the matching `home/exact_dot_agents/skills/symlink_<skill>.tmpl` target.
- Added concise agent guidance that future managed skill changes must include both the skill body and the public symlink template.

## Validation

Check shell formatting for the changed Bats test.

```shell
make format
```

The implementer verified the focused managed skill symlink coverage before handoff.

```shell
bats tests/install/common/agent_skill_symlinks.bats
```

The implementer verified the related agent guidance and skill tests before handoff.

```shell
bats tests/install/common/agents_guidance.bats tests/install/common/agent_skill_symlinks.bats tests/install/common/skills.bats
```
