### PR TITLE
docs(agents): add self-improvement guidance

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -34,6 +34,14 @@
 
 - Question policy: Ask questions based on the information the user provided to propose the best solution.
 
+## Self-Improvement
+
+- Immediate adaptation: When the user corrects your behavior or output, or a failure has a verified root cause, apply the correction to the current task and identify the reusable lesson that would prevent recurrence.
+- Placement: Follow the scope-classification and source-of-truth rules above. Put concise, cross-task behavioral rules in the appropriate `AGENTS.md`; put specialized, repeatable procedures or domain knowledge in an existing relevant skill. If no existing skill fits and the lesson is substantial and reusable, propose a new skill.
+- Approval: Before changing persistent guidance, present the proposed rule or skill change, its scope, and its source of truth to the user. Make the change only after explicit approval.
+- Quality: Persist only concise, actionable prevention guidance that generalizes beyond the current task. Do not persist secrets, task-specific facts, transient state, incident details, or unverified assumptions.
+- Deduplication: Search existing guidance before proposing a change, and prefer strengthening an existing rule or skill over adding a duplicate.
+
 ## Authority Boundaries
 
 - Scope of implementation requests: Treat general implementation requests such as “implement the plan” or “continue implementing” as permission to edit files in the repository, run tests, and commit. A plan, handoff summary, or a previous agent's plan does not authorize pushing, creating or updating a PR, merging, running `chezmoi apply`, changing runtime state, or deleting or cleaning up files.

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -69,6 +69,29 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -ne 0 ]
 }
 
+@test "[common] shared guidance defines approved self-improvement workflow" {
+    run grep -F '## Self-Improvement' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'apply the correction to the current task and identify the reusable lesson that would prevent recurrence.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Put concise, cross-task behavioral rules in the appropriate `AGENTS.md`; put specialized, repeatable procedures or domain knowledge in an existing relevant skill.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'If no existing skill fits and the lesson is substantial and reusable, propose a new skill.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Make the change only after explicit approval.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'Do not persist secrets, task-specific facts, transient state, incident details, or unverified assumptions.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'prefer strengthening an existing rule or skill over adding a duplicate.' "${SHARED_AGENTS_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] shared guidance requires concrete coding plans" {
     run grep -F '## Plan Specificity' "${SHARED_AGENTS_PATH}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Summary

- add a shared self-improvement workflow for user corrections and failures with verified root causes
- route durable lessons to the appropriate `AGENTS.md` or skill, requiring explicit approval before persistence
- add regression coverage for trigger, placement, approval, quality, and deduplication requirements

## Testing

- `git diff --check`
- `shfmt --indent 4 --space-redirects --diff tests/install/common/agents_guidance.bats`
- local Bats not run per repository policy
