### PR TITLE
fix(agent-skill-eval): isolate Git local environment

### DIFF
--- a/scripts/agent_skill_eval.py
+++ b/scripts/agent_skill_eval.py
@@ -639,7 +639,7 @@ def invoke_codex(
         command.extend(["--output-schema", str(schema)])
     command.append("-")
     try:
-        environment = os.environ.copy()
+        environment = git_environment_without_local_variables()
         if codex_home is not None:
             environment["CODEX_HOME"] = str(codex_home)
         completed = subprocess.run(
@@ -662,8 +662,26 @@ def invoke_codex(
     return completed.stdout
 
 
+def git_environment_without_local_variables() -> dict[str, str]:
+    local_env_vars = subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.split()
+    environment = os.environ.copy()
+    for name in local_env_vars:
+        environment.pop(name, None)
+    return environment
+
+
 def initialize_temp_repo(path: Path) -> None:
-    subprocess.run(["git", "init", "-q", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", str(path)],
+        check=True,
+        capture_output=True,
+        env=git_environment_without_local_variables(),
+    )
 
 
 def initialize_codex_home(path: Path) -> None:

--- a/tests/python/test_agent_skill_eval.py
+++ b/tests/python/test_agent_skill_eval.py
@@ -406,6 +406,69 @@ class AgentSkillEvalTest(unittest.TestCase):
 
         self.assertEqual(parsed.actions, ("github_search",))
 
+    def test_temp_repo_and_codex_clear_git_local_environment(self) -> None:
+        tempdir, outer_repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        foreign_repo = outer_repo / "foreign-repo"
+        environment_dump = outer_repo / "codex-environment.json"
+        fake_codex = outer_repo / "fake-codex"
+        fake_codex.write_text(
+            f"""#!{sys.executable}
+import json
+import os
+from pathlib import Path
+
+local_names = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE")
+observed = {{name: os.environ.get(name) for name in local_names}}
+observed["GIT_CONFIG_GLOBAL"] = os.environ.get("GIT_CONFIG_GLOBAL")
+observed["AUTH_TOKEN"] = os.environ.get("AUTH_TOKEN")
+observed["PATH"] = os.environ.get("PATH")
+Path(os.environ["ENVIRONMENT_DUMP"]).write_text(
+    json.dumps(observed), encoding="utf-8"
+)
+print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", "text": "ok"}}}}))
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o755)
+
+        original_cwd = Path.cwd()
+        self.addCleanup(lambda: os.chdir(original_cwd))
+        os.chdir(outer_repo)
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GIT_DIR": str(outer_repo / ".git"),
+                "GIT_WORK_TREE": str(outer_repo),
+                "GIT_INDEX_FILE": str(outer_repo / ".git/index"),
+                "GIT_CONFIG_GLOBAL": str(outer_repo / "global.gitconfig"),
+                "AUTH_TOKEN": "secret",
+                "PATH": "/usr/bin:/bin",
+                "AGENT_SKILL_EVAL_CODEX": str(fake_codex),
+                "ENVIRONMENT_DUMP": str(environment_dump),
+            },
+            clear=False,
+        ):
+            self.module.initialize_temp_repo(foreign_repo)
+            trace = self.module.invoke_codex(foreign_repo, "prompt", timeout=10)
+
+        os.chdir(original_cwd)
+        self.assertIn("item.completed", trace)
+        self.assertTrue((foreign_repo / ".git").is_dir())
+        self.assertEqual(
+            Path(run_git(foreign_repo, "rev-parse", "--show-toplevel")).resolve(),
+            foreign_repo.resolve(),
+        )
+        observed = json.loads(environment_dump.read_text(encoding="utf-8"))
+        self.assertIsNone(observed["GIT_DIR"])
+        self.assertIsNone(observed["GIT_WORK_TREE"])
+        self.assertIsNone(observed["GIT_INDEX_FILE"])
+        self.assertEqual(
+            observed["GIT_CONFIG_GLOBAL"], str(outer_repo / "global.gitconfig")
+        )
+        self.assertEqual(observed["AUTH_TOKEN"], "secret")
+        self.assertEqual(observed["PATH"], "/usr/bin:/bin")
+
     def test_web_search_override_enables_the_selected_custom_provider(self) -> None:
         with mock.patch.object(
             self.module,


### PR DESCRIPTION
## Why

Git hooks export repository-local `GIT_*` variables. Those variables leaked into the evaluator's temporary `git init` and Codex subprocesses, so they could operate on the enclosing repository rather than the temporary repository.

## What Changed

- Remove only the names reported by `git rev-parse --local-env-vars` before initializing temporary repositories and invoking Codex.
- Preserve non-local environment variables, including `GIT_CONFIG_GLOBAL`, authentication variables, and `PATH`.
- Add a regression test covering both temporary repository initialization and the Codex child process.

## Validation

Run the focused evaluator test suite; all 30 tests passed.

```shell
uv run --no-project python -m unittest tests/python/test_agent_skill_eval.py
```

Check the staged diff for whitespace errors.

```shell
git diff --check
```
