### PR TITLE
Run skills through active mise toolchain

### DIFF
--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -45,7 +45,7 @@ function install_herdr() {
 #
 function install_herdr_integrations() {
     for integration in "${HERDR_INTEGRATIONS[@]}"; do
-        "${MISE_BIN}" exec herdr -- herdr integration install "${integration}"
+        "${MISE_BIN}" exec -- herdr integration install "${integration}"
     done
 }
 
@@ -53,7 +53,7 @@ function install_herdr_integrations() {
 # @description Install the shared Herdr skill globally.
 #
 function install_herdr_skill() {
-    "${MISE_BIN}" exec npm:skills -- skills add "${HERDR_SKILL_REPO}" \
+    "${MISE_BIN}" exec -- skills add "${HERDR_SKILL_REPO}" \
         --skill "${HERDR_SKILL_NAME}" \
         --agent "${HERDR_SKILL_AGENTS[@]}" \
         --global \

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -27,7 +27,7 @@ function activate_mise() {
 # @description Install upstream skills managed by tool-specific installers.
 #
 function install_skills() {
-    "${MISE_BIN}" exec npm:skills -- skills add anthropics/skills \
+    "${MISE_BIN}" exec -- skills add anthropics/skills \
         --skill skill-creator \
         --agent claude-code \
         --global \

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -23,8 +23,58 @@ EOF
     chmod +x "${MISE_BIN}"
 }
 
+function write_mise_with_stale_named_runner() {
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+
+if [ "$1" = "exec" ]; then
+    if [ "${2:-}" != "--" ]; then
+        printf '%s\n' 'SyntaxError: The requested module '\''node:util'\'' does not provide an export named '\''styleText'\''' >&2
+        printf '%s\n' 'Node.js v18.20.3' >&2
+        exit 1
+    fi
+
+    shift 2
+    "$@"
+fi
+EOF
+    chmod +x "${MISE_BIN}"
+}
+
 @test "[common] herdr run-once template exists" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
+}
+
+@test "[common] herdr installer does not bypass the active mise toolchain" {
+    run grep -En 'exec[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+--' "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 1 ]
+}
+
+@test "[common] install_herdr_skill succeeds when the named npm runner is stale" {
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt"
+    export MISE_CALLS_PATH SKILLS_CALLS_PATH
+    write_mise_with_stale_named_runner
+
+    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${SKILLS_CALLS_PATH}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+
+    PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" run install_herdr_skill
+    [ "${status}" -eq 0 ]
+
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+
+    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
 }
 
 @test "[common] activate_mise evaluates mise activation output" {
@@ -62,7 +112,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${lines[0]}" = "exec herdr -- herdr integration install claude" ]
+    [ "${lines[0]}" = "exec -- herdr integration install claude" ]
 }
 
 @test "[common] install_herdr_skill installs the shared skill globally" {
@@ -74,7 +124,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec npm:skills -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${output}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
 }
 
 @test "[common] herdr script runs full installation workflow" {
@@ -124,8 +174,8 @@ EOF
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "activate bash" ]
     [ "${lines[1]}" = "install herdr" ]
-    [ "${lines[2]}" = "exec herdr -- herdr integration install claude" ]
-    [ "${lines[3]}" = "exec npm:skills -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${lines[2]}" = "exec -- herdr integration install claude" ]
+    [ "${lines[3]}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 readonly SCRIPT_PATH="./install/common/herdr.sh"
+readonly MISE_HELPERS_PATH="./tests/install/common/mise_helpers.bash"
 readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_once_after_03-install-herdr.sh.tmpl"
 
 function setup() {
@@ -8,6 +9,7 @@ function setup() {
     mkdir -p "${HOME}/.local/bin"
 
     source "${SCRIPT_PATH}"
+    source "${MISE_HELPERS_PATH}"
 }
 
 function teardown() {
@@ -23,33 +25,8 @@ EOF
     chmod +x "${MISE_BIN}"
 }
 
-function write_mise_with_stale_named_runner() {
-    cat > "${MISE_BIN}" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
-
-if [ "$1" = "exec" ]; then
-    if [ "${2:-}" != "--" ]; then
-        printf '%s\n' 'SyntaxError: The requested module '\''node:util'\'' does not provide an export named '\''styleText'\''' >&2
-        printf '%s\n' 'Node.js v18.20.3' >&2
-        exit 1
-    fi
-
-    shift 2
-    "$@"
-fi
-EOF
-    chmod +x "${MISE_BIN}"
-}
-
 @test "[common] herdr run-once template exists" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
-}
-
-@test "[common] herdr installer does not bypass the active mise toolchain" {
-    run grep -En 'exec[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+--' "${SCRIPT_PATH}"
-
-    [ "${status}" -eq 1 ]
 }
 
 @test "[common] install_herdr_skill succeeds when the named npm runner is stale" {
@@ -138,11 +115,8 @@ if [ "$*" = "activate bash" ]; then
     printf '%s\n' "export PATH=\"${HOME}/.local/bin:${PATH}\""
 fi
 if [ "$1" = "exec" ]; then
-    shift
-    while [ "$1" != "--" ]; do
-        shift
-    done
-    shift
+    [ "${2:-}" = "--" ] || exit 1
+    shift 2
     "$@"
 fi
 EOF

--- a/tests/install/common/mise_helpers.bash
+++ b/tests/install/common/mise_helpers.bash
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+function write_mise_with_stale_named_runner() {
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+
+if [ "$1" = "exec" ]; then
+    if [ "${2:-}" != "--" ]; then
+        printf '%s\n' 'SyntaxError: The requested module '\''node:util'\'' does not provide an export named '\''styleText'\''' >&2
+        printf '%s\n' 'Node.js v18.20.3' >&2
+        exit 1
+    fi
+
+    shift 2
+    "$@"
+fi
+EOF
+    chmod +x "${MISE_BIN}"
+}

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -23,8 +23,58 @@ EOF
     chmod +x "${MISE_BIN}"
 }
 
+function write_mise_with_stale_named_runner() {
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+
+if [ "$1" = "exec" ]; then
+    if [ "${2:-}" != "--" ]; then
+        printf '%s\n' 'SyntaxError: The requested module '\''node:util'\'' does not provide an export named '\''styleText'\''' >&2
+        printf '%s\n' 'Node.js v18.20.3' >&2
+        exit 1
+    fi
+
+    shift 2
+    "$@"
+fi
+EOF
+    chmod +x "${MISE_BIN}"
+}
+
 @test "[common] skills run-once template exists" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
+}
+
+@test "[common] skills installer does not bypass the active mise toolchain" {
+    run grep -En 'exec[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+--' "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 1 ]
+}
+
+@test "[common] install_skills succeeds when the named npm runner is stale" {
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt"
+    export MISE_CALLS_PATH SKILLS_CALLS_PATH
+    write_mise_with_stale_named_runner
+
+    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${SKILLS_CALLS_PATH}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+
+    PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" run install_skills
+    [ "${status}" -eq 0 ]
+
+    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+
+    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
 }
 
 @test "[common] activate_mise evaluates mise activation output" {
@@ -50,7 +100,7 @@ EOF
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec npm:skills -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+    [ "${output}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
 }
 
 @test "[common] skills script runs full installation workflow" {
@@ -92,7 +142,7 @@ EOF
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "activate bash" ]
-    [ "${lines[1]}" = "exec npm:skills -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+    [ "${lines[1]}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
 
     run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
     [ "${status}" -eq 0 ]

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 readonly SCRIPT_PATH="./install/common/skills.sh"
+readonly MISE_HELPERS_PATH="./tests/install/common/mise_helpers.bash"
 readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_once_after_04-install-skills.sh.tmpl"
 
 function setup() {
@@ -8,6 +9,7 @@ function setup() {
     mkdir -p "${HOME}/.local/bin"
 
     source "${SCRIPT_PATH}"
+    source "${MISE_HELPERS_PATH}"
 }
 
 function teardown() {
@@ -23,33 +25,8 @@ EOF
     chmod +x "${MISE_BIN}"
 }
 
-function write_mise_with_stale_named_runner() {
-    cat > "${MISE_BIN}" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
-
-if [ "$1" = "exec" ]; then
-    if [ "${2:-}" != "--" ]; then
-        printf '%s\n' 'SyntaxError: The requested module '\''node:util'\'' does not provide an export named '\''styleText'\''' >&2
-        printf '%s\n' 'Node.js v18.20.3' >&2
-        exit 1
-    fi
-
-    shift 2
-    "$@"
-fi
-EOF
-    chmod +x "${MISE_BIN}"
-}
-
 @test "[common] skills run-once template exists" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
-}
-
-@test "[common] skills installer does not bypass the active mise toolchain" {
-    run grep -En 'exec[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+--' "${SCRIPT_PATH}"
-
-    [ "${status}" -eq 1 ]
 }
 
 @test "[common] install_skills succeeds when the named npm runner is stale" {
@@ -114,11 +91,8 @@ if [ "$*" = "activate bash" ]; then
     printf '%s\n' "export PATH=\"${HOME}/.local/bin:${PATH}\""
 fi
 if [ "$1" = "exec" ]; then
-    shift
-    while [ "$1" != "--" ]; do
-        shift
-    done
-    shift
+    [ "${2:-}" = "--" ] || exit 1
+    shift 2
     "$@"
 fi
 EOF


### PR DESCRIPTION
## Why

`chezmoi apply` could fail when `mise exec npm:skills -- skills ...` selected a stale named npm runner using Node.js v18, even though the active project toolchain provided a newer Node.js runtime. The failure surfaced as `node:util` lacking the `styleText` export.

## What Changed

- Run `skills` through the active mise project toolchain with `mise exec -- skills ...`.
- Run `herdr` through the active mise project toolchain with `mise exec -- herdr ...`.
- Add bats regression coverage that simulates stale named runner failure and verifies the active toolchain path succeeds.
- Share the stale named-runner mise fixture through `tests/install/common/mise_helpers.bash`.
- Remove source-text grep guard tests in favor of behavioral stale-runner regression tests.
- Simplify full-workflow fake mise stubs to assert `exec --` directly before dispatching the requested command.

## Validation

Inspect the diff for whitespace and conflict marker issues.

```shell
git diff --check
```

Parse the updated shell scripts and shared bats helper.

```shell
bash -n install/common/herdr.sh install/common/skills.sh tests/install/common/mise_helpers.bash
```

Run shellcheck through the project mise environment.

```shell
mise exec -- shellcheck install/common/herdr.sh install/common/skills.sh tests/install/common/mise_helpers.bash
```

Confirm removed source-text guards and obsolete fake-mise parser loops no longer appear in the bats files.

```shell
! rg -n 'installer does not bypass the active mise toolchain|while \[ "\$1" != "--" \]; do' tests/install/common/herdr.bats tests/install/common/skills.bats
```

Confirm the removed named-runner patterns no longer appear in installer code or regression tests.

```shell
! rg -n 'exec (npm:skills|herdr) --' install/common tests/install/common
```

Bats regression coverage is included in `tests/install/common/herdr.bats` and `tests/install/common/skills.bats`; per repository policy, bats validation is left to GitHub Actions CI.
