### PR TITLE
Revert merge queue workflow support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    branches: [main]
-    types: [checks_requested]
 
 jobs:
   changes:
@@ -34,8 +31,6 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
 
@@ -45,12 +40,6 @@ jobs:
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "${BASE_REF}"
             diff_range="origin/${BASE_REF}...${HEAD_SHA}"
-          elif [ "${EVENT_NAME}" = "merge_group" ]; then
-            if [ -z "${MERGE_GROUP_BASE_SHA}" ] || [ -z "${MERGE_GROUP_HEAD_SHA}" ]; then
-              echo "merge_group event is missing github.event.merge_group.base_sha or github.event.merge_group.head_sha." >&2
-              exit 1
-            fi
-            diff_range="${MERGE_GROUP_BASE_SHA}...${MERGE_GROUP_HEAD_SHA}"
           elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
             diff_range="${BEFORE_SHA}...${HEAD_SHA}"
           else


### PR DESCRIPTION
## Why

GitHub merge queue is not available for this personal-account repository, so workflow support added in #572 cannot be used.

## What Changed

- Reverts merge queue workflow integration from `.github/workflows/test.yaml`.
- Removes the `merge_group` trigger, merge group SHA environment variables, and merge group diff range handling.

## Validation

Inspect the committed diff for whitespace and conflict marker issues.

```shell
git diff --check HEAD^ HEAD
```

Confirm no merge queue event references remain in the test workflow.

```shell
! git grep -n "merge_group" -- .github/workflows/test.yaml
```

Confirm only the test workflow changed in the revert commit.

```shell
test "$(git diff --name-only HEAD^ HEAD)" = ".github/workflows/test.yaml"
```

Local bats tests were intentionally not run per repository policy; GitHub Actions will validate bats.
