### PR TITLE
fix(tests): allow Codex version updates

### DIFF
--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -326,9 +326,11 @@ EOF
     [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
 }
 
-@test "[common] Codex CLI is pinned and exempt from mise release age" {
-    run grep -F '"aqua:openai/codex" = "0.145.0"' "${MISE_CONFIG_SOURCE}"
-    [ "${status}" -eq 0 ]
+@test "[common] Codex CLI has a stable semver pin and is exempt from mise release age" {
+    local codex_version
+
+    codex_version="$(sed -nE 's/^[[:space:]]*"aqua:openai\/codex"[[:space:]]*=[[:space:]]*"([^"]+)"[[:space:]]*$/\1/p' "${MISE_CONFIG_SOURCE}")"
+    [[ "${codex_version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
 
     run grep -F '"aqua:openai/codex",' "${MISE_CONFIG_SOURCE}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

The Codex mise test hardcoded version `0.145.0`, so Renovate PR #586 failed CI after correctly updating Codex to `0.146.0`. That assertion would reject every future automated Codex pin bump.

## What Changed

- Extract the configured Codex version instead of comparing it with one release.
- Require an exact three-component numeric semver, rejecting floating values, ranges, and prereleases.
- Keep the assertion that Codex bypasses mise's minimum release age.

## Validation

Check shell formatting for the updated Bats test.

```shell
shfmt -d -i 4 -sr tests/install/common/mise.bats
```

Verify the current pin matches the stable semver constraint and representative floating/prerelease values do not.

```shell
codex_version="$(sed -nE 's/^[[:space:]]*"aqua:openai\/codex"[[:space:]]*=[[:space:]]*"([^"]+)"[[:space:]]*$/\1/p' home/dot_mise/config.toml)"
[[ "${codex_version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
! [[ 'latest' =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
! [[ '0.146.0-beta.1' =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
```

Inspect the patch for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

The Bats suite is intentionally left to GitHub Actions per repository policy.
