### PR TITLE
feat(agents): add research-before-implementation workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,15 +2,15 @@ repos:
   - repo: local
     hooks:
       - id: agent-skill-validate
-        name: validate changed agent skills
+        name: validate changed agent skills and guidance
         entry: uv run --no-project python scripts/agent_skill_eval.py validate --staged
         language: system
         pass_filenames: false
-        files: ^home/dot_config/exact_agents/skills/
+        files: ^home/dot_config/exact_agents/(AGENTS\.md|skills/)
 
       - id: agent-skill-eval
-        name: evaluate changed agent skills
+        name: evaluate changed agent skills and guidance
         entry: uv run --no-project python scripts/agent_skill_eval.py eval --staged --trials 1 --jobs 2 --timeout 180
         language: system
         pass_filenames: false
-        files: ^home/dot_config/exact_agents/skills/
+        files: ^home/dot_config/exact_agents/(AGENTS\.md|skills/)

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -47,6 +47,7 @@
 
 - Keep reports and responses concise. Expand only when asked.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
+- Before implementing non-trivial work involving third-party tools, first search the web for current specifications, recommended approaches, and relevant context, then search GitHub for representative implementations and operational patterns. Only after reviewing both, design and write the code based on that evidence rather than memory or local inspection alone.
 - Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
 - Do not overdesign error handling before implementing core behavior, and do not add error handling to final throwaway deliverables.
 - Write tests before behavior-changing implementation, verify them, and then refactor.

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -47,7 +47,7 @@
 
 - Keep reports and responses concise. Expand only when asked.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
-- Before implementing non-trivial work involving third-party tools, first search the web for current specifications, recommended approaches, and relevant context, then search GitHub for representative implementations and operational patterns. Only after reviewing both, design and write the code based on that evidence rather than memory or local inspection alone.
+- Use `research-before-implementation` before designing or editing non-trivial work involving third-party tools.
 - Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
 - Do not overdesign error handling before implementing core behavior, and do not add error handling to final throwaway deliverables.
 - Write tests before behavior-changing implementation, verify them, and then refactor.

--- a/home/dot_config/exact_agents/skills/research-before-implementation/SKILL.md
+++ b/home/dot_config/exact_agents/skills/research-before-implementation/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: research-before-implementation
+description: Research current official web documentation and representative GitHub implementation code before designing or editing non-trivial work involving third-party tools, libraries, platforms, APIs, configuration formats, or version-dependent behavior. Use for implementation, migration, integration, and configuration tasks where local files or memory alone cannot establish current supported behavior.
+---
+
+# Research Before Implementation
+
+Treat research as a gate, not a recommendation. Before any design decision or file edit, complete these tool stages in order:
+
+1. Call the agent's native web search tool (`web_search` in Codex) for current official sources. Inspect documentation, specifications, release notes, and recommended approaches from at least one relevant non-GitHub domain.
+2. Only after those results return, call the native web search tool again with results restricted to `github.com`. Inspect representative implementation code or configuration and operational patterns, not only repository descriptions.
+3. Compare the documented behavior with the GitHub examples. Resolve version, platform, and maintenance differences before choosing the design.
+4. Implement and verify the change based on that evidence.
+5. In the final response, name and link the web sources and GitHub examples consulted and state how they affected the implementation.
+
+Do not edit files until both tool calls are complete. Do not substitute memory or local repository inspection for either external research stage. If a required source cannot be accessed, report the limitation before implementation instead of silently skipping the stage.

--- a/home/dot_config/exact_agents/skills/research-before-implementation/agents/openai.yaml
+++ b/home/dot_config/exact_agents/skills/research-before-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Research Before Implementation"
+  short_description: "Research current docs and GitHub before coding"
+  default_prompt: "Use $research-before-implementation to research current sources before implementing this third-party integration."

--- a/home/dot_config/exact_agents/skills/research-before-implementation/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/research-before-implementation/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "skill": "research-before-implementation",
+  "evals": [
+    {
+      "id": "research-before-third-party-implementation",
+      "prompt": "In this empty repository, add a minimal GitHub Actions workflow that uses the current supported jdx/mise-action syntax to install tools from mise.toml and run a simple version check. Add only the necessary files, do not run the workflow, and do not merely explain the solution.",
+      "should_trigger": true,
+      "assertions": [
+        "The final response names current non-GitHub web documentation and representative GitHub implementation code inspected before implementation.",
+        "The final response reports concrete files added for a plausible jdx/mise-action workflow rather than only describing a hypothetical solution."
+      ],
+      "required_actions": [
+        "web_search",
+        "github_search",
+        "file_change"
+      ]
+    },
+    {
+      "id": "trivial-local-edit",
+      "prompt": "Create hello.txt containing exactly the word hello, then briefly report completion.",
+      "should_trigger": false,
+      "assertions": [
+        "The response briefly reports that hello.txt was created."
+      ]
+    }
+  ]
+}

--- a/home/dot_gemini/config/skills/symlink_research-before-implementation.tmpl
+++ b/home/dot_gemini/config/skills/symlink_research-before-implementation.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/research-before-implementation

--- a/home/exact_dot_agents/skills/symlink_research-before-implementation.tmpl
+++ b/home/exact_dot_agents/skills/symlink_research-before-implementation.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/research-before-implementation

--- a/scripts/agent_skill_eval.py
+++ b/scripts/agent_skill_eval.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate and evaluate changed agent skills with isolated Codex runs."""
+"""Validate and evaluate agent skills and guidance with isolated Codex runs."""
 
 from __future__ import annotations
 
@@ -22,6 +22,8 @@ from typing import TypeVar
 import tomllib
 
 SKILLS_ROOT = Path("home/dot_config/exact_agents/skills")
+GUIDANCE_PATH = Path("home/dot_config/exact_agents/AGENTS.md")
+GUIDANCE_EVAL_SKILLS = ("research-before-implementation",)
 TRANSIENT_PATTERN = re.compile(
     r"(?:429|too many requests|timed? ?out|timeout|connection|network|tls|"
     r"status\s*5\d\d|http\s*5\d\d)",
@@ -43,12 +45,22 @@ class EvalCase:
     prompt: str
     should_trigger: bool
     assertions: tuple[str, ...]
+    required_actions: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
 class ParsedTrace:
     output: str
     skill_read: bool
+    actions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EvalTarget:
+    name: str
+    kind: str
+    path: Path
+    eval_path: Path
 
 
 @dataclass(frozen=True)
@@ -65,6 +77,7 @@ class RunResult:
     variant: str
     output: str
     skill_read: bool
+    actions: tuple[str, ...] = ()
 
 
 class CodexError(RuntimeError):
@@ -155,6 +168,29 @@ def discover_changed_skills(repo: Path, staged: bool) -> list[Path]:
     return sorted(skill_paths, key=lambda path: path.name)
 
 
+def discover_changed_targets(repo: Path, staged: bool) -> list[EvalTarget]:
+    skill_paths = {path.name: path for path in discover_changed_skills(repo, staged)}
+    args = ["diff"]
+    if staged:
+        args.append("--cached")
+    args.extend(["--name-only", "--diff-filter=ACMR"])
+    changed_paths = set(run_git(repo, *args).splitlines())
+    if GUIDANCE_PATH.as_posix() in changed_paths:
+        for name in GUIDANCE_EVAL_SKILLS:
+            skill = repo / SKILLS_ROOT / name
+            if skill.is_dir():
+                skill_paths[name] = skill
+    return [
+        EvalTarget(
+            name=name,
+            kind="skill",
+            path=path,
+            eval_path=path / "evals/evals.json",
+        )
+        for name, path in sorted(skill_paths.items())
+    ]
+
+
 def discover_all_skills(repo: Path) -> list[Path]:
     root = repo / SKILLS_ROOT
     if not root.is_dir():
@@ -167,6 +203,18 @@ def discover_all_skills(repo: Path) -> list[Path]:
         ),
         key=lambda path: path.name,
     )
+
+
+def discover_all_targets(repo: Path) -> list[EvalTarget]:
+    return [
+        EvalTarget(
+            name=path.name,
+            kind="skill",
+            path=path,
+            eval_path=path / "evals/evals.json",
+        )
+        for path in discover_all_skills(repo)
+    ]
 
 
 def parse_frontmatter(path: Path) -> dict[str, str]:
@@ -189,59 +237,55 @@ def parse_frontmatter(path: Path) -> dict[str, str]:
 
 
 def load_cases(skill: Path) -> list[EvalCase]:
-    data = json.loads((skill / "evals/evals.json").read_text(encoding="utf-8"))
+    return load_cases_file(skill / "evals/evals.json")
+
+
+def load_cases_file(path: Path) -> list[EvalCase]:
+    data = json.loads(path.read_text(encoding="utf-8"))
     return [
         EvalCase(
             id=item["id"],
             prompt=item["prompt"],
             should_trigger=item["should_trigger"],
             assertions=tuple(item["assertions"]),
+            required_actions=tuple(item.get("required_actions", ())),
         )
         for item in data["evals"]
     ]
 
 
-def validate_skill(skill: Path) -> list[str]:
+def validate_eval_file(
+    eval_file: Path, owner_key: str, owner_name: str, *, allow_actions: bool
+) -> list[str]:
     errors: list[str] = []
-    skill_file = skill / "SKILL.md"
-    eval_file = skill / "evals/evals.json"
-    if not skill_file.is_file():
-        return [f"{skill}: missing SKILL.md"]
-    try:
-        frontmatter = parse_frontmatter(skill_file)
-        if set(frontmatter) != {"name", "description"}:
-            errors.append("SKILL.md frontmatter must contain only name and description")
-        if frontmatter.get("name") != skill.name:
-            errors.append(f"SKILL.md name must be {skill.name!r}")
-        if not frontmatter.get("description"):
-            errors.append("SKILL.md description must not be empty")
-    except (OSError, ValueError) as error:
-        errors.append(str(error))
+    display_name = "evals/evals.json" if owner_key == "skill" else eval_file.name
     if not eval_file.is_file():
-        errors.append("missing evals/evals.json")
-        return errors
+        return [f"missing {display_name}"]
     try:
         data = json.loads(eval_file.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as error:
-        errors.append(f"invalid evals/evals.json: {error}")
-        return errors
+        return [f"invalid {display_name}: {error}"]
     if not isinstance(data, dict):
-        return errors + ["evals/evals.json must contain an object"]
+        return [f"{display_name} must contain an object"]
     if data.get("version") != 1:
         errors.append("eval version must be 1")
-    if data.get("skill") != skill.name:
-        errors.append(f"eval skill must be {skill.name!r}")
+    if data.get(owner_key) != owner_name:
+        errors.append(f"eval {owner_key} must be {owner_name!r}")
     evals = data.get("evals")
     if not isinstance(evals, list):
         return errors + ["evals must be an array"]
     identifiers: set[str] = set()
     trigger_values: set[bool] = set()
+    base_fields = {"id", "prompt", "should_trigger", "assertions"}
     for index, item in enumerate(evals):
         location = f"evals[{index}]"
         if not isinstance(item, dict):
             errors.append(f"{location} must be an object")
             continue
-        if set(item) != {"id", "prompt", "should_trigger", "assertions"}:
+        allowed_fields = base_fields | (
+            {"required_actions"} if allow_actions else set()
+        )
+        if not base_fields <= set(item) or not set(item) <= allowed_fields:
             errors.append(f"{location} has unsupported or missing fields")
         identifier = item.get("id")
         if not isinstance(identifier, str) or not identifier:
@@ -266,6 +310,12 @@ def validate_skill(skill: Path) -> list[str]:
             )
         ):
             errors.append(f"{location}.assertions must contain non-empty strings")
+        actions = item.get("required_actions", [])
+        if not isinstance(actions, list) or not all(
+            action in {"web_search", "github_search", "file_change"}
+            for action in actions
+        ):
+            errors.append(f"{location}.required_actions contains unsupported actions")
     if True not in trigger_values:
         errors.append("at least one positive eval is required")
     if False not in trigger_values:
@@ -273,9 +323,36 @@ def validate_skill(skill: Path) -> list[str]:
     return errors
 
 
+def validate_skill(skill: Path) -> list[str]:
+    errors: list[str] = []
+    skill_file = skill / "SKILL.md"
+    eval_file = skill / "evals/evals.json"
+    if not skill_file.is_file():
+        return [f"{skill}: missing SKILL.md"]
+    try:
+        frontmatter = parse_frontmatter(skill_file)
+        if set(frontmatter) != {"name", "description"}:
+            errors.append("SKILL.md frontmatter must contain only name and description")
+        if frontmatter.get("name") != skill.name:
+            errors.append(f"SKILL.md name must be {skill.name!r}")
+        if not frontmatter.get("description"):
+            errors.append("SKILL.md description must not be empty")
+    except (OSError, ValueError) as error:
+        errors.append(str(error))
+    errors.extend(
+        validate_eval_file(eval_file, "skill", skill.name, allow_actions=True)
+    )
+    return errors
+
+
+def validate_target(target: EvalTarget) -> list[str]:
+    return validate_skill(target.path)
+
+
 def parse_trace(trace: str, skill_name: str) -> ParsedTrace:
     messages: list[str] = []
     skill_read = False
+    actions: list[str] = []
     marker = f"/skills/{skill_name}/SKILL.md"
     relative_marker = f"skills/{skill_name}/SKILL.md"
     for line in trace.splitlines():
@@ -289,11 +366,51 @@ def parse_trace(trace: str, skill_name: str) -> ParsedTrace:
         item_type = item.get("type")
         if item_type == "agent_message" and isinstance(item.get("text"), str):
             messages.append(item["text"])
+        if item_type == "web_search":
+            query = str(item.get("query", ""))
+            actions.append(
+                "github_search" if "github" in query.lower() else "web_search"
+            )
+        if item_type == "file_change":
+            actions.append("file_change")
         if item_type == "command_execution":
             command = str(item.get("command", ""))
             if marker in command or relative_marker in command:
                 skill_read = True
-    return ParsedTrace(output=messages[-1] if messages else "", skill_read=skill_read)
+            if re.search(r"\bgh\s+search\s+(?:code|repos?|commits?)\b", command):
+                actions.append("github_search")
+    return ParsedTrace(
+        output=messages[-1] if messages else "",
+        skill_read=skill_read,
+        actions=tuple(actions),
+    )
+
+
+def contains_ordered_actions(
+    actions: tuple[str, ...], required: tuple[str, ...]
+) -> bool:
+    remaining = iter(actions)
+    return all(any(action == expected for action in remaining) for expected in required)
+
+
+def required_actions_pass(cases: list[EvalCase], results: list[RunResult]) -> bool:
+    return not required_action_failures(cases, results)
+
+
+def required_action_failures(
+    cases: list[EvalCase], results: list[RunResult]
+) -> list[str]:
+    cases_by_id = {case.id: case for case in cases}
+    return [
+        f"{result.case_id} trial {result.trial}: required actions "
+        f"{cases_by_id[result.case_id].required_actions}, observed {result.actions}; "
+        f"output={normalize_artifact(result.output)!r}"
+        for result in results
+        if result.variant == "candidate"
+        and not contains_ordered_actions(
+            result.actions, cases_by_id[result.case_id].required_actions
+        )
+    ]
 
 
 def retry_transient(operation: Callable[[], T], retries: int = 1) -> T:
@@ -333,6 +450,34 @@ def codex_executable() -> str:
     return os.environ.get("AGENT_SKILL_EVAL_CODEX", "codex")
 
 
+def configured_model_provider() -> str | None:
+    config_path = Path.home() / ".codex/config.toml"
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    provider = config.get("model_provider")
+    providers = config.get("model_providers")
+    if (
+        not isinstance(provider, str)
+        or not provider
+        or not isinstance(providers, dict)
+        or not isinstance(providers.get(provider), dict)
+    ):
+        return None
+    return provider
+
+
+def web_search_provider_override() -> str | None:
+    provider = configured_model_provider()
+    if provider is None:
+        return None
+    key = (
+        provider if re.fullmatch(r"[A-Za-z0-9_-]+", provider) else json.dumps(provider)
+    )
+    return f"model_providers.{key}.supports_standalone_web_search=true"
+
+
 def disabled_skill_override() -> str | None:
     paths: set[Path] = set()
     home = Path.home()
@@ -349,25 +494,42 @@ def disabled_skill_override() -> str | None:
 
 
 def invoke_codex(
-    repo: Path, prompt: str, timeout: int, schema: Path | None = None
+    repo: Path,
+    prompt: str,
+    timeout: int,
+    schema: Path | None = None,
+    *,
+    sandbox: str = "read-only",
+    search: bool = False,
+    codex_home: Path | None = None,
 ) -> str:
-    command = [
-        codex_executable(),
-        "exec",
-        "--ephemeral",
-        "--json",
-        "--sandbox",
-        "read-only",
-        "--cd",
-        str(repo),
-    ]
+    command = [codex_executable()]
+    if search:
+        command.append("--search")
+        provider_override = web_search_provider_override()
+        if provider_override:
+            command.extend(["-c", provider_override])
     override = disabled_skill_override()
     if override:
         command.extend(["-c", override])
+    command.extend(
+        [
+            "exec",
+            "--ephemeral",
+            "--json",
+            "--sandbox",
+            sandbox,
+            "--cd",
+            str(repo),
+        ]
+    )
     if schema is not None:
         command.extend(["--output-schema", str(schema)])
     command.append("-")
     try:
+        environment = os.environ.copy()
+        if codex_home is not None:
+            environment["CODEX_HOME"] = str(codex_home)
         completed = subprocess.run(
             command,
             input=prompt,
@@ -375,6 +537,7 @@ def invoke_codex(
             capture_output=True,
             timeout=timeout,
             check=False,
+            env=environment,
         )
     except subprocess.TimeoutExpired as error:
         raise TransientCodexError(f"Codex timed out after {timeout}s") from error
@@ -391,17 +554,36 @@ def initialize_temp_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q", str(path)], check=True, capture_output=True)
 
 
-def run_case(skill: Path, spec: RunSpec, timeout: int) -> RunResult:
+def initialize_codex_home(path: Path) -> None:
+    path.mkdir()
+    source = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    for name in ("config.toml", "auth.json"):
+        candidate = source / name
+        if candidate.exists():
+            (path / name).symlink_to(candidate)
+
+
+def run_target_case(target: EvalTarget, spec: RunSpec, timeout: int) -> RunResult:
     def operation() -> RunResult:
         with tempfile.TemporaryDirectory(prefix="agent-skill-eval-") as tempdir:
-            repo = Path(tempdir)
+            root = Path(tempdir)
+            repo = root / "repo"
             initialize_temp_repo(repo)
+            codex_home = root / "codex-home"
+            initialize_codex_home(codex_home)
             if spec.variant == "candidate":
-                destination = repo / ".agents/skills" / skill.name
+                destination = repo / ".agents/skills" / target.name
                 destination.parent.mkdir(parents=True)
-                shutil.copytree(skill, destination)
-            trace = invoke_codex(repo, spec.case.prompt, timeout)
-            parsed = parse_trace(trace, skill.name)
+                shutil.copytree(target.path, destination)
+            trace = invoke_codex(
+                repo,
+                spec.case.prompt,
+                timeout,
+                sandbox="workspace-write",
+                search=bool(spec.case.required_actions),
+                codex_home=codex_home,
+            )
+            parsed = parse_trace(trace, target.name)
             if not normalize_artifact(parsed.output):
                 raise TransientCodexError("Codex returned no deliverable")
             return RunResult(
@@ -410,9 +592,20 @@ def run_case(skill: Path, spec: RunSpec, timeout: int) -> RunResult:
                 variant=spec.variant,
                 output=parsed.output,
                 skill_read=parsed.skill_read,
+                actions=parsed.actions,
             )
 
     return retry_transient(operation, retries=1)
+
+
+def run_case(skill: Path, spec: RunSpec, timeout: int) -> RunResult:
+    target = EvalTarget(
+        name=skill.name,
+        kind="skill",
+        path=skill,
+        eval_path=skill / "evals/evals.json",
+    )
+    return run_target_case(target, spec, timeout)
 
 
 def judge_schema() -> dict[str, object]:
@@ -540,24 +733,43 @@ def codex_identity() -> str:
 
 
 def cache_key(skill: Path, config: EvalConfig, codex_identity: str) -> str:
+    return target_cache_key(
+        EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        ),
+        config,
+        codex_identity,
+    )
+
+
+def target_cache_key(
+    target: EvalTarget, config: EvalConfig, codex_identity: str
+) -> str:
     digest = hashlib.sha256()
     digest.update(json.dumps(asdict(config), sort_keys=True).encode())
     digest.update(codex_identity.encode())
     digest.update(Path(__file__).read_bytes())
-    for path in sorted(skill.rglob("*")):
+    digest.update(target.kind.encode())
+    paths = [target.path] if target.path.is_file() else sorted(target.path.rglob("*"))
+    for path in paths:
         if path.is_file():
-            digest.update(path.relative_to(skill).as_posix().encode())
+            digest.update(path.as_posix().encode())
             digest.update(path.read_bytes())
+    if target.eval_path.is_file() and target.eval_path != target.path:
+        digest.update(target.eval_path.read_bytes())
     return digest.hexdigest()
 
 
-def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
+def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) -> bool:
     identity = codex_identity()
-    key = cache_key(skill, config, identity)
+    key = target_cache_key(target, config, identity)
     if cache.load(key) is not None:
-        print(f"{skill.name}: passed (cached)")
+        print(f"{target.name}: passed (cached)")
         return True
-    cases = load_cases(skill)
+    cases = load_cases_file(target.eval_path)
     specs: list[RunSpec] = []
     for trial in range(1, config.trials + 1):
         for case in cases:
@@ -567,7 +779,7 @@ def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
     results: list[RunResult] = []
     with ThreadPoolExecutor(max_workers=config.jobs) as executor:
         futures = {
-            executor.submit(run_case, skill, spec, config.timeout): spec
+            executor.submit(run_target_case, target, spec, config.timeout): spec
             for spec in specs
         }
         for future in as_completed(futures):
@@ -578,6 +790,8 @@ def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
         or result.skill_read == cases_by_id[result.case_id].should_trigger
         for result in results
     )
+    action_failures = required_action_failures(cases, results)
+    actions_ok = not action_failures
     judged, mappings = judge_results(cases, results, config.timeout)
     expected = {
         (case.id, trial) for case in cases for trial in range(1, config.trials + 1)
@@ -586,7 +800,7 @@ def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
     candidate_assertions_ok = True
     candidate_wins = 0
     baseline_wins = 0
-    failure_details: list[str] = []
+    failure_details = action_failures.copy()
     for entry in judged:
         if not isinstance(entry, dict):
             candidate_assertions_ok = False
@@ -634,16 +848,17 @@ def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
     passed = (
         seen == expected
         and trigger_ok
+        and actions_ok
         and candidate_assertions_ok
         and comparison_passes(candidate_wins, baseline_wins)
     )
     if passed:
-        cache.store(key, {"passed": True, "skill": skill.name})
-        print(f"{skill.name}: passed")
+        cache.store(key, {"passed": True, "target": target.name, "kind": target.kind})
+        print(f"{target.name}: passed")
         return True
     print(
-        f"{skill.name}: failed "
-        f"(coverage={seen == expected}, triggers={trigger_ok}, "
+        f"{target.name}: failed "
+        f"(coverage={seen == expected}, triggers={trigger_ok}, actions={actions_ok}, "
         f"candidate_assertions={candidate_assertions_ok}, "
         f"candidate_wins={candidate_wins}, baseline_wins={baseline_wins})",
         file=sys.stderr,
@@ -651,6 +866,19 @@ def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
     for detail in failure_details:
         print(f"  - {detail}", file=sys.stderr)
     return False
+
+
+def evaluate_skill(skill: Path, config: EvalConfig, cache: ResultCache) -> bool:
+    return evaluate_target(
+        EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        ),
+        config,
+        cache,
+    )
 
 
 def cache_for_repo(repo: Path) -> ResultCache:
@@ -666,6 +894,14 @@ def selected_skills(repo: Path, staged: bool, all_skills: bool) -> list[Path]:
         discover_all_skills(repo)
         if all_skills
         else discover_changed_skills(repo, staged)
+    )
+
+
+def selected_targets(repo: Path, staged: bool, all_targets: bool) -> list[EvalTarget]:
+    return (
+        discover_all_targets(repo)
+        if all_targets
+        else discover_changed_targets(repo, staged)
     )
 
 
@@ -687,15 +923,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     repo = find_repo_root()
-    skills = selected_skills(repo, args.staged, args.all_skills)
-    if not skills:
-        print("No matching skills changed.")
+    targets = selected_targets(repo, args.staged, args.all_skills)
+    if not targets:
+        print("No matching evaluation targets changed.")
         return 0
     invalid = False
-    for skill in skills:
-        errors = validate_skill(skill)
+    for target in targets:
+        errors = validate_target(target)
         for error in errors:
-            print(f"{skill.name}: {error}", file=sys.stderr)
+            print(f"{target.name}: {error}", file=sys.stderr)
         invalid = invalid or bool(errors)
     if invalid or args.command == "validate":
         return 1 if invalid else 0
@@ -706,8 +942,8 @@ def main(argv: list[str] | None = None) -> int:
     cache = cache_for_repo(repo)
     try:
         passed = True
-        for skill in skills:
-            passed = evaluate_skill(skill, config, cache) and passed
+        for target in targets:
+            passed = evaluate_target(target, config, cache) and passed
     except CodexError as error:
         print(f"Codex evaluation failed: {error}", file=sys.stderr)
         return 1

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -362,6 +362,7 @@ readonly GITIGNORE_PATH="./.gitignore"
 
     [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_humanizer-ja.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/humanizer-ja" ]
     [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_manage-agent-guidance.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/manage-agent-guidance" ]
+    [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_research-before-implementation.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/research-before-implementation" ]
     [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_structured-writing.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/structured-writing" ]
     [ ! -e "${SHARED_SKILLS_SYMLINK_DIR}/symlink_setup-agent-docs.tmpl" ]
     [ "$(< "${SHARED_SKILLS_SYMLINK_DIR}/symlink_shdoc-shell-docs.tmpl")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shdoc-shell-docs" ]
@@ -370,7 +371,7 @@ readonly GITIGNORE_PATH="./.gitignore"
 @test "[common] Gemini skills expose repo-managed skills through per-skill symlink templates" {
     [ -d "${GEMINI_SKILLS_SYMLINK_DIR}" ]
 
-    local skills="ai-slop-checklist-ja cgd-dev-identity convert-to-transformers gh-comment-attach-files high-impact-journal-publishing humanizer-ja manage-agent-guidance python-uv-workflow shdoc-shell-docs structured-writing"
+    local skills="ai-slop-checklist-ja cgd-dev-identity convert-to-transformers gh-comment-attach-files high-impact-journal-publishing humanizer-ja manage-agent-guidance python-uv-workflow research-before-implementation shdoc-shell-docs structured-writing"
     local skill
     local template
     local expected
@@ -390,7 +391,7 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ ! -e "${GEMINI_SKILLS_SYMLINK_DIR}/symlink_setup-agent-docs.tmpl" ]
 }
 
-@test "[common] prek validates and evaluates only changed managed skills" {
+@test "[common] prek validates and evaluates changed managed skills and guidance" {
     [ -f "${PREK_CONFIG_PATH}" ]
     [ -f "${SKILL_EVAL_SCRIPT}" ]
 

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -62,6 +62,16 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
                 for expected in item["contains"]:
                     self.assertIn(expected, text)
 
+    def test_third_party_implementation_researches_before_coding(self) -> None:
+        agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"
+        text = agents_path.read_text(encoding="utf-8")
+        web_search = text.index("first search the web")
+        github_search = text.index("then search GitHub")
+        implementation = text.index("Only after reviewing both, design and write the code")
+
+        self.assertLess(web_search, github_search)
+        self.assertLess(github_search, implementation)
+
     def test_always_on_sections_are_not_duplicated_in_managed_skills(self) -> None:
         agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"
         skill_root = REPO_ROOT / "home/dot_config/exact_agents/skills"

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -5,7 +5,6 @@ import subprocess
 import unittest
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = REPO_ROOT / "tests/fixtures/agent_guidance_requirements.json"
 EXTRA_DIRECTIVE_LINES = {4, 14}
@@ -62,21 +61,37 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
                 for expected in item["contains"]:
                     self.assertIn(expected, text)
 
-    def test_third_party_implementation_researches_before_coding(self) -> None:
+    def test_third_party_research_has_one_routing_rule_and_skill_owner(self) -> None:
         agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"
-        text = agents_path.read_text(encoding="utf-8")
-        web_search = text.index("first search the web")
-        github_search = text.index("then search GitHub")
-        implementation = text.index("Only after reviewing both, design and write the code")
+        skill_path = (
+            REPO_ROOT
+            / "home/dot_config/exact_agents/skills/research-before-implementation/SKILL.md"
+        )
+        agents = agents_path.read_text(encoding="utf-8")
+        skill = skill_path.read_text(encoding="utf-8")
+        web_search = skill.index(
+            "Call the agent's native web search tool (`web_search` in Codex)"
+        )
+        github_search = skill.index(
+            "call the native web search tool again with results restricted to `github.com`"
+        )
+        implementation = skill.index("Implement and verify")
 
+        self.assertEqual(agents.count("`research-before-implementation`"), 1)
         self.assertLess(web_search, github_search)
         self.assertLess(github_search, implementation)
+        self.assertIn("Do not edit files until both tool calls are complete", skill)
+        self.assertIn(
+            "In the final response, name and link the web sources and GitHub examples consulted",
+            skill,
+        )
 
     def test_always_on_sections_are_not_duplicated_in_managed_skills(self) -> None:
         agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"
         skill_root = REPO_ROOT / "home/dot_config/exact_agents/skills"
         always_on_sections = {
-            line for line in agents_path.read_text(encoding="utf-8").splitlines()
+            line
+            for line in agents_path.read_text(encoding="utf-8").splitlines()
             if line.startswith("## ")
         }
         duplicates = {

--- a/tests/python/test_agent_skill_eval.py
+++ b/tests/python/test_agent_skill_eval.py
@@ -69,6 +69,15 @@ def write_skill(repo: Path, name: str, *, with_evals: bool = True) -> Path:
     return skill
 
 
+def write_guidance(repo: Path) -> Path:
+    guidance = repo / "home/dot_config/exact_agents/AGENTS.md"
+    guidance.parent.mkdir(parents=True)
+    guidance.write_text(
+        "# AGENTS.md\n\nResearch before implementation.\n", encoding="utf-8"
+    )
+    return guidance
+
+
 class AgentSkillEvalTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -117,6 +126,59 @@ class AgentSkillEvalTest(unittest.TestCase):
         run_git(repo, "add", "-u")
 
         self.assertEqual(self.module.discover_changed_skills(repo, staged=True), [])
+
+    def test_discover_changed_targets_includes_staged_user_guidance(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        guidance = write_guidance(repo)
+        write_skill(repo, "research-before-implementation")
+        run_git(repo, "add", ".")
+        run_git(repo, "commit", "-qm", "initial")
+        guidance.write_text(
+            guidance.read_text(encoding="utf-8") + "Search GitHub too.\n",
+            encoding="utf-8",
+        )
+        run_git(repo, "add", ".")
+
+        targets = self.module.discover_changed_targets(repo, staged=True)
+
+        self.assertEqual(
+            [target.name for target in targets], ["research-before-implementation"]
+        )
+        self.assertEqual(targets[0].kind, "skill")
+
+    def test_discover_all_targets_includes_evaluable_skills(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        write_skill(repo, "evaluable")
+
+        targets = self.module.discover_all_targets(repo)
+
+        self.assertEqual(
+            [(target.kind, target.name) for target in targets],
+            [("skill", "evaluable")],
+        )
+
+    def test_prek_hooks_trigger_for_guidance_and_skills(self) -> None:
+        config = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+        expected = "files: ^home/dot_config/exact_agents/(AGENTS\\.md|skills/)"
+        self.assertEqual(config.count(expected), 2)
+
+    def test_validate_skill_accepts_required_action_sequence(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        skill = write_skill(repo, "research")
+        eval_path = skill / "evals/evals.json"
+        data = json.loads(eval_path.read_text(encoding="utf-8"))
+        data["evals"][0]["required_actions"] = [
+            "web_search",
+            "github_search",
+            "file_change",
+        ]
+        eval_path.write_text(json.dumps(data), encoding="utf-8")
+
+        self.assertEqual(self.module.validate_skill(skill), [])
 
     def test_validate_skill_requires_eval_file(self) -> None:
         tempdir, repo = self.make_repo()
@@ -176,6 +238,222 @@ class AgentSkillEvalTest(unittest.TestCase):
 
         self.assertTrue(parsed.skill_read)
         self.assertEqual(parsed.output, "final answer")
+
+    def test_parse_trace_records_research_before_file_change(self) -> None:
+        trace = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "web_search", "query": "current mise docs"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "web_search",
+                            "query": "site:github.com mise macOS defaults",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "file_change", "changes": []},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "implemented"},
+                    }
+                ),
+            ]
+        )
+
+        parsed = self.module.parse_trace(trace, "demo")
+
+        self.assertEqual(parsed.actions, ("web_search", "github_search", "file_change"))
+        self.assertTrue(
+            self.module.contains_ordered_actions(
+                parsed.actions, ("web_search", "github_search", "file_change")
+            )
+        )
+
+    def test_parse_trace_recognizes_gh_code_search_as_github_research(self) -> None:
+        trace = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "gh search code 'defaults repo:mise-plugins/mise'",
+                },
+            }
+        )
+
+        parsed = self.module.parse_trace(trace, "demo")
+
+        self.assertEqual(parsed.actions, ("github_search",))
+
+    def test_web_search_override_enables_the_selected_custom_provider(self) -> None:
+        with mock.patch.object(
+            self.module,
+            "configured_model_provider",
+            return_value="custom-provider",
+        ):
+            override = self.module.web_search_provider_override()
+
+        self.assertEqual(
+            override,
+            "model_providers.custom-provider.supports_standalone_web_search=true",
+        )
+
+    def test_invoke_places_global_search_config_before_exec(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with (
+            mock.patch.object(
+                self.module,
+                "web_search_provider_override",
+                return_value="model_providers.custom.supports_standalone_web_search=true",
+            ),
+            mock.patch.object(
+                self.module,
+                "disabled_skill_override",
+                return_value='skills.config=[{path="/tmp/demo",enabled=false}]',
+            ),
+            mock.patch.object(
+                self.module.subprocess, "run", return_value=completed
+            ) as run,
+        ):
+            self.module.invoke_codex(Path("/tmp"), "prompt", 10, search=True)
+
+        command = run.call_args.args[0]
+        exec_index = command.index("exec")
+        self.assertLess(command.index("--search"), exec_index)
+        self.assertTrue(
+            all(
+                index < exec_index
+                for index, value in enumerate(command)
+                if value == "-c"
+            )
+        )
+
+    def test_required_actions_rejects_implementation_before_research(self) -> None:
+        case = self.module.EvalCase(
+            id="research",
+            prompt="Implement an example.",
+            should_trigger=True,
+            assertions=("The example works.",),
+            required_actions=("web_search", "github_search", "file_change"),
+        )
+        result = self.module.RunResult(
+            case_id="research",
+            trial=1,
+            variant="candidate",
+            output="implemented",
+            skill_read=False,
+            actions=("file_change", "web_search", "github_search"),
+        )
+
+        self.assertFalse(self.module.required_actions_pass([case], [result]))
+        self.assertEqual(
+            self.module.required_action_failures([case], [result]),
+            [
+                (
+                    "research trial 1: required actions "
+                    "('web_search', 'github_search', 'file_change'), observed "
+                    "('file_change', 'web_search', 'github_search'); "
+                    "output='implemented'"
+                )
+            ],
+        )
+
+    def test_run_research_skill_enables_search_and_workspace_writes(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        skill = write_skill(repo, "research")
+        target = self.module.EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        )
+        case = self.module.EvalCase(
+            id="research",
+            prompt="Implement an example.",
+            should_trigger=True,
+            assertions=("The example works.",),
+            required_actions=("web_search", "github_search", "file_change"),
+        )
+        spec = self.module.RunSpec(case=case, trial=1, variant="candidate")
+
+        def fake_invoke(
+            run_repo,
+            prompt,
+            timeout,
+            schema=None,
+            *,
+            sandbox="read-only",
+            search=False,
+            codex_home=None,
+        ):
+            self.assertTrue((run_repo / ".agents/skills/research/SKILL.md").is_file())
+            self.assertEqual(sandbox, "workspace-write")
+            self.assertTrue(search)
+            self.assertIsNotNone(codex_home)
+            return "\n".join(
+                [
+                    json.dumps(
+                        {"item": {"type": "web_search", "query": "current docs"}}
+                    ),
+                    json.dumps(
+                        {
+                            "item": {
+                                "type": "web_search",
+                                "query": "site:github.com example",
+                            }
+                        }
+                    ),
+                    json.dumps({"item": {"type": "file_change"}}),
+                    json.dumps(
+                        {"item": {"type": "agent_message", "text": "implemented"}}
+                    ),
+                ]
+            )
+
+        with mock.patch.object(self.module, "invoke_codex", side_effect=fake_invoke):
+            result = self.module.run_target_case(target, spec, timeout=10)
+
+        self.assertEqual(result.actions, ("web_search", "github_search", "file_change"))
+
+    def test_run_research_skill_baseline_has_no_candidate_skill(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        skill = write_skill(repo, "research")
+        target = self.module.EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        )
+        case = self.module.EvalCase(
+            id="research",
+            prompt="Implement an example.",
+            should_trigger=True,
+            assertions=("The example works.",),
+        )
+        spec = self.module.RunSpec(case=case, trial=1, variant="baseline")
+
+        def fake_invoke(run_repo, *args, **kwargs):
+            self.assertFalse((run_repo / ".agents/skills/research").exists())
+            self.assertEqual(kwargs["sandbox"], "workspace-write")
+            return json.dumps({"item": {"type": "agent_message", "text": "baseline"}})
+
+        with mock.patch.object(self.module, "invoke_codex", side_effect=fake_invoke):
+            self.module.run_target_case(target, spec, timeout=10)
 
     def test_cache_key_changes_with_trials_and_skill_content(self) -> None:
         tempdir, repo = self.make_repo()


### PR DESCRIPTION
## Summary

- add `research-before-implementation` as the authoritative workflow for researching current official documentation and representative GitHub code before implementation
- keep the user-level `AGENTS.md` rule as a thin routing instruction and expose the managed skill to the shared skills pool and Gemini
- extend the existing evaluation runner and prek hooks so `AGENTS.md` changes trigger behavioral evaluation
- verify the ordered Codex trajectory `web_search -> GitHub search -> file change`, including isolated candidate and baseline runs
- enable standalone web search for the selected custom Codex provider only within evaluation runs

## Validation

- `uv run --no-project --with pyyaml python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py home/dot_config/exact_agents/skills/research-before-implementation`
- `uvx ruff format --check scripts/agent_skill_eval.py tests/python/test_agent_skill_eval.py tests/python/test_agent_guidance_requirements.py`
- `uvx ruff check scripts/agent_skill_eval.py tests/python/test_agent_skill_eval.py tests/python/test_agent_guidance_requirements.py`
- `uv run --no-project python -m unittest discover -s tests/python -p 'test_*.py'`
- `mise exec -- prek run agent-skill-validate`
- `mise exec -- prek run agent-skill-eval`

Local Bats tests were not run, per repository policy; the related Bats coverage is delegated to GitHub Actions.
