### PR TITLE
fix(renovate): track agent infrastructure releases immediately

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,7 +64,9 @@
       "matchDepNames": [
         "herdr",
         "aqua:anthropics/claude-code",
-        "aqua:openai/codex"
+        "aqua:google-antigravity/antigravity-cli",
+        "aqua:openai/codex",
+        "github:router-for-me/CLIProxyAPI"
       ],
       "groupName": "agent tooling",
       "minimumReleaseAge": "0 days"

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -50,7 +50,9 @@ renovate_text = json.dumps(renovate)
 expected_dep_names = [
     "herdr",
     "aqua:anthropics/claude-code",
+    "aqua:google-antigravity/antigravity-cli",
     "aqua:openai/codex",
+    "github:router-for-me/CLIProxyAPI",
 ]
 logical_names = {name.split("/")[-1] for name in expected_dep_names}
 configured_dep_names = {
@@ -85,7 +87,9 @@ codex_rule = next(
 
 assert configured_dep_names == set(expected_dep_names)
 assert configured_agents["claude-code"].startswith("aqua:")
+assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
+assert configured_agents["CLIProxyAPI"].startswith("github:")
 assert agent_rule["matchManagers"] == ["mise"]
 assert agent_rule["matchDepNames"] == expected_dep_names
 assert agent_rule["minimumReleaseAge"] == "0 days"


### PR DESCRIPTION
## Why

Antigravity CLI and CLIProxyAPI are part of the agent infrastructure, but Renovate currently leaves them in the general mise group with the repository-wide seven-day release delay. They should follow the same immediate grouped update policy as Herdr, Claude Code, and Codex.

## What Changed

- Add `aqua:google-antigravity/antigravity-cli` and `github:router-for-me/CLIProxyAPI` to the explicit `agent tooling` Renovate dependency list.
- Keep the group-level `minimumReleaseAge` at `0 days`.
- Synchronize the Renovate Bats expectations and assert that Antigravity remains on the Aqua backend while CLIProxyAPI remains on the GitHub backend.

## Validation

Parse the Renovate configuration as JSON.

```shell
python3 -m json.tool .github/renovate.json >/dev/null
```

Check shell formatting for the synchronized Bats test.

```shell
shfmt -d -i 4 -sr tests/install/common/renovate.bats
```

Validate the configuration against Renovate's schema.

```shell
npx --yes --package renovate renovate-config-validator .github/renovate.json
```

Run Renovate locally in full dry-run mode with GitHub datasource access.

```shell
GITHUB_COM_TOKEN="$(gh auth token)" LOG_LEVEL=debug npx --yes --package renovate renovate --platform=local --dry-run=full --onboarding=false --require-config=required --repository-cache=disabled
```

The dry-run grouped both updates under `renovate/agent-tooling`: Antigravity CLI `1.1.6` to `1.1.10` and CLIProxyAPI `7.2.97` to `7.2.116`.

The Bats suite is intentionally left to GitHub Actions per repository policy.
