### PR TITLE
fix(renovate): extract Codex release versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,9 +51,18 @@
     },
     {
       "matchManagers": ["mise"],
-      "matchDepNames": ["/(claude-code|codex|herdr)$/"],
+      "matchDepNames": [
+        "herdr",
+        "aqua:anthropics/claude-code",
+        "aqua:openai/codex"
+      ],
       "groupName": "agent tooling",
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchDepNames": ["aqua:openai/codex"],
+      "extractVersion": "^rust-v?(?<version>.+)$"
     }
   ]
 }

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -3,7 +3,7 @@
 readonly RENOVATE_CONFIG_PATH="./.github/renovate.json"
 readonly MISE_CONFIG_PATH="./home/dot_mise/config.toml"
 
-@test "[common] Renovate groups agent tooling independently of mise backends" {
+@test "[common] Renovate tracks the configured agent dependencies" {
     run python3 - "${RENOVATE_CONFIG_PATH}" "${MISE_CONFIG_PATH}" << 'PYTHON'
 import json
 import re
@@ -15,7 +15,12 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-logical_names = {"claude-code", "codex", "herdr"}
+expected_dep_names = [
+    "herdr",
+    "aqua:anthropics/claude-code",
+    "aqua:openai/codex",
+]
+logical_names = {name.split("/")[-1] for name in expected_dep_names}
 configured_dep_names = {
     match.group("name")
     for match in re.finditer(
@@ -38,28 +43,32 @@ mise_rule_index = next(
     for index, rule in enumerate(rules)
     if rule.get("groupName") == "mise tools"
 )
+codex_rule = next(
+    rule
+    for rule in rules
+    if rule.get("matchManagers") == ["mise"]
+    and rule.get("matchDepNames") == ["aqua:openai/codex"]
+    and "extractVersion" in rule
+)
 
-assert {name.split("/")[-1] for name in configured_dep_names} == logical_names
+assert configured_dep_names == set(expected_dep_names)
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
 assert agent_rule["matchManagers"] == ["mise"]
+assert agent_rule["matchDepNames"] == expected_dep_names
 assert agent_rule["minimumReleaseAge"] == "0 days"
 assert mise_rule_index < agent_rule_index
 
-patterns = agent_rule["matchDepNames"]
-assert patterns and all(pattern.startswith("/") and pattern.endswith("/") for pattern in patterns)
-assert all(
-    any(re.search(pattern[1:-1], dep_name) for pattern in patterns)
-    for dep_name in configured_dep_names
-)
-assert not any(
-    backend in pattern
-    for pattern in patterns
-    for backend in ("aqua:", "npm:", "github:", "ubi:")
-)
 assert "matchPackageNames" not in agent_rule
 assert "npm:@anthropic-ai/claude-code" not in renovate_text
 assert "npm:@openai/codex" not in renovate_text
+
+assert codex_rule["matchManagers"] == ["mise"]
+assert codex_rule["matchDepNames"] == ["aqua:openai/codex"]
+python_pattern = codex_rule["extractVersion"].replace("(?<version>", "(?P<version>")
+match = re.fullmatch(python_pattern, "rust-v0.146.0")
+assert match is not None
+assert match.group("version") == "0.146.0"
 PYTHON
 
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

Renovate's mise manager does not consume aqua-registry's `version_prefix: rust-` metadata for Codex. As a result, it ignored Codex's `rust-v0.146.0` tag while updating Claude Code and Herdr in the agent tooling group.

## What Changed

- Match the three configured agent dependencies by their exact mise dependency identifiers.
- Add a Codex-only extraction rule that converts `rust-v*` tags into versions Renovate can compare.
- Update regression coverage to keep Claude Code and Codex on aqua, reject the stale npm identifiers, synchronize configured dependency names with the grouping rule, and verify `rust-v0.146.0` extracts as `0.146.0`.

## Validation

Validate the Renovate configuration against the current schema.

```shell
npx --yes --package renovate@latest renovate-config-validator .github/renovate.json
```

Check JSON and workflow YAML syntax.

```shell
python3 -m json.tool .github/renovate.json >/dev/null
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/renovate.yaml", aliases: true)'
```

Check shell formatting for the Bats regression test.

```shell
shfmt -d -i 4 -sr tests/install/common/renovate.bats
```

Run Renovate locally in full dry-run mode with the candidate package rules. The result placed Claude Code, Codex `0.145.0 → 0.146.0`, and Herdr in `renovate/agent-tooling`.

```shell
RENOVATE_TOKEN="$(gh auth token)" RENOVATE_PLATFORM=github RENOVATE_REPOSITORIES=shunk031/dotfiles RENOVATE_DRY_RUN=full LOG_LEVEL=debug RENOVATE_CONFIG='<candidate package rules>' npx --yes --package renovate@latest renovate
```

The Bats suite is intentionally left to GitHub Actions per repository policy.
