### PR TITLE
refactor(tooling): remove legacy proxy tooling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,8 +45,7 @@
         "herdr",
         "aqua:anthropics/claude-code",
         "aqua:google-antigravity/antigravity-cli",
-        "aqua:openai/codex",
-        "github:router-for-me/CLIProxyAPI"
+        "aqua:openai/codex"
       ],
       "groupName": "agent tooling",
       "minimumReleaseAge": "0 days"

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -49,7 +49,6 @@ sqlite = "3.53.3"
 
 # GitHub release tools
 "github:d-kuro/gwq" = "0.1.1"
-"github:router-for-me/CLIProxyAPI" = "7.2.116"
 "github:shuntaka9576/blocc" = { version = "0.6.0", os = ["linux"] }
 
 # npm tools

--- a/install/ubuntu/server/ssh_server.sh
+++ b/install/ubuntu/server/ssh_server.sh
@@ -28,7 +28,7 @@ function install_openssh_server() {
 }
 
 #
-# @description Merge proxy and CLIProxyAPI variables into `AcceptEnv` in `sshd_config`.
+# @description Merge proxy variables into `AcceptEnv` in `sshd_config`.
 #
 function configure_accept_env() {
     local merged value
@@ -41,8 +41,6 @@ function configure_accept_env() {
         http_proxy
         https_proxy
         no_proxy
-        CLI_PROXY_API_CALLBACK_PORT
-        CLI_PROXY_API_PROXY_URL
     )
     values=()
 

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -56,7 +56,6 @@ expected_dep_names = [
     "aqua:anthropics/claude-code",
     "aqua:google-antigravity/antigravity-cli",
     "aqua:openai/codex",
-    "github:router-for-me/CLIProxyAPI",
 ]
 logical_names = {name.split("/")[-1] for name in expected_dep_names}
 configured_dep_names = {
@@ -94,7 +93,6 @@ assert configured_agents["fnox"] == "fnox"
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
-assert configured_agents["CLIProxyAPI"].startswith("github:")
 assert agent_rule["matchManagers"] == ["mise"]
 assert agent_rule["matchDepNames"] == expected_dep_names
 assert agent_rule["minimumReleaseAge"] == "0 days"

--- a/tests/install/ubuntu/common/ssh_server_unit.bats
+++ b/tests/install/ubuntu/common/ssh_server_unit.bats
@@ -56,7 +56,7 @@ function setup() {
     : > "${SERVICE_CALLS_PATH}"
 }
 
-@test "[ubuntu-common] configure_accept_env adds CLIProxyAPI variables" {
+@test "[ubuntu-common] configure_accept_env adds proxy variables" {
     cat > "${SSHD_CONFIG_PATH}" << 'EOF'
 Port 22
 AcceptEnv LANG LC_*
@@ -67,14 +67,18 @@ EOF
 
     run grep '^AcceptEnv ' "${SSHD_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
-    [[ "${output}" == *"CLI_PROXY_API_CALLBACK_PORT"* ]]
-    [[ "${output}" == *"CLI_PROXY_API_PROXY_URL"* ]]
+    [[ "${output}" == *"HTTP_PROXY"* ]]
+    [[ "${output}" == *"HTTPS_PROXY"* ]]
+    [[ "${output}" == *"NO_PROXY"* ]]
+    [[ "${output}" == *"http_proxy"* ]]
+    [[ "${output}" == *"https_proxy"* ]]
+    [[ "${output}" == *"no_proxy"* ]]
 }
 
 @test "[ubuntu-common] configure_accept_env preserves existing env vars and deduplicates" {
     cat > "${SSHD_CONFIG_PATH}" << 'EOF'
 AcceptEnv LANG HTTP_PROXY
-AcceptEnv CLI_PROXY_API_PROXY_URL NO_PROXY
+AcceptEnv NO_PROXY
 EOF
 
     run_ssh_server_function configure_accept_env
@@ -90,8 +94,6 @@ EOF
             if (counts["LANG"] != 1) exit 2
             if (counts["HTTP_PROXY"] != 1) exit 3
             if (counts["NO_PROXY"] != 1) exit 4
-            if (counts["CLI_PROXY_API_PROXY_URL"] != 1) exit 5
-            if (counts["CLI_PROXY_API_CALLBACK_PORT"] != 1) exit 6
         }
     ' "${SSHD_CONFIG_PATH}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

Remove the legacy CLIProxyAPI dependency and SSH environment forwarding from the public dotfiles source. This is coordinated with the private runtime-removal PR; neither pull request applies configuration or changes active runtime state.

## What Changed

- Remove the CLIProxyAPI mise tool pin and its Renovate coverage.
- Stop forwarding the legacy proxy environment variables through the Ubuntu SSH server configuration.
- Keep the fnox and Codex tool configuration intact.
- Update the focused Renovate and SSH-server test expectations.

## Validation

Check that the complete branch diff has no whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Inspect that the full pull-request diff is limited to the public tooling, Renovate, SSH forwarding, and focused test coverage.

```shell
git diff --name-status origin/main...HEAD
```

Bats tests are CI-only under repository policy and will run in GitHub Actions.
