### PR TITLE
fix(evaluator): isolate Codex homes during skill evaluation

### DIFF
--- a/scripts/agent_guidance_eval.py
+++ b/scripts/agent_guidance_eval.py
@@ -981,6 +981,8 @@ def judge_results(
     with tempfile.TemporaryDirectory(prefix="agent-guidance-judge-") as tempdir:
         repo = Path(tempdir)
         initialize_temp_repo(repo)
+        codex_home = repo / "codex-home"
+        initialize_codex_home(codex_home)
         schema = repo / "judge-schema.json"
         schema.write_text(json.dumps(judge_schema()), encoding="utf-8")
 
@@ -990,6 +992,7 @@ def judge_results(
                 prompt,
                 timeout,
                 schema,
+                codex_home=codex_home,
                 **codex_settings_kwargs(model, reasoning_effort),
             )
 

--- a/tests/python/test_agent_guidance_eval.py
+++ b/tests/python/test_agent_guidance_eval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -715,6 +716,44 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         for name, value in observed.items():
             self.assertIsNone(value, name)
 
+    def test_codex_home_copies_config_and_auth_without_mutating_source(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        source = repo / "source-codex-home"
+        isolated = repo / "isolated-codex-home"
+        source.mkdir()
+        source_config = source / "config.toml"
+        source_auth = source / "auth.json"
+        config_bytes = (
+            b'[projects."/tmp/agent-skill-eval-live/repo"]\ntrust_level = "trusted"\n'
+        )
+        auth_bytes = b'{"auth": "fixture"}\n'
+        source_config.write_bytes(config_bytes)
+        source_auth.write_bytes(auth_bytes)
+        source_config.chmod(0o600)
+        source_auth.chmod(0o600)
+
+        with mock.patch.dict(os.environ, {"CODEX_HOME": str(source)}, clear=False):
+            self.module.initialize_codex_home(isolated)
+
+        target_config = isolated / "config.toml"
+        target_auth = isolated / "auth.json"
+        for target, expected, source_path in (
+            (target_config, config_bytes, source_config),
+            (target_auth, auth_bytes, source_auth),
+        ):
+            self.assertTrue(target.is_file())
+            self.assertFalse(target.is_symlink())
+            self.assertEqual(target.read_bytes(), expected)
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
+            self.assertEqual(source_path.read_bytes(), expected)
+            self.assertEqual(stat.S_IMODE(source_path.stat().st_mode), 0o600)
+
+        target_config.write_bytes(
+            target_config.read_bytes() + b"\n[projects.\"/tmp/new\"]\n"
+        )
+        self.assertEqual(source_config.read_bytes(), config_bytes)
+
     def test_web_search_override_enables_the_selected_custom_provider(self) -> None:
         with mock.patch.object(
             self.module,
@@ -810,6 +849,21 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
             ["--model", "gpt-5.6-luna", "-c", 'model_reasoning_effort="xhigh"'],
         )
 
+    def test_workspace_write_uses_cd_as_primary_codex_workspace(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        repo = Path("/tmp/agent-skill-eval/repo")
+        with mock.patch.object(
+            self.module.subprocess, "run", return_value=completed
+        ) as run:
+            self.module.invoke_codex(repo, "prompt", 10, sandbox="workspace-write")
+
+        command = run.call_args.args[0]
+        cd_index = command.index("--cd")
+        self.assertEqual(command[cd_index + 1], str(repo))
+        self.assertNotIn("--add-dir", command)
+
     def test_target_variants_receive_target_model_settings(self) -> None:
         tempdir, repo = self.make_repo()
         self.addCleanup(tempdir.cleanup)
@@ -904,8 +958,16 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
                 }
             }
         )
+
+        def fake_invoke(*args, **kwargs):
+            judge_home = kwargs["codex_home"]
+            self.assertTrue(judge_home.is_dir())
+            self.assertFalse((judge_home / "config.toml").is_symlink())
+            self.assertFalse((judge_home / "auth.json").is_symlink())
+            return trace
+
         with mock.patch.object(
-            self.module, "invoke_codex", return_value=trace
+            self.module, "invoke_codex", side_effect=fake_invoke
         ) as invoke:
             self.module.judge_results(
                 [case],


### PR DESCRIPTION
## Summary

- Use Codex CLI `--cd` as the evaluator workspace boundary and remove the ineffective redundant `--add-dir` workaround.
- Give target, baseline, and judge runs isolated `CODEX_HOME` directories with regular copies of `config.toml` and `auth.json`.
- Add regressions for source immutability, regular-file isolation, judge-home isolation, and `--cd` ownership.
- Preserve the current `main` Herdr-context and sandbox isolation; unrelated guidance changes are excluded.

## Validation

- `uv run --no-project python -m unittest tests.python.test_agent_guidance_eval`: 47 passed
- Full Python test suite: 70 passed
- `uv run --no-project python scripts/agent_guidance_eval.py validate --all`: passed
- `prek validate-config`: passed
- `uvx ruff check scripts/agent_guidance_eval.py tests/python/test_agent_guidance_eval.py`: passed
- `git diff --check origin/main...HEAD`: passed
- GitHub Actions Unit test matrix for `686a502`: all 4 passed

## External model evaluation (non-required)

- `make eval-skills` was attempted as an external evaluation; it is not a required GitHub check for this PR.
- The run reached real candidate/baseline judgments but did not complete because the Gateway model refresh disconnected, and a later cache-assisted run hit a 180-second Codex timeout.
- These provider/evaluation issues are separate from deterministic PR validation. No unrelated skill changes are included in the final diff.
