### PR TITLE
docs(agents): centralize implementation principles

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -4,9 +4,3 @@
 > After reading this `AGENTS.md`, say: `🤖 I read ~/.codex/AGENTS.md.`
 
 - 共通指示: `~/.agents/AGENTS.md` を最初に読み、その内容をこの Codex 固有 entrypoint と合わせて適用してください。
-- private 指示: `~/.agents/AGENTS-private.md` が読める場合は、そこにある Codex の環境固有設定も適用してください。
-
-## Codex 固有の委譲
-
-- 標準機能: 調査と実装の委譲には Codex の native subagents を使い、別プロセスの委譲基盤を追加しないでください。
-- GitHub workflow: branch、commit、push、pull request、CI確認は、利用可能な場合 `gh-workflow-manager` custom agent に委譲してください。

--- a/home/dot_config/codex/README.md
+++ b/home/dot_config/codex/README.md
@@ -1,6 +1,6 @@
 This directory is the public canonical source for Codex guidance and custom-agent adapters.
 
-- [AGENTS.md](AGENTS.md) is exposed as `~/.codex/AGENTS.md` through [home/dot_codex/symlink_AGENTS.md.tmpl](../../dot_codex/symlink_AGENTS.md.tmpl). It points Codex to the shared guidance at `~/.agents/AGENTS.md` and keeps only Codex-specific delegation rules here.
+- [AGENTS.md](AGENTS.md) is exposed as `~/.codex/AGENTS.md` through [home/dot_codex/symlink_AGENTS.md.tmpl](../../dot_codex/symlink_AGENTS.md.tmpl). It is a minimal Codex entrypoint that records the acknowledgment and points Codex to the shared guidance at `~/.agents/AGENTS.md`.
 - [agents/](agents/) contains Codex TOML adapters exposed as `~/.codex/agents`. Long shared instructions remain under `~/.agents/agents`.
 - Model providers, credentials, private profiles, and internal launchers are managed by the private dotfiles repository; do not add them here.
 - [home/dot_codex/](../../dot_codex/) is only the adapter layer that exposes this source in the applied home layout.

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -8,6 +8,16 @@
 - Reasoning language: Think and reason in English by default.
 - Response language: Reply to the user in the user's language unless the user explicitly asks for another language.
 
+## 最重要の実装原則
+
+> [!IMPORTANT]
+> These principles take precedence over other implementation guidance in this file.
+
+- Backward compatibility: Do not preserve backward compatibility.
+- Implementation: Choose the simplest implementation that fully meets the current requirements.
+- Dependencies: Prefer established, well-maintained libraries over custom implementations.
+- Architecture: Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.
+
 ## 指示の記述
 
 - 記述形式: 詳細な指示は `- 概要: 詳細` のような形式で整理してください。
@@ -83,7 +93,7 @@
 
 - 例外処理: エラーを恐れないでください。まずは例外処理は気にせずコードを書いてください。
 - 最終成果物: 最終成果物でも例外処理は入れなくて構いません。
-- 後方互換性: 研究開発用途が主なため後方互換性は気にしないでください。あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
+- テスト: あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
 
 ### Worktree の方針
 

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -30,7 +30,7 @@ readonly GEMINI_SKILL_DIR_SYMLINK_TEMPLATE="./home/dot_gemini/config/symlink_ski
 readonly LINK_SHARED_SKILLS_SCRIPT="./home/.chezmoiscripts/common/run_after_90-link-shared-skills.sh.tmpl"
 readonly GITIGNORE_PATH="./.gitignore"
 
-@test "[common] codex guidance entrypoint reads shared guidance" {
+@test "[common] codex guidance entrypoint stays minimal and reads shared guidance" {
     [ -f "${SHARED_AGENTS_PATH}" ]
     [ -f "${CODEX_AGENTS_PATH}" ]
     [ ! -e "./home/dot_config/codex/AGENTS.codex-only.md" ]
@@ -40,8 +40,33 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F '`~/.agents/AGENTS.md` を最初に読み' "${CODEX_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '`~/.agents/AGENTS-private.md`' "${CODEX_AGENTS_PATH}"
+    run grep -F '`~/.agents/AGENTS-private.md`' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
+    run grep -F '`~/.agents/AGENTS-private.md`' "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
+    run grep -F '## Codex 固有の委譲' "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
+    run grep -F 'native subagents' "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
+    run grep -F 'gh-workflow-manager' "${CODEX_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "[common] shared guidance defines highest-priority implementation principles" {
+    run grep -F '## 最重要の実装原則' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'These principles take precedence over other implementation guidance in this file.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Do not preserve backward compatibility.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Choose the simplest implementation that fully meets the current requirements.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Prefer established, well-maintained libraries over custom implementations.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+    run grep -F '後方互換性は気にしないでください' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -ne 0 ]
 }
 
 @test "[common] shared guidance requires concrete coding plans" {


### PR DESCRIPTION
## Why

Shared agent guidance needs a single, highest-priority source for implementation principles across the managed entrypoints.

## What Changed

- Define the highest-priority implementation principles in shared agent guidance.
- Keep the Codex entrypoint minimal by removing duplicated private and delegation rules.
- Extend guidance installation coverage for the new ownership boundary.

## Validation

Not run locally: repository policy requires Bats validation in GitHub Actions.
