### PR TITLE
feat(github): add CGD keychain authentication

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-cgd-dev-identity/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-cgd-dev-identity/SKILL.md
@@ -13,31 +13,33 @@ Perform git and gh write operations for creative-graphic-design organization rep
 
 Before starting write operations, perform the following checks in the working shell and worktree. Run them as a starting procedure rather than investigating only after a failure.
 
-1. Pass the bot token to each write command that uses gh or git credentials. The token is distributed to all shells as `CGD_DEV_GH_TOKEN` (managed by zshenv_private):
+1. Ensure that GitHub CLI has the bot account in its system credential store. On a new machine, run the interactive setup command once and authenticate in the browser as `creative-graphic-design-dev`:
 
    ```bash
-   GH_TOKEN="$CGD_DEV_GH_TOKEN" gh pr create ...
-   GH_TOKEN="$CGD_DEV_GH_TOKEN" git push
+   setup-gh-cgd
    ```
 
-   For manual work in a persistent shell, you may use the following shorthand:
+   Do not use `gh auth switch` during agent work. It changes the active account for the whole host and can race with concurrent sessions.
+
+2. Retrieve the stored bot token by account name and pass it only to each write command that uses gh or git credentials:
 
    ```bash
-   export GH_TOKEN="$CGD_DEV_GH_TOKEN"
+   GH_TOKEN="$(gh auth token --hostname github.com --user creative-graphic-design-dev)" gh pr create ...
+   GH_TOKEN="$(gh auth token --hostname github.com --user creative-graphic-design-dev)" git push
    ```
 
-   In environments that start a new shell for each command, such as Claude Code's shell tool, `export` does not persist to the next command. Use the per-command prefix as the canonical approach.
+   Do not export the token into a persistent shell and do not print it. The per-command prefix keeps account selection explicit and avoids changing GitHub CLI's global active account.
 
-2. Verify the GitHub identity and push permission for the organization repository. `gh api user` only confirms the logged-in account and cannot verify access to organization resources:
+3. Verify the GitHub identity and push permission for the organization repository. `gh api user` only confirms the logged-in account and cannot verify access to organization resources:
 
    ```bash
-   GH_TOKEN="$CGD_DEV_GH_TOKEN" gh api user --jq .login
-   GH_TOKEN="$CGD_DEV_GH_TOKEN" gh api repos/creative-graphic-design/<repo> --jq .permissions.push
+   GH_TOKEN="$(gh auth token --hostname github.com --user creative-graphic-design-dev)" gh api user --jq .login
+   GH_TOKEN="$(gh auth token --hostname github.com --user creative-graphic-design-dev)" gh api repos/creative-graphic-design/<repo> --jq .permissions.push
    ```
 
    Do not start write operations unless the first command returns `creative-graphic-design-dev` and the second returns `true`.
 
-3. Set the commit author to the bot for each commit command:
+4. Set the commit author to the bot for each commit command:
 
    ```bash
    git -c user.name=creative-graphic-design-dev \
@@ -47,7 +49,7 @@ Before starting write operations, perform the following checks in the working sh
 
    Do not use `git config user.name/email` in a linked worktree: it writes to the shared `.git/config` and changes the author for the main checkout and concurrent worktrees as well.
 
-4. Push over HTTPS because SSH does not use the proxy in this environment. Set an explicit push URL:
+5. Push over HTTPS because SSH does not use the proxy in this environment. Set an explicit push URL:
 
    ```bash
    git remote set-url --push origin https://github.com/creative-graphic-design/<repo>
@@ -57,12 +59,11 @@ Before starting write operations, perform the following checks in the working sh
 
 ## Scope
 
-- This skill applies only to creative-graphic-design organization repositories. Do not use it for other organizations or personal repositories; use normal authentication there. The token is a fine-grained PAT that works only for authorized repositories in the organization, so passing `GH_TOKEN` in an out-of-scope repository causes an authentication error.
+- This skill applies only to creative-graphic-design organization repositories. Do not use the stored bot credential for other organizations or personal repositories; use normal authentication there.
 - Attribute every coding-agent write to an organization repository to the bot. This includes commits, pushes, PR creation and updates, PR replies, issue comments, labels, milestones, and user-requested merges.
 - The human (`shunk031`) retains only PR approval in the GitHub UI and the decision to merge. Do not approve PRs as the bot.
 
 ## Troubleshooting
 
-- If an organization-resource endpoint (the repos API or a push) returns 403 with “organization forbids ... lifetime greater than 366 days,” organization policy requires the token lifetime to be no longer than one year. `gh api user` still succeeds in this state, so do not use it to diagnose the issue. Change the token expiration to within one year; the token value itself can remain the same.
-- If the token expires, reissue a fine-grained PAT as the creative-graphic-design-dev account with Contents, Pull requests, Issues, and Workflows set to Read and write and access limited to the target repositories. Then update the `CGD_DEV_GH_TOKEN` line in zshenv_private.
-- To add a repository to the scope, add it under the PAT's Repository access. Reissuing the token is unnecessary; changing its configuration is sufficient.
+- If `gh auth token --user creative-graphic-design-dev` fails or the stored credential is rejected, remove that account with `gh auth logout --hostname github.com --user creative-graphic-design-dev`, then rerun `setup-gh-cgd`. This changes local authentication state and must be done interactively by the user.
+- If the identity check succeeds but repository permission is `false`, grant `creative-graphic-design-dev` access to the target repository before retrying. Reauthentication is unnecessary when only repository membership changes.

--- a/home/dot_config/exact_agents/skills/shunk031-cgd-dev-identity/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-cgd-dev-identity/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "skill": "shunk031-cgd-dev-identity",
+  "evals": [
+    {
+      "id": "write-cgd-pull-request",
+      "prompt": "Give the exact safe command sequence an agent should follow to commit an existing documentation change in creative-graphic-design/design-generators, push it, and create a pull request as the required machine user. Include the preflight checks and attribution rules.",
+      "should_trigger": true,
+      "assertions": [
+        "The response retrieves the creative-graphic-design-dev credential with gh auth token --user and passes it through GH_TOKEN only to the relevant gh or git command.",
+        "The response verifies both the creative-graphic-design-dev login and push permission for the target repository before writing.",
+        "The commit uses the creative-graphic-design-dev name and machine-user noreply email without changing shared git config.",
+        "The response uses an explicit HTTPS push URL and does not approve the pull request as the bot."
+      ]
+    },
+    {
+      "id": "bootstrap-cgd-authentication",
+      "prompt": "The creative-graphic-design-dev account is not configured on this new Mac. Prepare the supported authentication path before doing CGD repository work.",
+      "should_trigger": true,
+      "assertions": [
+        "The response runs or instructs the user to run setup-gh-cgd and authenticate as creative-graphic-design-dev.",
+        "The response does not request, print, persistently export, or store a PAT in dotfiles.",
+        "The response does not use gh auth switch as the runtime account-selection mechanism."
+      ]
+    },
+    {
+      "id": "personal-repository-write",
+      "prompt": "Commit and push a documentation fix to my personal GitHub repository outside creative-graphic-design.",
+      "should_trigger": false,
+      "assertions": [
+        "The response does not use the creative-graphic-design-dev credential or commit identity."
+      ]
+    }
+  ]
+}

--- a/home/dot_local/bin/exact_common/executable_setup-gh-cgd
+++ b/home/dot_local/bin/exact_common/executable_setup-gh-cgd
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# @file home/dot_local/bin/exact_common/executable_setup-gh-cgd
+# @brief Authenticate the CGD development account with GitHub CLI.
+# @description
+#   Adds the creative-graphic-design-dev account to GitHub CLI's credential
+#   store, verifies the stored identity, and restores the previously active
+#   account after an interactive login.
+
+set -Eeuo pipefail
+
+readonly CGD_GH_HOST="github.com"
+readonly CGD_GH_USER="creative-graphic-design-dev"
+
+# @description Run GitHub CLI without ambient token overrides.
+function gh_with_stored_auth() {
+    env -u GH_TOKEN -u GITHUB_TOKEN gh "$@"
+}
+
+# @description Print the token stored by GitHub CLI for the CGD account.
+# @stdout The stored authentication token.
+function get_cgd_token() {
+    gh_with_stored_auth auth token \
+        --hostname "${CGD_GH_HOST}" \
+        --user "${CGD_GH_USER}"
+}
+
+# @description Verify that the stored CGD credential resolves to the expected account.
+function verify_cgd_identity() {
+    local token login
+
+    token="$(get_cgd_token)" || return 1
+    login="$(GH_TOKEN="${token}" gh api user --jq .login)" || return 1
+
+    if [ "${login}" != "${CGD_GH_USER}" ]; then
+        printf 'Expected GitHub account %s, got %s.\n' "${CGD_GH_USER}" "${login}" >&2
+        return 1
+    fi
+}
+
+# @description Print the currently active GitHub account when one is available.
+# @stdout The active GitHub login, or no output when GitHub CLI is unauthenticated.
+function get_active_user() {
+    gh_with_stored_auth api user --jq .login 2> /dev/null
+}
+
+# @description Restore the account that was active before CGD login.
+# @arg $1 string Previously active GitHub login, or an empty string.
+function restore_active_user() {
+    local previous_user="$1"
+
+    if [ -n "${previous_user}" ] && [ "${previous_user}" != "${CGD_GH_USER}" ]; then
+        gh_with_stored_auth auth switch \
+            --hostname "${CGD_GH_HOST}" \
+            --user "${previous_user}"
+    fi
+}
+
+# @description Authenticate the CGD account and preserve the previous active account.
+function main() {
+    local previous_user
+
+    if get_cgd_token > /dev/null 2>&1; then
+        verify_cgd_identity
+        printf '%s is already authenticated in the GitHub CLI credential store.\n' "${CGD_GH_USER}"
+        return
+    fi
+
+    previous_user="$(get_active_user || true)"
+    printf 'Authenticate in the browser as %s.\n' "${CGD_GH_USER}"
+    gh_with_stored_auth auth login \
+        --hostname "${CGD_GH_HOST}" \
+        --git-protocol https \
+        --web
+
+    if ! verify_cgd_identity; then
+        restore_active_user "${previous_user}" || true
+        return 1
+    fi
+
+    restore_active_user "${previous_user}"
+    printf 'Authenticated %s in the GitHub CLI credential store.\n' "${CGD_GH_USER}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/tests/files/common.bats
+++ b/tests/files/common.bats
@@ -9,6 +9,7 @@
         "${HOME}/.config/tango.yml"
         "${HOME}/.local/bin/common/dev"
         "${HOME}/.local/bin/common/setup-gh"
+        "${HOME}/.local/bin/common/setup-gh-cgd"
         "${HOME}/.gnupg/gpg-agent.conf"
         "${HOME}/.ssh/config"
         "${HOME}/.vimrc"

--- a/tests/install/common/setup_gh_cgd.bats
+++ b/tests/install/common/setup_gh_cgd.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./home/dot_local/bin/exact_common/executable_setup-gh-cgd"
+
+function setup() {
+    export TEST_BIN_DIR="${BATS_TEST_TMPDIR}/bin"
+    export GH_CALLS_PATH="${BATS_TEST_TMPDIR}/gh_calls.txt"
+    export GH_LOGIN_STATE_PATH="${BATS_TEST_TMPDIR}/gh_login_state"
+    export GH_STUB_ACTIVE_USER="shunk031"
+    export GH_STUB_CGD_LOGIN="creative-graphic-design-dev"
+    PATH="${TEST_BIN_DIR}:$(getconf PATH)"
+    export PATH
+
+    mkdir -p "${TEST_BIN_DIR}"
+    rm -f "${GH_CALLS_PATH}" "${GH_LOGIN_STATE_PATH}"
+    write_gh_stub
+}
+
+function write_gh_stub() {
+    cat > "${TEST_BIN_DIR}/gh" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s|GH_TOKEN=%s\n' "$*" "${GH_TOKEN:-}" >> "${GH_CALLS_PATH}"
+
+case "$*" in
+    "auth token --hostname github.com --user creative-graphic-design-dev")
+        if [ -e "${GH_LOGIN_STATE_PATH}" ]; then
+            printf 'cgd-token\n'
+        else
+            exit 1
+        fi
+        ;;
+    "api user --jq .login")
+        if [ "${GH_TOKEN:-}" = "cgd-token" ]; then
+            printf '%s\n' "${GH_STUB_CGD_LOGIN}"
+        else
+            printf '%s\n' "${GH_STUB_ACTIVE_USER}"
+        fi
+        ;;
+    "auth login --hostname github.com --git-protocol https --web")
+        touch "${GH_LOGIN_STATE_PATH}"
+        ;;
+    "auth switch --hostname github.com --user "*)
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+
+    chmod +x "${TEST_BIN_DIR}/gh"
+}
+
+@test "[common] setup-gh-cgd logs in and restores the previous active account" {
+    run bash "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Authenticated creative-graphic-design-dev"* ]]
+    grep -Fx 'auth login --hostname github.com --git-protocol https --web|GH_TOKEN=' "${GH_CALLS_PATH}"
+    grep -Fx 'api user --jq .login|GH_TOKEN=cgd-token' "${GH_CALLS_PATH}"
+    grep -Fx 'auth switch --hostname github.com --user shunk031|GH_TOKEN=' "${GH_CALLS_PATH}"
+}
+
+@test "[common] setup-gh-cgd reuses an existing stored account" {
+    touch "${GH_LOGIN_STATE_PATH}"
+
+    run bash "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already authenticated"* ]]
+    ! grep -Fq 'auth login' "${GH_CALLS_PATH}"
+    ! grep -Fq 'auth switch' "${GH_CALLS_PATH}"
+}
+
+@test "[common] setup-gh-cgd rejects the wrong authenticated identity" {
+    touch "${GH_LOGIN_STATE_PATH}"
+    export GH_STUB_CGD_LOGIN="shunk031"
+
+    run bash "${SCRIPT_PATH}"
+    [ "${status}" -eq 1 ]
+    [[ "${output}" == *"Expected GitHub account creative-graphic-design-dev, got shunk031"* ]]
+}


### PR DESCRIPTION
## Why

The CGD development identity currently depends on a PAT exported to every shell. Store the account credential in the OS keychain instead and resolve it only for the GitHub command that needs it.

## What Changed

- Add `setup-gh-cgd` to bootstrap browser authentication for `creative-graphic-design-dev`, verify the stored identity, and restore the previously active GitHub account.
- Update `shunk031-cgd-dev-identity` to retrieve the account-specific token with `gh auth token --user creative-graphic-design-dev` for each `gh` or `git` write command.
- Remove the `CGD_DEV_GH_TOKEN` environment-variable and manually managed PAT assumptions.
- Add behavior evaluations and Bats coverage for the setup command and identity guidance.

## Validation

ShellCheck and shfmt passed for the updated shell code.

The Python suite passed with 35 tests and 85 subtests.

Secret-safe stub scenarios passed.

Skill static validation and real skill evaluation passed.

Local Bats was intentionally not run; Bats coverage is validated by GitHub Actions.
