### PR TITLE
ci(mise): reuse bootstrapped installation

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -100,15 +100,11 @@ jobs:
           alert-comment-cc-users: "@shunk031"
           benchmark-data-dir-path: "."
 
-      - uses: jdx/mise-action@v4.2.3
-        with:
-          install: true
-          cache: true
-
       - name: Test file existence
         run: |
           brew install bats-core
 
+          source "${HOME}/.config/shell/mise.bash"
           cd $(chezmoi source-path)/../
           bats --print-output-on-failure \
             tests/files/common.bats \

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -76,11 +76,6 @@ jobs:
           #              │               └─ Simulate inputting an system arcitecture into the config.
           #              └─ Simulate inputting an email address into the config.
 
-      - uses: jdx/mise-action@v4.2.3
-        with:
-          install: true
-          cache: true
-
       # - name: Install latest bats-core
       #   run: |
       #     tmp_dir=$(mktemp -d /tmp/bats-core-XXXXX)
@@ -93,6 +88,7 @@ jobs:
         env:
           SYSTEM: ${{ matrix.system }}
         run: |
+          source "${HOME}/.config/shell/mise.bash"
           cd $(chezmoi source-path)/../
           bats tests/files/common.bats
           bats --allow-empty-suite \

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -5,6 +5,10 @@ readonly TMPL_SCRIPT_GLOB="./home/.chezmoiscripts/common/run_once_after_*-instal
 readonly RUN_AFTER_TEMPLATE="./home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl"
 readonly MISE_CONFIG_SOURCE="./home/dot_mise/config.toml"
 readonly MISE_BASH_SOURCE="./home/dot_config/exact_shell/mise.bash"
+readonly MISE_SETUP_WORKFLOWS=(
+    "./.github/workflows/ubuntu.yaml"
+    "./.github/workflows/macos.yaml"
+)
 
 function write_mise_config() {
     local version="$1"
@@ -184,6 +188,18 @@ function run_mise_bash_startup() {
     min_version="$(get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}")"
     run is_mise_version_at_least "${min_version}" "2026.8.2"
     [ "${status}" -eq 0 ]
+}
+
+@test "[common] setup workflows reuse the chezmoi-bootstrapped mise" {
+    local workflow
+
+    for workflow in "${MISE_SETUP_WORKFLOWS[@]}"; do
+        run grep -F 'source "${HOME}/.config/shell/mise.bash"' "${workflow}"
+        [ "${status}" -eq 0 ]
+
+        run grep -F 'jdx/mise-action' "${workflow}"
+        [ "${status}" -ne 0 ]
+    done
 }
 
 @test "[common] mise bash startup exits cleanly when mise is absent" {


### PR DESCRIPTION
## Why

`setup.sh` and chezmoi already install the minimum compatible mise release and the configured tools. Running `jdx/mise-action` afterward is redundant and restores a separate no-config cache, which can replace the bootstrapped mise with a stale binary.

## What Changed

- Remove `jdx/mise-action` from the Ubuntu and macOS setup workflows.
- Source the chezmoi-managed `${HOME}/.config/shell/mise.bash` before the file tests so they use the existing bootstrapped mise and tools.
- Add a static regression test that requires both workflows to use this single mise path.

## Validation

Check the workflow contract and regression assertions.

```shell
for workflow in .github/workflows/ubuntu.yaml .github/workflows/macos.yaml; do
  rg -F 'source "${HOME}/.config/shell/mise.bash"' "${workflow}"
  ! rg -Fq 'jdx/mise-action' "${workflow}"
done
```

Parse the updated workflow YAML files.

```shell
ruby -e 'require "yaml"; ARGV.each { |path| YAML.parse_file(path) }' .github/workflows/ubuntu.yaml .github/workflows/macos.yaml
```

Run the repository quality gates.

```shell
mise exec -- prek run --all-files
```

Inspect the final diff for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Local Bats tests were not run, per repository policy; GitHub Actions runs the required validation.
