### PR TITLE
refactor(zsh): remove private environment loader

### DIFF
--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -1,0 +1,2 @@
+# Remove the retired zshenv loader for private environment variables.
+.zshenv

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -1,7 +1,0 @@
-#!/usr/bin/env zsh
-
-readonly ZSHENV_PRIVATE="${HOME}/.zshenv_private"
-
-if [ -f "${ZSHENV_PRIVATE}" ]; then
-    source "${ZSHENV_PRIVATE}"
-fi


### PR DESCRIPTION
## Why

The portable `.zshenv` exists only to load an environment file owned by the private dotfiles repository. The LY SSE Cisco Umbrella CA environment has moved to mise in [the private companion PR](https://github.com/shunk031/dotfiles-private/pull/147), so the legacy shell loader can be retired.

Apply the private PR first and this public PR second to avoid a transient loss of the CA environment.

## What Changed

- Remove the public `.zshenv` loader for the private environment file.
- Add a chezmoi removal manifest for the previously applied `.zshenv`.
- Preserve the ownership split: the private repository owns the internal CA environment, while this public repository owns removal of the portable loader.

## Validation

Check the complete commit diff for whitespace errors.

```shell
git diff HEAD^ HEAD --check
```

Verify that the loader is gone and the removal manifest contains only its explanation and applied path.

```shell
test ! -e home/dot_zshenv
test "$(wc -l < home/.chezmoiremove | tr -d ' ')" -eq 2
sed -n '1p' home/.chezmoiremove | rg -q '^# '
sed -n '2p' home/.chezmoiremove | rg -qxF '.zshenv'
```

Local Bats tests were not run; repository policy reserves them for GitHub Actions.
