### PR TITLE
Expose mise shims in zshenv

### DIFF
--- a/home/dot_config/exact_shell/mise.zsh
+++ b/home/dot_config/exact_shell/mise.zsh
@@ -1,0 +1,27 @@
+#!/usr/bin/env zsh
+
+# @file home/dot_config/exact_shell/mise.zsh
+# @brief Expose mise shims for minimal Zsh startup contexts.
+# @description
+#   Makes the standalone mise binary and mise shims available in non-interactive
+#   Zsh sessions without loading interactive plugins or prompt configuration.
+
+_mise_local_bin="${HOME%/}/.local/bin"
+_mise_bin="${_mise_local_bin}/mise"
+_mise_shims="${HOME%/}/.local/share/mise/shims"
+
+if [ -x "${_mise_bin}" ]; then
+    case ":${PATH}:" in
+    *:"${_mise_local_bin}":*) ;;
+    *) export PATH="${_mise_local_bin}:${PATH}" ;;
+    esac
+
+    if [ -d "${_mise_shims}" ]; then
+        case ":${PATH}:" in
+        *:"${_mise_shims}":*) ;;
+        *) export PATH="${_mise_shims}:${PATH}" ;;
+        esac
+    fi
+fi
+
+unset _mise_bin _mise_local_bin _mise_shims

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -1,7 +1,14 @@
 #!/usr/bin/env zsh
 
-readonly ZSHENV_PRIVATE="${HOME}/.zshenv_private"
+_zshenv_private="${HOME}/.zshenv_private"
+_zshenv_mise="${HOME}/.config/shell/mise.zsh"
 
-if [ -f "${ZSHENV_PRIVATE}" ]; then
-    source "${ZSHENV_PRIVATE}"
+if [ -f "${_zshenv_private}" ]; then
+    source "${_zshenv_private}"
 fi
+
+if [ -f "${_zshenv_mise}" ]; then
+    source "${_zshenv_mise}"
+fi
+
+unset _zshenv_mise _zshenv_private

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -5,6 +5,8 @@ readonly TMPL_SCRIPT_GLOB="./home/.chezmoiscripts/common/run_once_after_*-instal
 readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
 readonly MISE_CONFIG_SOURCE="./home/dot_mise/config.toml"
 readonly MISE_BASH_SOURCE="./home/dot_config/exact_shell/mise.bash"
+readonly MISE_ZSH_SOURCE="./home/dot_config/exact_shell/mise.zsh"
+readonly ZSHENV_SOURCE="./home/dot_zshenv"
 
 function write_mise_config() {
     local version="$1"
@@ -172,6 +174,17 @@ function run_mise_bash_startup() {
     run env -u BASH_ENV -u BASH_XTRACEFD -u SHELLOPTS -u PS4 bash -c "$1"
 }
 
+function install_zshenv_sources() {
+    mkdir -p "${HOME}/.config/shell"
+    cp "${ZSHENV_SOURCE}" "${HOME}/.zshenv"
+    cp "${MISE_ZSH_SOURCE}" "${HOME}/.config/shell/mise.zsh"
+}
+
+function run_mise_zsh_startup() {
+    command -v zsh > /dev/null 2>&1 || skip "zsh is not installed"
+    run env -u ZDOTDIR -u BASH_ENV -u BASH_XTRACEFD -u SHELLOPTS -u PS4 zsh -c "$1"
+}
+
 @test "[common] mise config declares a parseable top-level min_version" {
     run get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}"
     [ "${status}" -eq 0 ]
@@ -215,6 +228,74 @@ function run_mise_bash_startup() {
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "1" ]
     [ "${lines[1]}" = "1" ]
+}
+
+@test "[common] mise zsh startup leaves PATH unchanged when mise is absent" {
+    local expected_path="${PATH}"
+
+    mkdir -p "${HOME}/.local/bin" "${HOME}/.local/share/mise/shims"
+
+    run_mise_zsh_startup 'source "'"${MISE_ZSH_SOURCE}"'"; printf "%s\n" "${PATH}"'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "${expected_path}" ]
+}
+
+@test "[common] mise zsh startup exposes mise and mise shims" {
+    write_mise_stub
+    write_chezmoi_shim
+
+    run_mise_zsh_startup 'source "'"${MISE_ZSH_SOURCE}"'"; command -v mise; command -v chezmoi'
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "${MISE_INSTALL_PATH}" ]
+    [ "${lines[1]}" = "${HOME}/.local/share/mise/shims/chezmoi" ]
+}
+
+@test "[common] mise zsh startup avoids duplicate PATH entries" {
+    write_mise_stub
+    write_chezmoi_shim
+
+    run_mise_zsh_startup '
+        count_path_entry() {
+            local entry="$1"
+
+            printf "%s" "${PATH}" | tr : "\n" | awk -v entry="${entry}" "\$0 == entry { count++ } END { print count + 0 }"
+        }
+
+        source "'"${MISE_ZSH_SOURCE}"'"
+        source "'"${MISE_ZSH_SOURCE}"'"
+        count_path_entry "${HOME}/.local/bin"
+        count_path_entry "${HOME}/.local/share/mise/shims"
+    '
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "1" ]
+    [ "${lines[1]}" = "1" ]
+}
+
+@test "[common] zshenv sources minimal mise startup after zshenv_private" {
+    write_mise_stub
+    write_chezmoi_shim
+    install_zshenv_sources
+    mkdir -p "${HOME}/private-bin"
+    cat > "${HOME}/.zshenv_private" << EOF
+export ZSHENV_PRIVATE_LOADED=1
+export PATH="${HOME}/private-bin:\${PATH}"
+EOF
+
+    run_mise_zsh_startup '
+        printf "%s\n" "${PATH}" | tr : "\n" | awk "NR <= 3"
+        command -v mise
+        command -v chezmoi
+        printf "%s\n" "${ZSHENV_PRIVATE_LOADED:-}"
+        printf "%s %s\n" "${+_zshenv_private}" "${+_zshenv_mise}"
+    '
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "${HOME}/.local/share/mise/shims" ]
+    [ "${lines[1]}" = "${HOME}/.local/bin" ]
+    [ "${lines[2]}" = "${HOME}/private-bin" ]
+    [ "${lines[3]}" = "${MISE_INSTALL_PATH}" ]
+    [ "${lines[4]}" = "${HOME}/.local/share/mise/shims/chezmoi" ]
+    [ "${lines[5]}" = "1" ]
+    [ "${lines[6]}" = "0 0" ]
 }
 
 @test "[common] get_mise_min_version_from_config reads top-level min_version" {


### PR DESCRIPTION
## Why

Remote and non-interactive Zsh sessions read `.zshenv` but do not source `.zshrc`, so commands that depend on mise shims can fail before the interactive shell configuration runs. Sourcing `.zshrc` is too broad for these contexts because it can load prompt and plugin setup.

## What Changed

- Add a minimal `home/dot_config/exact_shell/mise.zsh` startup helper that prepends `~/.local/bin` and `~/.local/share/mise/shims` only when the standalone mise binary exists.
- Source the helper from `home/dot_zshenv` after `~/.zshenv_private`, then clean up helper variables.
- Cover non-interactive Zsh startup behavior in `tests/install/common/mise.bats`, including absent mise, shim exposure, duplicate prevention, private env ordering, and helper variable cleanup.

Interactive Zsh activation in `dot_zprofile` and plugin/prompt setup remain unchanged.

## Validation

Inspect the diff for whitespace errors.

```shell
git diff --check
```

Parse the updated Zsh startup files.

```shell
zsh -n home/dot_zshenv home/dot_config/exact_shell/mise.zsh
```

Parse existing Bash mise startup files.

```shell
bash -n install/common/mise.sh home/dot_config/exact_shell/mise.bash
```

Run shellcheck through mise for the Bash startup files.

```shell
mise exec -- shellcheck install/common/mise.sh home/dot_config/exact_shell/mise.bash
```

Smoke-test a minimal non-interactive Zsh environment with fake `mise` and `chezmoi` shim executables.

```shell
_tmp_home="$(mktemp -d)"
trap 'rm -rf "${_tmp_home}"' EXIT
mkdir -p "${_tmp_home}/.config/shell" "${_tmp_home}/.local/bin" "${_tmp_home}/.local/share/mise/shims"
cp home/dot_zshenv "${_tmp_home}/.zshenv"
cp home/dot_config/exact_shell/mise.zsh "${_tmp_home}/.config/shell/mise.zsh"
cat > "${_tmp_home}/.local/bin/mise" <<'MISE_STUB'
#!/usr/bin/env sh
echo fake-mise
MISE_STUB
cat > "${_tmp_home}/.local/share/mise/shims/chezmoi" <<'CHEZMOI_STUB'
#!/usr/bin/env sh
echo fake-chezmoi
CHEZMOI_STUB
chmod +x "${_tmp_home}/.local/bin/mise" "${_tmp_home}/.local/share/mise/shims/chezmoi"
HOME="${_tmp_home}" ZDOTDIR="${_tmp_home}" zsh -c 'command -v mise; command -v chezmoi; test -z "${ZSH_VERSION:-}" || true'
```

Bats tests were not run locally per repository policy; GitHub Actions should validate them.
