### PR TITLE
Document Herdr tab naming guidance in Codex instructions

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -49,4 +49,5 @@
 - Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
 - Write tests before behavior-changing implementation, verify them, and then refactor.
 - Use the `shunk031-manage-agent-guidance` skill when adding, moving, or deleting persistent instructions, agent wrappers, or skills.
+- When using Herdr, follow the `shunk031-herdr-tab-status` skill to keep the current tab name aligned with the work's progress status.
 - Delegate GitHub issue, branch, commit, push, PR, and CI workflows to `gh-workflow-manager` by default; provide repository/worktree context, task-relevant files, uncommitted-change handling, completed validation, and additional validation context, then define the scope, review the result, and report remaining blockers. Work directly only when explicitly requested or the agent is unavailable.

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: shunk031-herdr-tab-status
+description: Keep the current Herdr worker tab name aligned with task progress using leading status emojis. Use when working in a Herdr-managed pane and starting work, changing the current step, completing a PR, or becoming blocked.
+---
+
+# Herdr Tab Status
+
+Apply this ownership contract to the current worker tab. The worker owns its own tab and follows the `herdr` skill to rename it whenever its progress state changes. Keep the status emoji at the beginning and use a concise task or step name.
+
+- `🚧 <current step>` while work is in progress.
+- `✅ <task> <PR number>` after the commit, PR creation, and DONE report are complete.
+- `⛔ <task>` when the worker is blocked waiting for an answer. The worker may set this for itself; the orchestrator may set it on the worker's behalf when the worker is silent or dead. Do not change another worker's tab during normal work.
+
+Follow the `herdr` skill's Herdr-environment and current-tab safety requirements before issuing tab commands.

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/agents/openai.yaml
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Herdr Tab Status"
+  short_description: "Keep Herdr worker tabs status-labeled"
+  default_prompt: "Use $shunk031-herdr-tab-status to update the current Herdr tab name with its progress status."

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "skill": "shunk031-herdr-tab-status",
+  "evals": [
+    {
+      "id": "label-active-work",
+      "prompt": "I am working in a Herdr-managed pane and have started the implementation step for a task. Choose the current worker tab name and explain when it should be updated.",
+      "should_trigger": true,
+      "assertions": [
+        "The response uses a tab name beginning with the 🚧 emoji.",
+        "The response includes a concise current-step label after the emoji.",
+        "The response says to update the tab when the progress state changes."
+      ]
+    },
+    {
+      "id": "label-completed-pr",
+      "prompt": "The commit is complete, pull request 615 has been created, and I have reported DONE. Choose the final worker tab name and explain when this status should be used.",
+      "should_trigger": true,
+      "assertions": [
+        "The response uses a tab name beginning with the ✅ emoji.",
+        "The response includes the PR number 615 in the tab name.",
+        "The response connects the completed label to the commit, PR creation, and DONE report."
+      ]
+    },
+    {
+      "id": "label-blocked-work",
+      "prompt": "The worker is blocked waiting for an answer about an implementation choice. Choose the tab name the orchestrator should use.",
+      "should_trigger": true,
+      "assertions": [
+        "The response uses a tab name beginning with the ⛔ emoji.",
+        "The response includes a concise task label after the emoji.",
+        "The response identifies waiting for a question or being blocked as the reason for the label.",
+        "The response allows the blocked worker to set its own label and the orchestrator to set it on behalf of a silent or dead worker."
+      ]
+    },
+    {
+      "id": "tab-ownership",
+      "prompt": "Define who may change a Herdr worker tab during normal work, after completing a PR and DONE report, and when the worker is blocked or silent.",
+      "should_trigger": true,
+      "assertions": [
+        "The response assigns the worker ownership of its own tab during normal work.",
+        "The response assigns the worker the 🚧 and ✅ status updates.",
+        "The response allows the worker to set ⛔ when blocked and the orchestrator to set it for a silent/dead worker.",
+        "The response says not to change another worker's tab during normal work."
+      ]
+    },
+    {
+      "id": "ordinary-coding-question",
+      "prompt": "Explain in one paragraph why a binary search runs in logarithmic time.",
+      "should_trigger": false,
+      "assertions": [
+        "The response accurately explains binary search's logarithmic time complexity.",
+        "The response does not introduce Herdr tab naming guidance."
+      ]
+    }
+  ]
+}

--- a/home/dot_gemini/config/skills/symlink_shunk031-herdr-tab-status.tmpl
+++ b/home/dot_gemini/config/skills/symlink_shunk031-herdr-tab-status.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shunk031-herdr-tab-status

--- a/home/exact_dot_agents/skills/symlink_shunk031-herdr-tab-status.tmpl
+++ b/home/exact_dot_agents/skills/symlink_shunk031-herdr-tab-status.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shunk031-herdr-tab-status

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -260,7 +260,7 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F 'test_expected_thin_adapters_are_complete_and_exclusive' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'test_guidance_reverse_scan_has_all_fifteen_derived_paths' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
+    run grep -F 'test_guidance_reverse_scan_has_all_sixteen_derived_paths' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
     [ "${status}" -eq 0 ]
 }
 

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -666,8 +666,8 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
                     expected = adapter["occurrences"] if path == adapter["path"] else 0
                     self.assertEqual(text.count(adapter["text"]), expected)
 
-    def test_guidance_reverse_scan_has_all_fifteen_derived_paths(self) -> None:
-        self.assertEqual(len(self._guidance_paths()), 15)
+    def test_guidance_reverse_scan_has_all_sixteen_derived_paths(self) -> None:
+        self.assertEqual(len(self._guidance_paths()), 16)
 
     def test_third_party_research_has_one_routing_rule_and_skill_owner(self) -> None:
         agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"


### PR DESCRIPTION
## Why

Shared agent guidance needs one tool-neutral source for consistent Herdr tab-status behavior, and the new managed skill adds a legitimate guidance path that the reverse-scan CI test must count.

## What Changed

- Added the shared reference in `home/dot_config/exact_agents/AGENTS.md` to follow the `shunk031-herdr-tab-status` skill when using Herdr.
- Kept `home/dot_config/codex/AGENTS.md` limited to Codex-specific guidance, without a Herdr-specific rule.
- Added the managed `shunk031-herdr-tab-status` skill, its metadata, evaluation cases, and matching symlink templates for shared agents and Gemini.
- Defined worker-owned tab updates: `🚧 <current step>` during work, `✅ <task> <PR number>` after the commit, PR creation, and DONE report, and `⛔ <task>` when blocked waiting for an answer. The orchestrator may set `⛔` for a silent or dead worker; normal work does not change another worker's tab.
- Updated the guidance reverse-scan test to expect 16 derived paths and renamed the corresponding Bats assertion after the managed skill added one legitimate path.

## Validation

Run the focused Python guidance tests.

```shell
python3 -m unittest tests/python/test_agent_guidance_requirements.py
```

Run the skill validator across the repository.

```shell
python3 scripts/agent_skill_eval.py validate --all
```

Run static pre-commit validation for the changed guidance and skill files.

```shell
SKIP=agent-skill-eval prek run --files home/dot_config/exact_agents/AGENTS.md home/dot_config/codex/AGENTS.md home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
```

Check the complete diff for whitespace errors.

```shell
git diff --check
```

Skill-creator quick validation passed.

Local model evaluation was not performed: it could not start because the existing runtime configuration contains a TOML conflict marker at line 71. The private runtime configuration was not modified.
