### PR TITLE
fix(renovate): track agent tooling releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,32 +35,25 @@
     },
     {
       "matchManagers": ["mise"],
-      "matchPackageNames": [
-        "npm:@anthropic-ai/claude-code",
-        "npm:@openai/codex"
-      ],
-      "groupName": "agent CLIs"
+      "groupName": "mise tools"
     },
     {
       "matchManagers": ["mise"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
       "matchUpdateTypes": ["minor", "major"],
       "groupName": "Python runtime"
     },
     {
       "matchManagers": ["mise"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
       "matchUpdateTypes": ["patch"],
       "enabled": false
     },
     {
       "matchManagers": ["mise"],
-      "groupName": "mise tools",
-      "matchPackageNames": [
-        "!python",
-        "!npm:@anthropic-ai/claude-code",
-        "!npm:@openai/codex"
-      ]
+      "matchDepNames": ["/(claude-code|codex|herdr)$/"],
+      "groupName": "agent tooling",
+      "minimumReleaseAge": "0 days"
     }
   ]
 }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 18 * * 0" # At 18:00 on Sunday.
+    - cron: "0 18 * * *" # At 18:00 every day.
 
 permissions:
   contents: read

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+readonly RENOVATE_CONFIG_PATH="./.github/renovate.json"
+readonly MISE_CONFIG_PATH="./home/dot_mise/config.toml"
+
+@test "[common] Renovate groups agent tooling independently of mise backends" {
+    run python3 - "${RENOVATE_CONFIG_PATH}" "${MISE_CONFIG_PATH}" << 'PYTHON'
+import json
+import re
+import sys
+from pathlib import Path
+
+renovate_path, mise_path = map(Path, sys.argv[1:])
+renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
+mise_text = mise_path.read_text(encoding="utf-8")
+renovate_text = json.dumps(renovate)
+
+logical_names = {"claude-code", "codex", "herdr"}
+configured_dep_names = {
+    match.group("name")
+    for match in re.finditer(
+        r'^\s*"?(?P<name>[^"\s=]+)"?\s*=\s*(?:"|\{)',
+        mise_text,
+        re.MULTILINE,
+    )
+    if match.group("name").split("/")[-1] in logical_names
+}
+configured_agents = {name.split("/")[-1]: name for name in configured_dep_names}
+
+rules = renovate["packageRules"]
+agent_rule_index, agent_rule = next(
+    (index, rule)
+    for index, rule in enumerate(rules)
+    if rule.get("groupName") == "agent tooling"
+)
+mise_rule_index = next(
+    index
+    for index, rule in enumerate(rules)
+    if rule.get("groupName") == "mise tools"
+)
+
+assert {name.split("/")[-1] for name in configured_dep_names} == logical_names
+assert configured_agents["claude-code"].startswith("aqua:")
+assert configured_agents["codex"].startswith("aqua:")
+assert agent_rule["matchManagers"] == ["mise"]
+assert agent_rule["minimumReleaseAge"] == "0 days"
+assert mise_rule_index < agent_rule_index
+
+patterns = agent_rule["matchDepNames"]
+assert patterns and all(pattern.startswith("/") and pattern.endswith("/") for pattern in patterns)
+assert all(
+    any(re.search(pattern[1:-1], dep_name) for pattern in patterns)
+    for dep_name in configured_dep_names
+)
+assert not any(
+    backend in pattern
+    for pattern in patterns
+    for backend in ("aqua:", "npm:", "github:", "ubi:")
+)
+assert "matchPackageNames" not in agent_rule
+assert "npm:@anthropic-ai/claude-code" not in renovate_text
+assert "npm:@openai/codex" not in renovate_text
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Why

Renovate's agent CLI rule was tied to npm-qualified package names, so the current aqua-managed Claude Code update fell into the generic mise tools group. Herdr was not included, and the weekly workflow delayed release tracking further.

## What Changed

- Match Herdr, Claude Code, and Codex by backend-independent mise dependency-name suffixes and group them as `agent tooling`.
- Let that later specialized rule override the generic mise group and bypass the repository-wide seven-day release age.
- Keep Claude Code and Codex on their current aqua definitions, with regression coverage that rejects stale npm-qualified rule names and guards backend migration behavior.
- Run the Renovate workflow daily instead of weekly.

## Validation

Validate the Renovate configuration against the current schema.

```shell
npx --yes --package renovate@latest renovate-config-validator .github/renovate.json
```

Check JSON and workflow YAML syntax.

```shell
python3 -m json.tool .github/renovate.json >/dev/null
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/renovate.yaml", aliases: true)'
```

Check shell formatting for the new Bats regression test.

```shell
shfmt -d -i 4 -sr tests/install/common/renovate.bats
```

Run Renovate locally in full dry-run mode to verify mise extracts `herdr`, `aqua:anthropics/claude-code`, and `aqua:openai/codex` as dependency names.

```shell
LOG_LEVEL=debug RENOVATE_CONFIG_FILE=.github/renovate.json RENOVATE_DRY_RUN=full npx --yes --package renovate@latest renovate --platform=local
```

The Bats suite is intentionally left to GitHub Actions per repository policy.
