### PR TITLE
feat(mise): add fnox for Codex authentication

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,7 @@
     {
       "matchManagers": ["mise"],
       "matchDepNames": [
+        "fnox",
         "herdr",
         "aqua:anthropics/claude-code",
         "aqua:google-antigravity/antigravity-cli",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -16,6 +16,7 @@ rust = "1.97.1"
 # CLI tools
 bun = "1.3.14"
 eza = "0.23.5"
+fnox = "1.32.0"
 gcloud = "575.0.0"
 herdr = "0.8.0"
 sqlite = "3.53.3"

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -190,6 +190,21 @@ function run_mise_bash_startup() {
     [ "${status}" -eq 0 ]
 }
 
+@test "[common] mise config pins fnox for command-backed authentication" {
+    run python3 - "${MISE_CONFIG_SOURCE}" << 'PYTHON'
+import sys
+import tomllib
+from pathlib import Path
+
+config = tomllib.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+assert config["min_version"] == "2026.8.2"
+assert config["tools"]["fnox"] == "1.32.0"
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] setup workflows reuse the chezmoi-bootstrapped mise" {
     local workflow
 

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -191,17 +191,16 @@ function run_mise_bash_startup() {
 }
 
 @test "[common] mise config pins fnox for command-backed authentication" {
-    run python3 - "${MISE_CONFIG_SOURCE}" << 'PYTHON'
-import sys
-import tomllib
-from pathlib import Path
+    run get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2026.8.2" ]
 
-config = tomllib.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-
-assert config["min_version"] == "2026.8.2"
-assert config["tools"]["fnox"] == "1.32.0"
-PYTHON
-
+    run awk '
+        /^\[tools\]$/ { in_tools = 1; next }
+        /^\[/ { in_tools = 0 }
+        in_tools && $0 == "fnox = \"1.32.0\"" { found = 1 }
+        END { exit !found }
+    ' "${MISE_CONFIG_SOURCE}"
     [ "${status}" -eq 0 ]
 }
 

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -51,6 +51,7 @@ mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
 expected_dep_names = [
+    "fnox",
     "herdr",
     "aqua:anthropics/claude-code",
     "aqua:google-antigravity/antigravity-cli",
@@ -89,6 +90,7 @@ codex_rule = next(
 )
 
 assert configured_dep_names == set(expected_dep_names)
+assert configured_agents["fnox"] == "fnox"
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")


### PR DESCRIPTION
## Why

Codex command-backed authentication needs `fnox` to be installed by the public mise configuration before the companion private authentication configuration can use it.

The companion change is https://github.com/shunk031/dotfiles-private/pull/144. This public dependency PR should merge first.

## What Changed

- Pin `fnox` 1.32.0 in the mise tool configuration without changing the `min_version` compatibility floor.
- Add `fnox` to the existing Renovate coverage for agent tooling.
- Add Bats assertions for the fnox pin, unchanged compatibility floor, and Renovate mapping.
- Keep the fnox assertion portable to the macOS system Python by using the existing mise-version helper and a POSIX `awk` check.
- Keep the public tool dependency separate from the private credential and Codex configuration.

## Validation

Check the committed diff for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Check the compatibility floor through the repository helper.

```shell
bash -c 'source ./install/common/mise.sh; test "$(get_mise_min_version_from_config ./home/dot_mise/config.toml)" = "2026.8.2"'
```

Check that fnox is pinned in the mise tools table.

```shell
awk '/^\[tools\]$/ { in_tools = 1; next } /^\[/ { in_tools = 0 } in_tools && $0 == "fnox = \"1.32.0\"" { found = 1 } END { exit !found }' ./home/dot_mise/config.toml
```

GitHub Actions validates the mise and Renovate Bats coverage on supported runners.
