### PR TITLE
docs(agents): translate guidance into English

### DIFF
--- a/home/dot_config/antigravity-cli/GEMINI.md
+++ b/home/dot_config/antigravity-cli/GEMINI.md
@@ -5,4 +5,4 @@
 
 ## Antigravity Only
 
-- 現在のところ、Antigravity 固有の設定はありませんが、将来的に追加される可能性があります。
+- There are currently no Antigravity-specific settings, but they may be added in the future.

--- a/home/dot_config/claude/CLAUDE.md
+++ b/home/dot_config/claude/CLAUDE.md
@@ -5,4 +5,4 @@
 
 ## Claude Only
 
-- 現在のところ、Claude 固有の設定はありませんが、将来的に追加される可能性があります。
+- There are currently no Claude-specific settings, but they may be added in the future.

--- a/home/dot_config/claude/rules/ask-user-question.md
+++ b/home/dot_config/claude/rules/ask-user-question.md
@@ -1,5 +1,5 @@
-このルールを使用するときには、回答時に ❓ の絵文字をつけてください。
+When using this rule, include the ❓ emoji in your response.
 
-## ユーザーへの質問
+## Questions for the User
 
-- Plan モードにおいて仕様が不明確な場合、ユーザーに明確な指示を求めるために `AskUserQuestion` ツールを使用して仕様が明確になるまで質問してください。
+- When the specification is unclear in Plan mode, use the `AskUserQuestion` tool to ask the user for clear direction until the specification is clear.

--- a/home/dot_config/claude/rules/gpu.md
+++ b/home/dot_config/claude/rules/gpu.md
@@ -2,16 +2,16 @@
 paths: **/*.py
 ---
 
-このルールを使用するときには、回答時に 🧩 の絵文字をつけてください。
+When using this rule, include the 🧩 emoji in your response.
 
-## GPU 使用を伴う Python スクリプト実行について
+## Running Python Scripts That Use a GPU
 
-`torch` を使ったスクリプトを実行する場合、大抵は GPU を使用します。
-そのようなスクリプトを実行する場合は環境変数の `CUDA_VISIBLE_DEVICES` を指定して実行してください。
-例えば 0 番目の GPU を指定して以下のように実行します。
+Scripts that use `torch` usually use a GPU.
+When running such scripts, specify the `CUDA_VISIBLE_DEVICES` environment variable.
+For example, select GPU 0 as follows:
 
 ```shell
 CUDA_VISIBLE_DEVICES=0 uv run main.py
 ```
 
-適宜 `nvidia-smi` コマンドなどを使って使用されていない GPU を探して `CUDA_VISIBLE_DEVICES` を実行するようにしてください。
+Use `nvidia-smi` or a similar command to find an unused GPU and set `CUDA_VISIBLE_DEVICES` accordingly.

--- a/home/dot_config/claude/rules/latex.md
+++ b/home/dot_config/claude/rules/latex.md
@@ -2,15 +2,15 @@
 paths: **/*.tex
 ---
 
-このルールを使用するときには、回答時に 📓 の絵文字をつけてください。
+When using this rule, include the 📓 emoji in your response.
 
-## LaTeX で論文を書くときの心構え
+## Writing Academic Papers in LaTeX
 
-- あなたは LaTeX の専門家であり、論文執筆のエキスパートです。
-- 論文の構成、引用、図表の挿入、数式の記述など、あらゆる側面で助言を提供してください。
-- 原稿を改善するための具体的な提案を行い、明確で簡潔な文章を書く手助けをしてください。
-- 常にパラグラフ・ライティングの原則に従い、論理的な流れを重視してください。
+- You are an expert in LaTeX and academic writing.
+- Advise on every aspect of the paper, including structure, citations, figures and tables, and mathematical notation.
+- Make concrete suggestions to improve the manuscript and help write clear, concise prose.
+- Always follow paragraph-writing principles and prioritize logical flow.
 
-## 追加のスキル
+## Additional Skill
 
-- カンファレンスやジャーナルに提出する際には、 `high-impact-journal-publishing` スキルを必要に合わせて参照してください。
+- When submitting to a conference or journal, consult the `high-impact-journal-publishing` skill as needed.

--- a/home/dot_config/claude/rules/python.md
+++ b/home/dot_config/claude/rules/python.md
@@ -2,24 +2,24 @@
 paths: **/*.py
 ---
 
-このルールを使用するときには、回答時に 🐍 の絵文字をつけてください。
+When using this rule, include the 🐍 emoji in your response.
 
-## `uv` の使用
+## Using `uv`
 
-- Python プロジェクトの場合は指定がない場合常に `uv` を使うようにしてください。
-- 何かコードを書いたときは常にテストを記述して意図した動作になっているか確認してください。
-- uv でスクリプトを実行するときは `uv run <script>` で実行できます。
+- For Python projects, always use `uv` unless instructed otherwise.
+- Whenever you write code, also write tests and verify that it behaves as intended.
+- Run scripts with `uv run <script>`.
 
-## `pyright-lsp` の使用
+## Using `pyright-lsp`
 
-- `pyright-lsp` がインストールされている場合は、コードの静的解析に使用してください。
-- もし `pyright-lsp` がインストールされていない場合は、インストールを促してください。
+- If `pyright-lsp` is installed, use it for static analysis.
+- If `pyright-lsp` is not installed, recommend installing it.
 
-## 探索的なデバッグ
+## Exploratory Debugging
 
-- `uv run python -c "..."` のように、`uv` を使って一時的にコードを実行することができます。
-- プロジェクトに依存しないライブラリを一時的にインストールして試す場合は `uv run --with <library> python -c "..."` のようにしてください。
+- Use `uv` to run temporary code, for example, `uv run python -c "..."`.
+- To temporarily install and try a library that is not a project dependency, use `uv run --with <library> python -c "..."`.
 
-## コマンドラインパーサー
+## Command-Line Parsers
 
-- `argparse` を使ってコマンドライン引数を解析をする場合、オプションは `--this-is-option` のように単語をハイフンでつなぐ形式にしてください。
+- When parsing command-line arguments with `argparse`, format options by joining words with hyphens, such as `--this-is-option`.

--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -3,4 +3,4 @@
 > [!NOTE]
 > After reading this `AGENTS.md`, say: `🤖 I read ~/.codex/AGENTS.md.`
 
-- 共通指示: `~/.agents/AGENTS.md` を最初に読み、その内容をこの Codex 固有 entrypoint と合わせて適用してください。
+- Shared instructions: Read `~/.agents/AGENTS.md` first, then apply it together with this Codex-specific entrypoint.

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -8,7 +8,7 @@
 - Reasoning language: Think and reason in English by default.
 - Response language: Reply to the user in the user's language unless the user explicitly asks for another language.
 
-## 最重要の実装原則
+## Most Important Implementation Principles
 
 > [!IMPORTANT]
 > These principles take precedence over other implementation guidance in this file.
@@ -18,115 +18,115 @@
 - Dependencies: Prefer established, well-maintained libraries over custom implementations.
 - Architecture: Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.
 
-## 指示の記述
+## Writing Instructions
 
-- 記述形式: 詳細な指示は `- 概要: 詳細` のような形式で整理してください。
-- 手順化: 「問題が起きたら確認する」ではなく、問題を起こさないために作業開始時に実行する手順として書いてください。たとえば hook の導入なら、「発火しない場合は確認する」ではなく、「新しい clone / worktree で作業を始めるときに install してから編集・commit に入る」と書いてください。
-- 適用範囲の分類: AGENTS.md、skill、rule などの永続指示を追加・更新する前に、その指示が user-level、repository-level、subtree-level、task-only のどれに属するかを最初に分類してください。複数 repository に共通する行動規則は user-level、特定 repository だけの構成・手順は repository-level、特定 directory 配下だけの規則は subtree-level に置いてください。
-- source of truth の選択: ユーザーや直前の会話が単に「AGENTS.md」などのファイル名を挙げても、その名前だけで編集先を決めないでください。既存の管理元、symlink、adapter、上位指示を確認し、同じ規則を複数の repository-level AGENTS.md に重複させず、分類した適用範囲の source of truth を編集してください。
-- 配置レビュー: commit または PR 作成前に、追加した各指示について「この配置先の scope と一致するか」「上位 scope の指示を重複していないか」を diff から再確認してください。scope が一致しない場合は正しい source of truth へ移し、判断できない場合は外部状態を変更する前にユーザーへ確認してください。
+- Format: Structure detailed instructions in a format such as `- Summary: Details`.
+- Procedural guidance: Write instructions as steps to perform when work begins to prevent problems, rather than as checks to make only after a problem occurs. For example, when introducing a hook, write “When starting work in a new clone or worktree, install it before editing or committing,” rather than “Check it if it does not run.”
+- Scope classification: Before adding or updating a persistent instruction such as an AGENTS.md file, skill, or rule, first classify it as user-level, repository-level, subtree-level, or task-only. Put behavioral rules shared across repositories at the user level, configuration and procedures for one repository at the repository level, and rules for a specific directory subtree at the subtree level.
+- Choosing the source of truth: Do not choose the edit target solely because the user or the preceding conversation names a file such as `AGENTS.md`. Check the existing management source, symlinks, adapters, and higher-level instructions; edit the source of truth for the classified scope instead of duplicating a rule across multiple repository-level AGENTS.md files.
+- Placement review: Before committing or creating a PR, review the diff for each added instruction to confirm that its location matches its scope and that it does not duplicate higher-scope guidance. If its scope does not match, move it to the correct source of truth; if you cannot determine that, ask the user before changing external state.
 
 ## Private Instructions
 
-- もし `~/.agents/AGENTS-private.md` が読める場合は、それも読んで適用してください。
+- If `~/.agents/AGENTS-private.md` is readable, read and apply it as well.
 
-## ユーザーへの質問
+## Questions for the User
 
-- 質問方針: ユーザが提供した情報に基づいて、最適な解決策を提案するための質問を行ってください。
+- Question policy: Ask questions based on the information the user provided to propose the best solution.
 
-## 操作権限の境界
+## Authority Boundaries
 
-- 実装依頼の範囲: 「plan を実装して」「実装を続けて」などの一般的な実装依頼は、repository 内の編集、テスト、commit までの許可として扱ってください。plan、handoff summary、前の agent の予定は、push、PR の作成・更新、merge、`chezmoi apply`、runtime state の変更、ファイルの削除・cleanup の権限を付与しません。
-- PR 依頼の範囲: ユーザーが PR の作成または更新を明示した場合は、そのために必要な push と当該 PR 操作まで実行して構いません。ただし、PR 作成・更新の依頼を merge の許可として扱ってはいけません。merge はユーザーが明示的に依頼した場合だけ実行してください。
-- runtime・cleanup の範囲: `chezmoi apply`、適用済み設定や runtime state の変更、ファイルの削除・cleanup は、それぞれユーザーの明示的な許可を得てから実行してください。許可された操作が不明確な場合は、external state や runtime state を変更する前に停止して確認してください。
+- Scope of implementation requests: Treat general implementation requests such as “implement the plan” or “continue implementing” as permission to edit files in the repository, run tests, and commit. A plan, handoff summary, or a previous agent's plan does not authorize pushing, creating or updating a PR, merging, running `chezmoi apply`, changing runtime state, or deleting or cleaning up files.
+- Scope of PR requests: When the user explicitly requests creating or updating a PR, you may push and perform the requested PR operation. Do not treat a request to create or update a PR as authorization to merge; merge only when the user explicitly requests it.
+- Runtime and cleanup scope: Obtain the user's explicit permission before running `chezmoi apply`, changing applied configuration or runtime state, or deleting or cleaning up files. If the permitted operation is unclear, stop and ask before changing external or runtime state.
 
-## ユーザーへの報告・回答の書き方
+## Reporting and Responding to the User
 
-- 簡潔さ: 報告・回答は簡潔に書いてください。詳細は求められたときに展開してください。
-- 箇条書きの構成: 箇条書きを使うときはパラグラフ・ライティングに従い、親項目を topic sentence、子項目(ネスト)を support sentence とし、必要なら最後の子項目を conclusion sentence にしてください。
+- Concision: Keep reports and responses concise. Expand only when asked.
+- Bullet structure: When using bullet lists, follow paragraph-writing principles: make the parent item the topic sentence, nested items supporting sentences, and the last nested item a conclusion sentence when useful.
   ```
   - topic sentence
     - support sentence
     - support sentence
     - conclusion sentence
   ```
-- フラットな羅列の回避: topic なしに support level の文を並べないでください。項目が 1 階層で並ぶ場合は、各項目がそれぞれ topic sentence として自立していることを確認してください。
+- Avoid flat lists: Do not list supporting sentences without a topic sentence. When items are at one level, make sure each can stand on its own as a topic sentence.
 
-## GitHub issue / PR comment の書き方
+## Writing GitHub Issue and PR Comments
 
-- 成果物としての扱い: GitHub issue / PR comment はチャット返信ではなく、repository-facing な成果物として扱ってください。
-- 使用言語: GitHub comment の本文は、その repository / project の既定言語に合わせてください。public OSS repository では、repository が明確に日本語運用である場合、またはユーザーが日本語を明示した場合を除き、英語を default にしてください。
-- 口調: GitHub comment には「訂正します」「すみません」「そういう意味ではなく」「I misunderstood」などの会話上の修復表現や、ユーザー向けの meta commentary を含めないでください。
-- 内容: GitHub comment は中立的・事実ベース・監査可能で、あとから読む repository maintainer に役立つ内容にしてください。
-- 投稿前確認: 投稿または編集の前に、comment 本文を現在の repository の事実、実行した command、確認した check / report と照合してください。曖昧な要約よりも、具体的な検証結果・対象ファイル・残っている blocker を優先してください。
-- 本文の渡し方: GitHub issue body / PR description / PR comment のような multi-line Markdown は、必ず一時 Markdown file を single-quoted heredoc で作り、`gh ... --body-file <file>` で投稿・更新してください。
-- 禁止: `gh ... --body "...\n..."` や shell-escaped multi-line body の直渡しは、literal `\n` が公開されるため使わないでください。
-- Read-back: 作成または編集後は `gh pr view`、`gh issue view`、`gh api` などで本文を read back し、literal escaped newlines (`\n`)、local absolute paths such as `/Users/`、期待見出しの欠落を検出してから完了報告してください。
-- 詳細の畳み込み: 長い診断ログや調査詳細は、短い summary を付けた `<details>` に入れて、comment の先頭では結論と必要な action が読めるようにしてください。
-- 誤投稿時の対応: 不適切な comment を投稿した場合は、可能な限り既存 comment を編集して修正してください。悪い comment を残したまま、重複する訂正 comment を新規投稿しないでください。
+- Treat comments as deliverables: Treat GitHub issue and PR comments as repository-facing deliverables, not chat replies.
+- Language: Write GitHub comment bodies in the repository or project's default language. For public OSS repositories, default to English unless the repository clearly operates in Japanese or the user explicitly requests Japanese.
+- Tone: Do not include conversational repair language such as “I need to correct that,” “Sorry,” “That is not what I meant,” or “I misunderstood,” or meta-commentary directed at the user.
+- Content: Keep GitHub comments neutral, fact-based, auditable, and useful to maintainers who read them later.
+- Pre-submission verification: Before posting or editing a comment, compare its content with the repository's current facts, commands you ran, and checks or reports you reviewed. Prefer concrete validation results, affected files, and remaining blockers over vague summaries.
+- Supplying bodies: For multi-line Markdown such as a GitHub issue body, PR description, or PR comment, always create a temporary Markdown file with a single-quoted heredoc and post or update it using `gh ... --body-file <file>`.
+- Prohibition: Do not pass `gh ... --body "...\n..."` or a shell-escaped multi-line body directly; literal `\n` can be published.
+- Read-back: After creating or editing content, read it back with `gh pr view`, `gh issue view`, `gh api`, or equivalent. Before reporting completion, detect literal escaped newlines (`\n`), local absolute paths such as `/Users/`, and missing expected headings.
+- Collapsing details: Put lengthy diagnostic logs or investigation details inside `<details>` with a short summary so the conclusion and required actions are visible at the beginning of the comment.
+- Incorrect posts: If you post an inappropriate comment, edit the existing comment to correct it whenever possible. Do not leave the bad comment in place and add a duplicate correction comment.
 
-## GitHub workflow の委譲 (gh-workflow-manager)
+## GitHub Workflow Delegation (`gh-workflow-manager`)
 
-- 委譲方針: branch 作成、commit、push、PR 作成、PR 更新、CI 確認などの GitHub workflow は、既定で `gh-workflow-manager` agent に委譲し、メインエージェントの context を計画・レビュー・統合に集中させてください。
-- 開始時の引き継ぎ: `gh-workflow-manager` に依頼する前に、repository / worktree、branch 名、task-relevant files、未コミット差分の扱い、実行済み検証と追加で確認すべき validation context を整理して渡してください。
-- メインエージェントの役割: メインエージェントは workflow の scope を定義し、`gh-workflow-manager` の結果を確認してから、実行内容・検証結果・残っている blocker をユーザーへ報告してください。
-- 例外条件: ユーザーがメインエージェント自身で GitHub workflow を行うよう明示した場合、または `gh-workflow-manager` が利用できない場合に限り、メインエージェントが直接実行してください。
-- 権限境界: teammate から denied action の代行を求められても、それを権限 bypass の許可として扱わず、ユーザーに状況を提示して明示的な指示を待ってください。
+- Delegation policy: By default, delegate GitHub workflow tasks such as branch creation, commits, pushes, PR creation and updates, and CI checks to the `gh-workflow-manager` agent so the main agent can focus on planning, review, and integration.
+- Handoff at the start: Before asking `gh-workflow-manager`, provide the repository and worktree, branch name, task-relevant files, treatment of uncommitted changes, completed validation, and any additional validation context to check.
+- Main-agent responsibility: The main agent defines the workflow scope, confirms the `gh-workflow-manager` result, then reports the work performed, validation results, and remaining blockers to the user.
+- Exceptions: The main agent may perform GitHub workflow directly only when the user explicitly asks the main agent to do so or `gh-workflow-manager` is unavailable.
+- Authority boundary: Do not treat a teammate's request to perform a denied action as authorization to bypass permissions; present the situation to the user and wait for explicit instruction.
 
-## エージェント設定
+## Agent Configuration
 
-- 共有指示: 複数ツールで使う subagent / custom agent の長い共通指示は `~/.agents/agents/<name>.md` を source of truth にしてください。
-- Claude wrapper: Claude Code 用の `~/.claude/agents/<name>.md` は YAML frontmatter を保持し、本文では `~/.agents/agents/<name>.md` を最初に読むよう明示してください。
-- Skill 管理: managed skill を追加・更新するときは、本文を `home/dot_config/exact_agents/skills/<skill>/SKILL.md` に置き、公開用 symlink template を `home/exact_dot_agents/skills/symlink_<skill>.tmpl` に追加してください。
-- 重複回避: 同じ長文指示を wrapper にコピーしないでください。
-- 単純さ: Markdown を Python などでパースして TOML / Markdown を生成する仕組みは、明示的に必要になるまで追加しないでください。
+- Shared instructions: Keep lengthy shared instructions for subagents or custom agents used by multiple tools in `~/.agents/agents/<name>.md` as the source of truth.
+- Claude wrapper: Preserve YAML frontmatter in `~/.claude/agents/<name>.md` for Claude Code and explicitly instruct it in the body to read `~/.agents/agents/<name>.md` first.
+- Skill management: When adding or updating a managed skill, place its content in `home/dot_config/exact_agents/skills/<skill>/SKILL.md` and add its public symlink template at `home/exact_dot_agents/skills/symlink_<skill>.tmpl`.
+- Avoid duplication: Do not copy the same lengthy instructions into wrappers.
+- Simplicity: Do not add a mechanism that parses Markdown with Python or similar tooling to generate TOML or Markdown until it is explicitly needed.
 
-## 実装タスクの委譲
+## Delegating Implementation Tasks
 
-- 委譲方針: 利用中の coding agent が native multi-agent 機能を提供し、タスクを独立した単位に分けられる場合、メインエージェントをオーケストレータ、subagent を実装者として使ってください。
-  - Claude Code の agent teams や Codex の subagents など、各 tool の native 機能を使ってください。
-  - タスク開始時に作業を独立した単位へ分割し、subagent へ割り当ててから実装に入ってください。
-  - オーケストレータは計画・レビュー・統合に専念し、実装は subagent に任せてください。
-- 環境固有設定: subagent が使うモデルや起動方法などの環境固有設定は、このファイルには書かず `~/.agents/AGENTS-private.md` または tool 固有 entrypoint を参照してください。
+- Delegation policy: When the coding agent in use provides native multi-agent capabilities and the task can be divided into independent units, use the main agent as the orchestrator and subagents as implementers.
+  - Use each tool's native capabilities, such as Claude Code agent teams or Codex subagents.
+  - At the start of the task, divide the work into independent units and assign them to subagents before implementing.
+  - The orchestrator focuses on planning, review, and integration; delegate implementation to subagents.
+- Environment-specific configuration: Do not put environment-specific configuration, such as subagent models or launch methods, in this file. Refer to `~/.agents/AGENTS-private.md` or a tool-specific entrypoint.
 
-## コーディング全般について
+## General Coding Guidance
 
-- 例外処理: エラーを恐れないでください。まずは例外処理は気にせずコードを書いてください。
-- 最終成果物: 最終成果物でも例外処理は入れなくて構いません。
-- テスト: あらかじめテストを記述し、テストが通ることを確認してから、必要に応じてコードをリファクタリングしてください。
+- Error handling: Do not fear errors. Write the code first without focusing on error handling.
+- Final deliverables: Final deliverables do not need error handling.
+- Tests: Write tests in advance, confirm that they pass, and then refactor as needed.
 
-### Worktree の方針
+### Worktree Policy
 
-- 既定ブランチ: 現在の checkout が `main` またはリポジトリの default branch である場合、リポジトリ管理下のファイルに対しては読み取り専用として扱ってください。
-- 事前確認: リポジトリ管理下のファイルを変更する可能性があるタスクに入る前に、現在の branch / worktree を最初に確認してください。
-- 編集前: `main` または default branch にいる場合は、worktree が clean でも、編集前に task-specific な新しい worktree を作成するか、そこへ移動してください。
-- 作成手順: worktree の作成には [`gwq`](https://github.com/d-kuro/gwq) を使ってください。default branch の checkout で `gwq add -b <task-branch>` を実行して作成し、`cd "$(gwq get <task-branch>)"` で移動してから編集を始めてください。`gwq add [branch] [path]` の第 2 引数は作成先 path なので、base ref のつもりで `origin/main` などを渡してはいけません。作成元を最新の `origin/main` に合わせる必要がある場合は、先に `git fetch origin main` し、worktree へ移動してから `git merge --ff-only origin/main` を実行してください。`gwq` が使えない環境でのみ `git worktree add` にフォールバックしてください。
-- 調査: 読み取り専用の調査は、現在の checkout のままで構いません。
-- 再利用条件: 現在の checkout を変更系の作業で再利用してよいのは、ユーザが明示的にそこで作業するよう求めた場合、またはこのタスク専用の non-default branch worktree にすでにいる場合だけです。
-- ローカル変更: 関係のないローカル変更がある場合は、そのタスクに混ぜないでください。別の worktree を使い、task-relevant files だけを持ち込んでください。
-- 優先順位: このルールは、現在の checkout が dirty な場合にだけ別 worktree を要求する、より弱いデフォルトより優先されます。
+- Default branch: When the current checkout is `main` or the repository's default branch, treat repository-tracked files as read-only.
+- Preflight check: Before beginning work that could modify repository-tracked files, first check the current branch and worktree.
+- Before editing: If you are on `main` or the default branch, create or move to a new task-specific worktree before editing, even if the worktree is clean.
+- Creation procedure: Use [`gwq`](https://github.com/d-kuro/gwq) to create worktrees. From the default-branch checkout, run `gwq add -b <task-branch>`, then move to it with `cd "$(gwq get <task-branch>)"` before editing. In `gwq add [branch] [path]`, the second argument is the destination path, so do not pass `origin/main` or another base ref there. If the worktree must start from the latest `origin/main`, run `git fetch origin main` first, move to the worktree, and then run `git merge --ff-only origin/main`. Fall back to `git worktree add` only when `gwq` is unavailable.
+- Investigation: Read-only investigation may remain in the current checkout.
+- Reuse conditions: Reuse the current checkout for modifications only when the user explicitly asks you to work there or it is already a task-specific, non-default-branch worktree.
+- Local changes: Do not mix unrelated local changes into the task. Use another worktree and bring in only task-relevant files.
+- Priority: This rule takes precedence over weaker defaults that require a separate worktree only when the current checkout is dirty.
 
-## Plan の具体性
+## Plan Specificity
 
-- 適用場面: コーディング、設定変更、CLI/API 変更、データフロー変更、テスト追加など、リポジトリ配下の変更を伴う plan では、抽象方針だけで終わらせてはいけません。実装担当がそのまま着手できる具体案まで示してください。
-- 必須項目: 最終 plan には、少なくとも以下を必ず含めてください。
-  - 変更対象のディレクトリ・ファイルパス
-  - 追加・編集・削除する関数、クラス、設定キー、CLI 引数、公開 API
-  - 各ファイルで何をどう変えるか
-  - 必要なテストファイル、追加するテストケース、確認する assertion の要点
-  - 実装上の前提、採用するデフォルト、未確定事項
-- 期待する粒度: 実装担当が追加の設計判断をほぼせずに着手できる粒度を必須とします。関数名、型、設定キー、CLI、データフロー、削除対象、差分の方向性まで明記してください。
-- コード具体性: 実装を伴う plan では、重要な変更箇所について関数シグネチャ案、疑似コード、または短いコードスニペットを必ず含めてください。必要なら 5〜20 行程度のコード断片で示してください。
-- 特に必須なケース: 並列化、具体 API の置換、データ変換パイプライン、状態管理、非同期化、スキーマ変更のように実装判断が増える plan では、採用する API、処理の流れ、関数骨格のいずれかが分かる具体案を必ず記載してください。
-- ファイル単位の書き方: `どのファイルのどのシンボルをどう変えるか` が伝わる粒度で書いてください。たとえば `src/foo/bar.py` の `build_dataset()` を map ベースの処理へ置き換える、`tests/test_bar.py` に同値性を確認するテストを追加する、のようにファイル単位・シンボル単位で記載してください。
-- 未完成条件: 上記の必須項目が欠けている plan は未完成として扱ってください。未完成の plan を最終 plan として提示してはいけません。
-- 不明点対応: 重要な前提が足りない場合は勝手に広げず、曖昧な点だけ短く確認してください。ただし、リポジトリを読めば分かることは質問せず、先に探索してください。
-- 仮定の扱い: 回答を待たずに進める場合は、「Assumptions」または「前提」として明示し、その仮定が実装へどう影響するかを書いてください。
+- Applicability: For plans involving repository changes, such as coding, configuration changes, CLI or API changes, data-flow changes, or new tests, do not stop at an abstract approach. Provide a concrete proposal that an implementer can start directly.
+- Required items: The final plan must include at least the following:
+  - Directories and file paths to change
+  - Functions, classes, configuration keys, CLI arguments, and public APIs to add, edit, or delete
+  - What to change in each file and how
+  - Required test files, test cases to add, and the essential assertions to verify
+  - Implementation assumptions, defaults to adopt, and unresolved questions
+- Expected granularity: Provide enough detail that an implementer can begin with almost no additional design decisions. Specify function names, types, configuration keys, CLI, data flow, removal targets, and the direction of the changes.
+- Code specificity: For important implementation changes, always include a proposed function signature, pseudocode, or short code snippet. Use a roughly 5–20 line fragment when useful.
+- Especially required cases: For plans that introduce more implementation decisions, such as parallelization, replacing a concrete API, a data-transformation pipeline, state management, asynchrony, or schema changes, always provide a concrete proposal that identifies the chosen API, processing flow, or function skeleton.
+- Per-file writing: Describe the work at a level that conveys which symbol in which file will change and how. For example, replace `build_dataset()` in `src/foo/bar.py` with map-based processing, or add equivalence tests to `tests/test_bar.py`.
+- Incomplete plans: Treat a plan that lacks any of the required items above as incomplete. Do not present an incomplete plan as the final plan.
+- Handling unknowns: If an important assumption is missing, do not expand the scope on your own; ask only about the ambiguity. However, do not ask about facts that can be learned by reading the repository; investigate first.
+- Handling assumptions: If you proceed without waiting for a response, state the assumptions under “Assumptions” or “Premises” and explain how they affect the implementation.
 
-## 未コミット差分の保護
+## Protecting Uncommitted Changes
 
-- 未コミット差分の扱い: 作業中に見つけた未コミット差分は、原則としてユーザーまたは並行 agent の作業として扱ってください。自分が作ったと明確に証明できない差分を、明示的な許可なしに戻してはいけません。
-- 差分判断: 未コミット差分を PR スコープから外す、戻す、または不要と判断する前に、必ず before / after を読み、なぜその変更が入ったのかを本文やコードの文脈から判断してください。ファイル名や直近タスクだけで「別件」と決めつけないでください。
-- 改善の扱い: before / after を読んで品質改善や指摘対応だと分かる差分は、勝手に戻さず、PR に含めるかどうかをユーザーへ確認してください。特に文章修正では、1 行差分でも情報順、引用位置、導入の自然さを改善している場合があります。
-- PR スコープ調整: PR に含めたくない未コミット差分がある場合は、差分を戻すのではなく、stage 対象を限定する、別 worktree を使う、またはユーザーへ確認してください。
-- 誤操作時: 未コミット差分を誤って消した場合は、すぐにユーザーへ報告し、直前の diff、エディタ履歴、シェル出力、stash、subagent 出力などから復元を試みてください。復元前に追加の上書きをしないでください。
+- Treatment of uncommitted changes: Treat uncommitted changes discovered during work as the user's or a concurrent agent's work by default. Do not revert a change unless you can clearly prove that you made it and have explicit permission.
+- Assessing changes: Before excluding an uncommitted change from PR scope, reverting it, or deciding it is unnecessary, read its before and after states and use the prose or code context to determine why it was made. Do not assume it is unrelated from the filename or the most recent task alone.
+- Improvements: If the before and after states show a quality improvement or a response to feedback, do not revert it on your own; ask the user whether to include it in the PR. In particular, even a one-line writing change may improve information order, citation placement, or the naturalness of the introduction.
+- Adjusting PR scope: When you do not want to include an uncommitted change in a PR, do not revert it. Instead, limit what you stage, use another worktree, or ask the user.
+- Accidental operations: If you accidentally delete uncommitted changes, report it to the user immediately and attempt recovery from the preceding diff, editor history, shell output, stash, or subagent output. Do not perform additional overwrites before recovery.

--- a/home/dot_config/exact_agents/skills/cgd-dev-identity/SKILL.md
+++ b/home/dot_config/exact_agents/skills/cgd-dev-identity/SKILL.md
@@ -1,43 +1,43 @@
 ---
 name: cgd-dev-identity
-description: creative-graphic-design org のリポジトリ(design-generators など)で git commit、push、PR 作成・更新、issue / PR コメント、label / milestone、ユーザー指示による merge 実行などの GitHub write を行うときは、必ずこの skill に従って machine user creative-graphic-design-dev として実行する。「bot として push」「dev アカウントで」「creative-graphic-design-dev で」と言われたときはもちろん、org 配下リポジトリへの write 作業を始めるとき全般で、明示指定がなくても必ず使う。
+description: Use this skill for all GitHub write operations in creative-graphic-design organization repositories (such as design-generators), including git commits and pushes, PR creation and updates, issue and PR comments, labels, milestones, and user-requested merges. Perform them as the creative-graphic-design-dev machine user. Use it both when the user explicitly requests the bot or dev account and whenever beginning write work in an organization repository without an explicit request.
 ---
 
 # CGD Dev Identity
 
 ## Overview
 
-creative-graphic-design org のリポジトリに対する git / gh の write 操作は、個人アカウントではなく machine user `creative-graphic-design-dev`(user id 176740601)として実行する。PR が bot 名義になることで、人間のアカウントがその PR を正式にレビュー・承認できる。GitHub では自分の PR を自分では承認できないため、個人アカウント名義で PR を作るとレビューフローが成立しない。
+Perform git and gh write operations for creative-graphic-design organization repositories as the `creative-graphic-design-dev` machine user (user ID 176740601), not a personal account. A bot-authored PR lets a human account formally review and approve it. Because GitHub does not permit users to approve their own PRs, creating a PR with a personal account would prevent the review flow from working.
 
 ## Setup
 
-write 操作を始める前に、作業シェルと worktree で以下を確認する。失敗してから調べるのではなく、開始手順として実行する。
+Before starting write operations, perform the following checks in the working shell and worktree. Run them as a starting procedure rather than investigating only after a failure.
 
-1. gh / git credential を使う write 系コマンドには、per-command で bot トークンを渡す。トークンは全シェルに `CGD_DEV_GH_TOKEN` として配布済み(zshenv_private 管理):
+1. Pass the bot token to each write command that uses gh or git credentials. The token is distributed to all shells as `CGD_DEV_GH_TOKEN` (managed by zshenv_private):
 
    ```bash
    GH_TOKEN="$CGD_DEV_GH_TOKEN" gh pr create ...
    GH_TOKEN="$CGD_DEV_GH_TOKEN" git push
    ```
 
-   同じ shell が持続する手動作業では、以下を省略記法として使ってよい:
+   For manual work in a persistent shell, you may use the following shorthand:
 
    ```bash
    export GH_TOKEN="$CGD_DEV_GH_TOKEN"
    ```
 
-   Claude Code の shell tool のようにコマンドごとに新しい shell が立つ環境では `export` は次のコマンドへ持続しないため、per-command prefix を正とする。
+   In environments that start a new shell for each command, such as Claude Code's shell tool, `export` does not persist to the next command. Use the per-command prefix as the canonical approach.
 
-2. GitHub identity と org repository の push 権限を確認する。`gh api user` はログイン中のアカウント確認にしかならず、org リソースへのアクセス可否は検証できない:
+2. Verify the GitHub identity and push permission for the organization repository. `gh api user` only confirms the logged-in account and cannot verify access to organization resources:
 
    ```bash
    GH_TOKEN="$CGD_DEV_GH_TOKEN" gh api user --jq .login
    GH_TOKEN="$CGD_DEV_GH_TOKEN" gh api repos/creative-graphic-design/<repo> --jq .permissions.push
    ```
 
-   1 つ目のコマンドで `creative-graphic-design-dev`、2 つ目のコマンドで `true` が返らなければ write を始めない。
+   Do not start write operations unless the first command returns `creative-graphic-design-dev` and the second returns `true`.
 
-3. commit author は commit 実行時に per-command で bot にする:
+3. Set the commit author to the bot for each commit command:
 
    ```bash
    git -c user.name=creative-graphic-design-dev \
@@ -45,24 +45,24 @@ write 操作を始める前に、作業シェルと worktree で以下を確認�
        commit ...
    ```
 
-   linked worktree で `git config user.name/email` を使うと共有 `.git/config` に書き込まれ、main checkout や並行 worktree の author まで bot に変わるため使わない。
+   Do not use `git config user.name/email` in a linked worktree: it writes to the shared `.git/config` and changes the author for the main checkout and concurrent worktrees as well.
 
-4. push は HTTPS で行う(この環境の SSH は proxy を通らない)。explicit pushurl を設定する:
+4. Push over HTTPS because SSH does not use the proxy in this environment. Set an explicit push URL:
 
    ```bash
    git remote set-url --push origin https://github.com/creative-graphic-design/<repo>
    ```
 
-`GH_TOKEN` は同じコマンド環境の gh と git credential helper の両方に効く。credential helper は username `x-access-token` でトークンを返す。
+`GH_TOKEN` applies to both gh and the git credential helper in the same command environment. The credential helper returns the token with the username `x-access-token`.
 
 ## Scope
 
-- 対象は creative-graphic-design org のリポジトリのみ。他 org・個人リポジトリではこの skill を使わず、通常の認証のまま作業する。トークンは fine-grained PAT で org 内の許可リポジトリにしか効かないため、対象外リポジトリで `GH_TOKEN` を渡したままにすると認証エラーになる。
-- coding agent が行う org リポジトリへの write はすべて bot 名義にする。対象には commit、push、PR 作成・更新、PR への返信、issue コメント、label、milestone、およびユーザー指示による merge の実行を含む。
-- 人間(`shunk031`)に残るのは GitHub UI 上での PR approve と merge 判断のみ。bot で PR を approve しない。
+- This skill applies only to creative-graphic-design organization repositories. Do not use it for other organizations or personal repositories; use normal authentication there. The token is a fine-grained PAT that works only for authorized repositories in the organization, so passing `GH_TOKEN` in an out-of-scope repository causes an authentication error.
+- Attribute every coding-agent write to an organization repository to the bot. This includes commits, pushes, PR creation and updates, PR replies, issue comments, labels, milestones, and user-requested merges.
+- The human (`shunk031`) retains only PR approval in the GitHub UI and the decision to merge. Do not approve PRs as the bot.
 
 ## Troubleshooting
 
-- org リソースのエンドポイント(repos API や push)で 403 が返り、「organization forbids ... lifetime greater than 366 days」と表示される場合、org ポリシーによりトークンの有効期限が 1 年を超えている。`gh api user` はこの状態でも成功するため判定に使えない。トークンの expiration を 1 年以内に変更すれば同じ値のまま通る。
-- トークンが失効した場合は、creative-graphic-design-dev アカウントで fine-grained PAT(Contents / Pull requests / Issues / Workflows を Read and write、対象リポジトリ限定)を再発行し、zshenv_private の `CGD_DEV_GH_TOKEN` 行を更新する。
-- 新しいリポジトリを対象に加える場合は、PAT の Repository access にそのリポジトリを追加する必要がある。トークン再発行は不要で、設定変更のみでよい。
+- If an organization-resource endpoint (the repos API or a push) returns 403 with “organization forbids ... lifetime greater than 366 days,” organization policy requires the token lifetime to be no longer than one year. `gh api user` still succeeds in this state, so do not use it to diagnose the issue. Change the token expiration to within one year; the token value itself can remain the same.
+- If the token expires, reissue a fine-grained PAT as the creative-graphic-design-dev account with Contents, Pull requests, Issues, and Workflows set to Read and write and access limited to the target repositories. Then update the `CGD_DEV_GH_TOKEN` line in zshenv_private.
+- To add a repository to the scope, add it under the PAT's Repository access. Reissuing the token is unnecessary; changing its configuration is sufficient.

--- a/home/dot_config/exact_agents/skills/gh-comment-attach-files/SKILL.md
+++ b/home/dot_config/exact_agents/skills/gh-comment-attach-files/SKILL.md
@@ -7,7 +7,7 @@ description: Attach local files to a GitHub issue or pull request comment via Pl
 
 ## Read Acknowledgement
 
-- After reading this skill, say: `🐙 私は gh-comment-attach-files を読みました。`
+- After reading this skill, say: `🐙 I read gh-comment-attach-files.`
 
 ## When To Use
 

--- a/home/dot_config/exact_agents/skills/python-uv-workflow/SKILL.md
+++ b/home/dot_config/exact_agents/skills/python-uv-workflow/SKILL.md
@@ -11,7 +11,7 @@ Use this workflow to keep Python implementation and refactoring aligned with rep
 
 ## Read Acknowledgement
 
-- After reading this skill, say: `🐍 私は python-uv-workflow を読みました。`
+- After reading this skill, say: `🐍 I read python-uv-workflow.`
 
 ## Workflow
 

--- a/home/dot_config/exact_agents/skills/setup-agent-docs/SKILL.md
+++ b/home/dot_config/exact_agents/skills/setup-agent-docs/SKILL.md
@@ -1,43 +1,43 @@
 ---
 name: setup-agent-docs
-description: リポジトリを coding agent 対応にするときの agent ドキュメント配線パターン(AGENTS.md を source of truth にし、CLAUDE.md は symlink にする)。新しいリポジトリのエージェント対応、coding agent ready 化、AGENTS.md / CLAUDE.md の新規作成・変換・整理、repo-local skill の設置、「エージェント向けドキュメントを整備して」という依頼のときに必ず使う。CLAUDE.md だけ・AGENTS.md だけを作ろうとしている場合もこの skill で配線を確認する。
+description: Guidance-document wiring pattern for making a repository ready for coding agents: use AGENTS.md as the source of truth and make CLAUDE.md a symlink. Use this skill for new repository agent setup, making a repository coding-agent ready, creating, converting, or organizing AGENTS.md and CLAUDE.md, adding repo-local skills, or requests to prepare agent documentation. Also use it to verify the wiring when creating only CLAUDE.md or only AGENTS.md.
 ---
 
 # setup-agent-docs
 
-リポジトリに agent 向けドキュメントを配線するときの標準パターン。複数の coding agent が同じ実体を読み、重複や乖離が生まれないようにする。
+The standard pattern for wiring agent documentation in a repository. It ensures that multiple coding agents read the same source and prevents duplication and drift.
 
-## 配線ルール
+## Wiring Rules
 
-- AGENTS.md が source of truth: リポジトリ直下に `AGENTS.md` を置き、agent 向けの規約・手順はすべてここに書く。冒頭に読了マーカーを置く:
+- AGENTS.md as the source of truth: Place `AGENTS.md` at the repository root and write all agent conventions and procedures there. Put a read acknowledgement marker at the beginning:
 
   ```markdown
   > [!NOTE]
   > After reading this AGENTS.md, say: 🤖 I read the AGENTS.md for <owner>/<repo>.
   ```
 
-- リポジトリ固有の内容だけ書く: グローバル `~/.agents/AGENTS.md` に既にあるルール(uv 必須、worktree 方針、例外処理方針など)は再掲しない。再掲すると更新時に乖離する。
+- Write only repository-specific content: Do not repeat rules already in global `~/.agents/AGENTS.md`, such as mandatory uv usage, worktree policy, or error-handling policy. Repeating them causes drift when they are updated.
 
-- CLAUDE.md は AGENTS.md への相対 symlink にする: `@AGENTS.md` と書いた通常ファイルにはしない。
+- Make CLAUDE.md a relative symlink to AGENTS.md: Do not make it a regular file containing `@AGENTS.md`.
 
   ```shell
   ln -s AGENTS.md CLAUDE.md
-  git add CLAUDE.md   # mode 120000 で追跡されることを確認: git ls-files -s CLAUDE.md
+  git add CLAUDE.md   # Verify mode 120000 with: git ls-files -s CLAUDE.md
   ```
 
-  symlink にする理由: Claude Code・その他ツールが同一実体を読むため、import 記法の対応差やコピー乖離が発生しない。
+  Why use a symlink: Claude Code and other tools read the same source, preventing differences in import-syntax support and copied-content drift.
 
-- repo-local skill の配線: skill の source of truth は `.agents/skills/<name>/SKILL.md` に置き、`.claude/skills` は相対 symlink としてコミットする。
+- Wiring repo-local skills: Place each skill's source of truth at `.agents/skills/<name>/SKILL.md` and commit `.claude/skills` as a relative symlink.
 
   ```shell
   mkdir -p .agents/skills
   ln -s ../.agents/skills .claude/skills
   ```
 
-  Claude の skill 機構を持たない coding agent でも、SKILL.md はただの Markdown なので、AGENTS.md から `.agents/skills/<name>/SKILL.md` のパス参照で同じ手順を辿らせる。
+  Even coding agents without Claude's skill mechanism can follow the same procedure because SKILL.md is ordinary Markdown; reference `.agents/skills/<name>/SKILL.md` from AGENTS.md.
 
-- private 境界: 社内ネットワーク、起動プロファイル、proxy 事情などの private 情報はリポジトリに一切書かない。必要な箇所には「環境固有の設定は `~/.agents/AGENTS-private.md` の該当節を参照」というポインタだけを置く。グローバル AGENTS.md が AGENTS-private.md の読み込みを指示しているため、ポインタだけで agent は辿れる。
+- Private boundary: Never write private information, such as internal networks, launch profiles, or proxy details, in the repository. Where needed, add only a pointer such as “For environment-specific settings, refer to the relevant section of `~/.agents/AGENTS-private.md`.” Because the global AGENTS.md instructs agents to read AGENTS-private.md, the pointer is sufficient.
 
-## 参考実装
+## Reference Implementation
 
-https://github.com/haralab-uec/kitada-experiments — `AGENTS.md`、`CLAUDE.md`(symlink)、`.agents/skills/`、`.claude/skills`(symlink)の実例。
+https://github.com/haralab-uec/kitada-experiments — an example using `AGENTS.md`, `CLAUDE.md` (symlink), `.agents/skills/`, and `.claude/skills` (symlink).

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -38,13 +38,13 @@ readonly GITIGNORE_PATH="./.gitignore"
 
     run grep -F '> After reading this `AGENTS.md`, say: `🤖 I read ~/.codex/AGENTS.md.`' "${CODEX_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '`~/.agents/AGENTS.md` を最初に読み' "${CODEX_AGENTS_PATH}"
+    run grep -F 'Shared instructions: Read `~/.agents/AGENTS.md` first' "${CODEX_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`~/.agents/AGENTS-private.md`' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F '`~/.agents/AGENTS-private.md`' "${CODEX_AGENTS_PATH}"
     [ "${status}" -ne 0 ]
-    run grep -F '## Codex 固有の委譲' "${CODEX_AGENTS_PATH}"
+    run grep -F '## Codex-Specific Delegation' "${CODEX_AGENTS_PATH}"
     [ "${status}" -ne 0 ]
     run grep -F 'native subagents' "${CODEX_AGENTS_PATH}"
     [ "${status}" -ne 0 ]
@@ -53,7 +53,7 @@ readonly GITIGNORE_PATH="./.gitignore"
 }
 
 @test "[common] shared guidance defines highest-priority implementation principles" {
-    run grep -F '## 最重要の実装原則' "${SHARED_AGENTS_PATH}"
+    run grep -F '## Most Important Implementation Principles' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
     run grep -F 'These principles take precedence over other implementation guidance in this file.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
@@ -65,58 +65,58 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F 'Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '後方互換性は気にしないでください' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not worry about backward compatibility.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -ne 0 ]
 }
 
 @test "[common] shared guidance requires concrete coding plans" {
-    run grep -F '## Plan の具体性' "${SHARED_AGENTS_PATH}"
+    run grep -F '## Plan Specificity' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '変更対象のディレクトリ・ファイルパス' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Directories and file paths to change' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '追加・編集・削除する関数、クラス、設定キー、CLI 引数、公開 API' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Functions, classes, configuration keys, CLI arguments, and public APIs to add, edit, or delete' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '各ファイルで何をどう変えるか' "${SHARED_AGENTS_PATH}"
+    run grep -F 'What to change in each file and how' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '確認する assertion の要点' "${SHARED_AGENTS_PATH}"
+    run grep -F 'the essential assertions to verify' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '関数シグネチャ案、疑似コード、または短いコードスニペットを必ず含めてください' "${SHARED_AGENTS_PATH}"
+    run grep -F 'always include a proposed function signature, pseudocode, or short code snippet' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '実装判断が増える plan では' "${SHARED_AGENTS_PATH}"
+    run grep -F 'For plans that introduce more implementation decisions' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '`どのファイルのどのシンボルをどう変えるか` が伝わる粒度で書いてください' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Describe the work at a level that conveys which symbol in which file will change and how.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '未完成の plan を最終 plan として提示してはいけません' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not present an incomplete plan as the final plan.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '「Assumptions」または「前提」として明示し' "${SHARED_AGENTS_PATH}"
+    run grep -F 'state the assumptions under “Assumptions” or “Premises”' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 
 @test "[common] shared guidance protects uncommitted diffs" {
-    run grep -F '## 未コミット差分の保護' "${SHARED_AGENTS_PATH}"
+    run grep -F '## Protecting Uncommitted Changes' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '自分が作ったと明確に証明できない差分を、明示的な許可なしに戻してはいけません' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not revert a change unless you can clearly prove that you made it and have explicit permission.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '差分を戻すのではなく、stage 対象を限定する、別 worktree を使う、またはユーザーへ確認してください' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Instead, limit what you stage, use another worktree, or ask the user.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 
 @test "[common] shared guidance prevents gwq base-ref misuse" {
-    run grep -F 'base ref のつもりで `origin/main` などを渡してはいけません' "${SHARED_AGENTS_PATH}"
+    run grep -F 'do not pass `origin/main` or another base ref there' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F 'worktree へ移動してから `git merge --ff-only origin/main` を実行してください' "${SHARED_AGENTS_PATH}"
+    run grep -F 'move to the worktree, and then run `git merge --ff-only origin/main`' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 
@@ -138,26 +138,26 @@ readonly GITIGNORE_PATH="./.gitignore"
 }
 
 @test "[common] shared guidance defines shared agent wrapper policy" {
-    run grep -F '## エージェント設定' "${SHARED_AGENTS_PATH}"
+    run grep -F '## Agent Configuration' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '複数ツールで使う subagent / custom agent の長い共通指示は `~/.agents/agents/<name>.md` を source of truth にしてください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Keep lengthy shared instructions for subagents or custom agents used by multiple tools in `~/.agents/agents/<name>.md` as the source of truth.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'Claude Code 用の `~/.claude/agents/<name>.md` は YAML frontmatter を保持し、本文では `~/.agents/agents/<name>.md` を最初に読むよう明示してください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Preserve YAML frontmatter in `~/.claude/agents/<name>.md` for Claude Code and explicitly instruct it in the body to read `~/.agents/agents/<name>.md` first.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '同じ長文指示を wrapper にコピーしないでください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not copy the same lengthy instructions into wrappers.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'Markdown を Python などでパースして TOML / Markdown を生成する仕組みは、明示的に必要になるまで追加しないでください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not add a mechanism that parses Markdown with Python or similar tooling to generate TOML or Markdown until it is explicitly needed.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 
 @test "[common] shared guidance defines tool-neutral native delegation policy" {
-    run grep -F '## 実装タスクの委譲' "${SHARED_AGENTS_PATH}"
+    run grep -F '## Delegating Implementation Tasks' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F '利用中の coding agent が native multi-agent 機能を提供し、タスクを独立した単位に分けられる場合' "${SHARED_AGENTS_PATH}"
+    run grep -F 'When the coding agent in use provides native multi-agent capabilities and the task can be divided into independent units' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'Claude Code の agent teams や Codex の subagents など、各 tool の native 機能を使ってください。' "${SHARED_AGENTS_PATH}"
+    run grep -F "Use each tool's native capabilities, such as Claude Code agent teams or Codex subagents." "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'subagent が使うモデルや起動方法などの環境固有設定は、このファイルには書かず `~/.agents/AGENTS-private.md` または tool 固有 entrypoint を参照してください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not put environment-specific configuration, such as subagent models or launch methods, in this file.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 
@@ -251,13 +251,13 @@ readonly GITIGNORE_PATH="./.gitignore"
 }
 
 @test "[common] shared guidance rejects inline multi-line GitHub bodies" {
-    run grep -F 'GitHub issue body / PR description / PR comment のような multi-line Markdown は、必ず一時 Markdown file を single-quoted heredoc で作り、`gh ... --body-file <file>` で投稿・更新してください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'For multi-line Markdown such as a GitHub issue body, PR description, or PR comment, always create a temporary Markdown file with a single-quoted heredoc and post or update it using `gh ... --body-file <file>`.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F '`gh ... --body "...\n..."` や shell-escaped multi-line body の直渡しは、literal `\n` が公開されるため使わないでください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'Do not pass `gh ... --body "...\n..."` or a shell-escaped multi-line body directly; literal `\n` can be published.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 
-    run grep -F 'literal escaped newlines (`\n`)、local absolute paths such as `/Users/`、期待見出しの欠落を検出してから完了報告してください。' "${SHARED_AGENTS_PATH}"
+    run grep -F 'detect literal escaped newlines (`\n`), local absolute paths such as `/Users/`, and missing expected headings.' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## Why

Keep the shared agent guidance accessible to English-speaking coding agents while preserving its existing operational rules.

## What Changed

Translated the public agent entrypoints, Claude and Gemini guidance, selected shared skills, and their installation-guidance assertions into English.

## Validation

Check the committed diff for whitespace errors.

```shell
git diff --check HEAD^ HEAD
```

Confirm the selected guidance files contain no Japanese text.

```shell
! rg -n '[ぁ-んァ-ン一-龯]' home/dot_config/exact_agents/AGENTS.md home/dot_config/codex/AGENTS.md home/dot_config/claude/CLAUDE.md home/dot_config/antigravity-cli/GEMINI.md home/dot_config/claude/rules/ask-user-question.md home/dot_config/claude/rules/gpu.md home/dot_config/claude/rules/latex.md home/dot_config/claude/rules/python.md home/dot_config/exact_agents/skills/cgd-dev-identity/SKILL.md home/dot_config/exact_agents/skills/gh-comment-attach-files/SKILL.md home/dot_config/exact_agents/skills/python-uv-workflow/SKILL.md home/dot_config/exact_agents/skills/setup-agent-docs/SKILL.md tests/install/common/agents_guidance.bats
```

Local Bats was not run, per repository policy; GitHub Actions provides that validation.
