### PR TITLE
fix: normalize shebang headers

### DIFF
--- a/home/dot_profile
+++ b/home/dot_profile
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # for mise shims
 # shellcheck source=dot_config/exact_shell/mise.bash
 if [ -f "${HOME%/}/.config/shell/mise.bash" ]; then

--- a/home/dot_profile
+++ b/home/dot_profile
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # for mise shims
 # shellcheck source=dot_config/exact_shell/mise.bash
 if [ -f "${HOME%/}/.config/shell/mise.bash" ]; then

--- a/home/dot_zprofile
+++ b/home/dot_zprofile
@@ -1,2 +1,2 @@
+#!/usr/bin/env zsh
 eval "$(~/.local/bin/mise activate zsh)"
-

--- a/home/dot_zprofile
+++ b/home/dot_zprofile
@@ -1,2 +1,3 @@
 #!/usr/bin/env zsh
+
 eval "$(~/.local/bin/mise activate zsh)"

--- a/scripts/agent_skill_eval.py
+++ b/scripts/agent_skill_eval.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 """Validate and evaluate agent skills and guidance with isolated Codex runs."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

Login profile files should declare their intended shell, and tracked script headers should use standard blank-line separation so syntax and formatting tools interpret them consistently.

## What Changed

- Add a Bash shebang and header separation to `home/dot_profile`.
- Add a Zsh shebang and header separation to `home/dot_zprofile` while removing its trailing blank line for shfmt compliance.
- Add standard blank-line separation after the existing shebang in `scripts/agent_skill_eval.py`.
- Keep the managed-skill attachment script unchanged as an intentional policy exception because managed-skill changes require their own evaluation coverage.

## Validation

Check the Bash login profile syntax.

```shell
bash -n home/dot_profile
```

Check the Zsh login profile syntax.

```shell
zsh -n home/dot_zprofile
```

Check shell formatting for both login profiles.

```shell
shfmt --indent 4 --space-redirects --diff home/dot_profile home/dot_zprofile
```

Parse the updated Python script with the standard-library AST parser through uv.

```shell
uv run --no-project python -c 'import ast; from pathlib import Path; ast.parse(Path("scripts/agent_skill_eval.py").read_text())'
```

Check the patch for whitespace errors.

```shell
git diff --check
```
