### PR TITLE
fix(mise): enforce bootstrap compatibility floor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,22 +11,6 @@
       "/(^|/)home/dot_mise/config\\.toml$/"
     ]
   },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)home/dot_mise/config\\.toml$/"
-      ],
-      "matchStrings": [
-        "^(?:[ \\t]*#.*\\n|[ \\t]*\\n)*[ \\t]*min_version[ \\t]*=[ \\t]*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
-      ],
-      "depNameTemplate": "jdx/mise",
-      "packageNameTemplate": "jdx/mise",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver-coerced",
-      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
@@ -37,11 +21,6 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["patch"],
       "enabled": false
-    },
-    {
-      "matchManagers": ["custom.regex"],
-      "matchPackageNames": ["jdx/mise"],
-      "groupName": "mise bootstrap"
     },
     {
       "matchManagers": ["mise"],

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,6 +6,10 @@ on:
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
+      - "home/dot_mise/config.toml"
+      - "install/common/mise.sh"
+      - "home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl"
+      - "home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
       - "install/macos/**"
       - "home/.chezmoiscripts/macos/**"
       - "home/dot_tmux.conf.d/os/macos.conf"
@@ -16,6 +20,10 @@ on:
     paths:
       - ".github/workflows/macos.yaml"
       - "setup.sh"
+      - "home/dot_mise/config.toml"
+      - "install/common/mise.sh"
+      - "home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl"
+      - "home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
       - "install/macos/**"
       - "home/.chezmoiscripts/macos/**"
       - "home/dot_tmux.conf.d/os/macos.conf"

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -6,6 +6,10 @@ on:
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"
+      - "home/dot_mise/config.toml"
+      - "install/common/mise.sh"
+      - "home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl"
+      - "home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
       - "install/ubuntu/**"
       - ".chezmoiscripts/ubuntu/**"
       - "dot_tmux.conf.d/os/ubuntu.conf"
@@ -16,6 +20,10 @@ on:
     paths:
       - ".github/workflows/ubuntu.yaml"
       - "setup.sh"
+      - "home/dot_mise/config.toml"
+      - "install/common/mise.sh"
+      - "home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl"
+      - "home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
       - "install/ubuntu/**"
       - ".chezmoiscripts/ubuntu/**"
       - "dot_tmux.conf.d/os/ubuntu.conf"

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -95,6 +95,7 @@ jobs:
         run: |
           cd $(chezmoi source-path)/../
           bats tests/files/common.bats
-          bats --filter-tags common,ubuntu:${SYSTEM} \
+          bats --allow-empty-suite \
+            --filter-tags common,ubuntu:${SYSTEM} \
             --print-output-on-failure \
             tests/files/ubuntu.bats

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,15 @@
 
 - Comment language: When adding or updating comments for shell scripts or shell-based executables, always write them in English using shdoc-compatible format.
 
+## mise Bootstrap Compatibility
+
+- Compatibility floor: Treat the top-level `min_version` in `home/dot_mise/config.toml` as the lowest mise version supported by the repository, not as the desired installed version. New machines install this exact version, while existing newer installations must not be downgraded.
+- Renovate ownership: Let Renovate manage versions under `[tools]`, but do not configure Renovate to raise `min_version` merely because a new mise release exists.
+- Atomic updates: Raise `min_version` only in the same pull request as a tool or configuration change that requires newer mise behavior. Record the requirement in the pull request description.
+- Failure handling: When a Renovate tool update fails with the compatibility-floor version, determine the minimum mise release that supports the update and change `min_version` in that Renovate pull request.
+- Fresh-install validation: Changes to `home/dot_mise/config.toml`, `install/common/mise.sh`, or the mise `run_once` and `run_after` scripts must run both Ubuntu and macOS setup workflows. These workflows must install the configured `min_version` on a clean runner and complete `mise install`.
+- Avoiding workarounds: Do not replace the compatibility floor with periodic bumps, an unpinned `latest` bootstrap, or automerge whose only purpose is hiding recurring mise update pull requests.
+
 ## Git / PR Workflow
 
 - Default branch read-only: When the current checkout is `main` or the repository default branch, treat repo-tracked files as read-only and create a task-specific worktree from the default branch before any edit, commit, or push work, even when the worktree is clean.

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -1,3 +1,5 @@
+# Minimum mise version compatible with this dotfiles configuration.
+# Raise this only when a configuration or tool change requires newer mise behavior.
 min_version = "2026.7.12"
 
 [tools]

--- a/install/common/mise.sh
+++ b/install/common/mise.sh
@@ -3,8 +3,8 @@
 # @file install/common/mise.sh
 # @brief Install and bootstrap `mise`.
 # @description
-#   Reads the required mise version from the mise config, installs or updates the
-#   standalone `mise` binary when needed, and runs `mise install`.
+#   Reads the minimum compatible mise version from the mise config, installs or
+#   updates the standalone `mise` binary when needed, and runs `mise install`.
 
 # set -Eeuo pipefail
 
@@ -53,7 +53,7 @@ function get_mise_min_version_from_config() {
 }
 
 #
-# @description Build the GitHub release tag for the configured mise version.
+# @description Build the GitHub release tag for the minimum compatible mise version.
 # @arg $1 path Path to the mise config file.
 # @stdout The mise GitHub release tag with a leading `v`.
 # @stderr An error when the configured version cannot be read.
@@ -90,7 +90,7 @@ function get_installed_mise_version() {
 }
 
 #
-# @description Test whether a mise version is at least a required version.
+# @description Test whether a mise version satisfies the minimum compatible version.
 # @arg $1 current Installed mise version without a leading `v`.
 # @arg $2 required Required mise version without a leading `v`.
 # @exitcode 0 When current is greater than or equal to required.
@@ -124,7 +124,7 @@ function is_mise_version_at_least() {
 }
 
 #
-# @description Install the configured standalone `mise` binary.
+# @description Install the minimum compatible standalone `mise` binary.
 #
 function install_mise() {
     # https://mise.run
@@ -148,7 +148,7 @@ function install_mise() {
 }
 
 #
-# @description Install mise when it is missing or older than the configured min_version.
+# @description Install mise when it is missing or below the compatibility floor.
 #
 function ensure_mise_min_version() {
     local required current

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -3,6 +3,8 @@
 readonly RENOVATE_CONFIG_PATH="./.github/renovate.json"
 readonly DEPENDABOT_CONFIG_PATH="./.github/dependabot.yaml"
 readonly MISE_CONFIG_PATH="./home/dot_mise/config.toml"
+readonly UBUNTU_WORKFLOW_PATH="./.github/workflows/ubuntu.yaml"
+readonly MACOS_WORKFLOW_PATH="./.github/workflows/macos.yaml"
 
 @test "[common] Renovate exclusively manages GitHub Actions updates" {
     run python3 - "${RENOVATE_CONFIG_PATH}" "${DEPENDABOT_CONFIG_PATH}" << 'PYTHON'
@@ -105,6 +107,53 @@ python_pattern = codex_rule["extractVersion"].replace("(?<version>", "(?P<versio
 match = re.fullmatch(python_pattern, "rust-v0.146.0")
 assert match is not None
 assert match.group("version") == "0.146.0"
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] Renovate does not raise the minimum compatible mise version" {
+    run python3 - "${RENOVATE_CONFIG_PATH}" << 'PYTHON'
+import json
+import sys
+from pathlib import Path
+
+renovate = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+custom_managers = renovate.get("customManagers", [])
+package_rules = renovate["packageRules"]
+
+assert all("min_version" not in json.dumps(manager) for manager in custom_managers)
+assert not any(
+    rule.get("matchManagers") == ["custom.regex"]
+    and rule.get("matchPackageNames") == ["jdx/mise"]
+    for rule in package_rules
+)
+assert not any(rule.get("groupName") == "mise bootstrap" for rule in package_rules)
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] mise changes trigger fresh-install workflows" {
+    run python3 - "${UBUNTU_WORKFLOW_PATH}" "${MACOS_WORKFLOW_PATH}" << 'PYTHON'
+import sys
+from pathlib import Path
+
+required_paths = [
+    "home/dot_mise/config.toml",
+    "install/common/mise.sh",
+    "home/.chezmoiscripts/common/run_once_after_02-install-mise.sh.tmpl",
+    "home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl",
+]
+
+for workflow_path in map(Path, sys.argv[1:]):
+    workflow = workflow_path.read_text(encoding="utf-8")
+    for required_path in required_paths:
+        path_entry = f'      - "{required_path}"'
+        assert workflow.count(path_entry) == 2, (
+            f"{workflow_path}: expected push and pull_request entries for "
+            f"{required_path}"
+        )
 PYTHON
 
     [ "${status}" -eq 0 ]

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -5,6 +5,7 @@ readonly DEPENDABOT_CONFIG_PATH="./.github/dependabot.yaml"
 readonly MISE_CONFIG_PATH="./home/dot_mise/config.toml"
 readonly UBUNTU_WORKFLOW_PATH="./.github/workflows/ubuntu.yaml"
 readonly MACOS_WORKFLOW_PATH="./.github/workflows/macos.yaml"
+readonly AGENTS_PATH="./AGENTS.md"
 
 @test "[common] Renovate exclusively manages GitHub Actions updates" {
     run python3 - "${RENOVATE_CONFIG_PATH}" "${DEPENDABOT_CONFIG_PATH}" << 'PYTHON'
@@ -154,6 +155,22 @@ for workflow_path in map(Path, sys.argv[1:]):
             f"{workflow_path}: expected push and pull_request entries for "
             f"{required_path}"
         )
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] repository guidance defines the mise compatibility contract" {
+    run python3 - "${AGENTS_PATH}" << 'PYTHON'
+import sys
+from pathlib import Path
+
+agents = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+assert "## mise Bootstrap Compatibility" in agents
+assert "not as the desired installed version" in agents
+assert "Raise `min_version` only in the same pull request" in agents
+assert "must run both Ubuntu and macOS setup workflows" in agents
 PYTHON
 
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

The top-level mise `min_version` is a compatibility floor for fresh-machine bootstrap, not a desired version that should follow every mise release. Renovate was raising that floor continuously, while mise-related changes did not trigger the Ubuntu and macOS fresh-install workflows that prove the declared floor can install every configured tool.

## What Changed

- Remove the Renovate custom manager and package rule for `jdx/mise` bootstrap updates.
- Document the repository-level mise bootstrap compatibility contract in `AGENTS.md`.
- Clarify the compatibility-floor semantics next to `min_version` and in the bootstrap shell documentation.
- Trigger Ubuntu and macOS setup workflows when the mise configuration or bootstrap scripts change.
- Add regression coverage for Renovate ownership, workflow triggers, and repository guidance.
- Allow the intentionally empty Ubuntu-specific file-test suite while continuing to run future tests added to it.

## Validation

- `git diff --check`
- `jq empty .github/renovate.json`
- Parse `home/dot_mise/config.toml` with Python `tomllib`.
- Validate the Renovate compatibility and workflow-trigger assertions with Python.
- Parse `.github/workflows/ubuntu.yaml` with Ruby YAML.
- `bash -n install/common/mise.sh`
- `bash -n home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl`
- `shfmt -i 4 -sr -d install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl tests/install/common/renovate.bats`
- `shellcheck install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl`
- `npx --yes --package renovate renovate-config-validator --strict`
- Run a Renovate local lookup dry run and verify that `min_version` is not extracted as an update dependency.

Bats tests were not run locally per repository policy; GitHub Actions validates them.
