### PR TITLE
fix(guidance): audit instruction consumers

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-manage-agent-guidance/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-manage-agent-guidance/SKILL.md
@@ -12,13 +12,14 @@ Keep each durable instruction in one source of truth and expose it through thin 
 1. Read all applicable guidance before proposing a change.
 2. Classify each rule as user-level, repository-level, subtree-level, task-only, custom-agent, or skill guidance. Treat a filename named in the request as a hypothesis, not as the confirmed target. Put behavioral rules shared across repositories at the user level, configuration and procedures for one repository at the repository level, and rules for a specific directory subtree at the subtree level.
 3. Locate the source of truth by inspecting higher-level instructions, managed sources, symlinks, imports, wrappers, and adapters. Edit that source for the classified scope instead of duplicating a rule across repository-level AGENTS.md files.
-4. Search current guidance and skills for an existing owner. Strengthen that owner instead of adding a duplicate.
-5. Before drafting or editing, report the evidence for scope, source of truth, and existing ownership. Name the inspected files, adapters, and matching owner rule; if none exists, state where you searched.
-6. Follow the scope-classification and source-of-truth rules above. Put concise cross-task invariants in the applicable `AGENTS.md` and specialized repeatable procedures in an existing relevant skill. Create a skill only when no existing owner fits and the procedure is substantial and reusable.
-7. Before committing or creating a PR, review the diff for each added instruction to confirm that its location matches its scope and that it does not duplicate higher-scope guidance; move it to the correct source of truth when the scope does not match, or ask before changing external state when it is unclear.
-8. Review the final diff for scope mismatch, duplication, secrets, transient facts, and adapter drift.
+4. Build a consumer map for every candidate overlap: record each canonical source, rendered path, actual reader, co-loaded higher-scope guidance, and standalone portability requirement. Matching wording does not prove redundant ownership, and different scope labels do not prove independent consumption. Decide separately for each consumer path instead of keeping or removing every copy as a group.
+5. Search current guidance and skills for an existing owner. Strengthen that owner instead of adding a duplicate.
+6. Before drafting or editing, report the evidence for scope, source of truth, existing ownership, and the consumer map. Name the inspected files, adapters, actual readers, and matching owner rule; if any are unknown, state what remains unverified.
+7. Follow the scope-classification and source-of-truth rules above. Put concise cross-task invariants in the applicable `AGENTS.md` and specialized repeatable procedures in an existing relevant skill. Create a skill only when no existing owner fits and the procedure is substantial and reusable.
+8. Before committing or creating a PR, review the diff for each added instruction to confirm that its location matches its scope and that it does not duplicate higher-scope guidance; move it to the correct source of truth when the scope does not match, or ask before changing external state when it is unclear.
+9. Review the final diff for scope mismatch, duplication, secrets, transient facts, and adapter drift.
 
-Do not draft or edit until steps 2–5 are complete. When evidence is unavailable, report the missing sources and propose the investigation instead of defaulting to the named file.
+Do not draft or edit until steps 2–6 are complete. When evidence is unavailable, report the missing sources and propose the investigation instead of defaulting to the named file.
 
 ## Persistence Quality
 

--- a/home/dot_config/exact_agents/skills/shunk031-manage-agent-guidance/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-manage-agent-guidance/evals/evals.json
@@ -57,6 +57,18 @@
       ]
     },
     {
+      "id": "audit-mixed-guidance-consumers",
+      "prompt": "This is a self-contained hypothetical dotfiles repository; use only the supplied facts. The exact safety rule `Fetch without writing FETCH_HEAD before creating a task worktree.` appears in three canonical files: the repository root `AGENTS.md`, `home/shared/AGENTS.md`, and `home/shared/agents/gh-workflow-manager.md`. Applying the dotfiles renders `home/shared/AGENTS.md` to `~/.agents/AGENTS.md` and the custom-agent file to `~/.agents/agents/gh-workflow-manager.md`. External clones read only the repository root and never receive these rendered user files. The owner's ordinary development sessions read both the repository root and rendered `~/.agents/AGENTS.md`. The gh-workflow-manager always reads rendered `~/.agents/AGENTS.md` before its custom-agent file. No wrapper copies the rule, and these are the complete consumer paths. Audit the apparent duplication and recommend what to keep, remove, or replace with a thin reference.",
+      "should_trigger": true,
+      "assertions": [
+        "The response maps each canonical source to its rendered path and actual readers, including which readers co-load higher-scope guidance.",
+        "The response keeps the repository-root rule for standalone external clones and the rendered user-level rule for cross-repository development, recognizing their intentional overlap for different consumer sets.",
+        "The response removes the custom-agent copy or replaces it with a minimal reference because gh-workflow-manager always co-loads the user-level owner.",
+        "The response does not classify all three copies as either required or redundant merely because their wording matches or their scope labels differ.",
+        "The response makes a separate ownership decision for each consumer path before recommending edits."
+      ]
+    },
+    {
       "id": "approved-removal-and-root-skill-ownership",
       "prompt": "In this hypothetical migration, a user explicitly approved exactly two removals of subjective error-handling guidance: source ID `hypothetical-coding-error-handling-1` with exact source text `- Error handling: Do not fear errors. Write the code first without focusing on error handling.`, and source ID `hypothetical-coding-final-deliverables-1` with exact source text `- Final deliverables: Final deliverables do not need error handling.` The supplied non-empty rationale for each removal is that the rule is subjective and redundant with the simplicity principle; no other removal is approved. The persistence-quality and skill-evaluation procedures are preserved and moved out of always-on `AGENTS.md`, not removed. The repository also has a README that owns skill-pool wiring and a gh-workflow-manager that owns exact gwq mechanics. Describe the migration and its review gates.",
       "should_trigger": true,

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -218,6 +218,10 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F 'When enforcement fully owns behavior, propose removal with concrete evidence and obtain approval rather than mapping it into `AGENTS.md` or a new skill.' "${MANAGE_AGENT_GUIDANCE_SKILL_PATH}/SKILL.md"
     [ "${status}" -eq 0 ]
+    run grep -F 'Build a consumer map for every candidate overlap' "${MANAGE_AGENT_GUIDANCE_SKILL_PATH}/SKILL.md"
+    [ "${status}" -eq 0 ]
+    run grep -F '"id": "audit-mixed-guidance-consumers"' "${MANAGE_AGENT_GUIDANCE_SKILL_PATH}/evals/evals.json"
+    [ "${status}" -eq 0 ]
     run grep -F '"id": "remove-machine-enforced-incident-guidance"' "${MANAGE_AGENT_GUIDANCE_SKILL_PATH}/evals/evals.json"
     [ "${status}" -eq 0 ]
     run grep -F 'hypothetical-incident-policy-1' "${MANAGE_AGENT_GUIDANCE_SKILL_PATH}/evals/evals.json"


### PR DESCRIPTION
## Why

Guidance with matching wording is not necessarily redundant: some copies serve standalone consumers, while others are always co-loaded with a higher-scope owner. Treating every apparent overlap as an all-or-nothing keep/remove decision can either break portability or preserve unnecessary duplication.

## What Changed

- Require a consumer map for each candidate overlap, covering canonical sources, rendered paths, actual readers, co-loaded higher-scope guidance, and standalone portability needs.
- Require ownership decisions per consumer path instead of classifying every matching copy as a group.
- Add a behavioral evaluation for mixed standalone, user-level, and custom-agent consumers.
- Add static coverage for the new workflow and evaluation case.

## Validation

Check the complete PR diff for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Validate the updated evaluation JSON.

```shell
jq empty home/dot_config/exact_agents/skills/shunk031-manage-agent-guidance/evals/evals.json
```

The Python suite passed with 52 tests. Prek static validation and real model evaluation also passed, including the commit hooks.

Local Bats was intentionally not run; Bats coverage is validated by GitHub Actions.
