### PR TITLE
Support merge queue checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 jobs:
   changes:
@@ -31,6 +34,8 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
 
@@ -40,6 +45,12 @@ jobs:
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "${BASE_REF}"
             diff_range="origin/${BASE_REF}...${HEAD_SHA}"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            if [ -z "${MERGE_GROUP_BASE_SHA}" ] || [ -z "${MERGE_GROUP_HEAD_SHA}" ]; then
+              echo "merge_group event is missing github.event.merge_group.base_sha or github.event.merge_group.head_sha." >&2
+              exit 1
+            fi
+            diff_range="${MERGE_GROUP_BASE_SHA}...${MERGE_GROUP_HEAD_SHA}"
           elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
             diff_range="${BEFORE_SHA}...${HEAD_SHA}"
           else


### PR DESCRIPTION
## Why

GitHub merge queue creates `merge_group` events, so required checks need to run for merge-group commits before branch protection can rely on the queue.

## What Changed

- Add a `merge_group` workflow trigger for `main` with `checks_requested` events.
- Teach the unit-test change detector to diff `merge_group.base_sha...merge_group.head_sha`.
- Fail clearly when a `merge_group` payload is missing either SHA.
- Keep the existing matrix job names and heavy-test skip behavior intact.

## Validation

Inspect the staged workflow diff for whitespace errors.

```shell
git diff --check
```

`actionlint` was not installed, so workflow linting was skipped.

Local `bats` tests were intentionally not run, per repository policy; GitHub Actions is used for `bats` validation.
