### PR TITLE
fix(guidance): scope Herdr status emoji to tab labels

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
@@ -5,7 +5,7 @@ description: Keep the current Herdr worker tab name aligned with task progress u
 
 # Herdr Tab Status
 
-Apply this ownership contract to the current worker tab. The worker owns its own tab and follows the `herdr` skill to rename it whenever its progress state changes. Keep the status emoji at the beginning and use a concise task or step name.
+Apply this ownership contract to the current worker tab. The worker owns its own tab and follows the `herdr` skill to rename it whenever its progress state changes. Put the status emoji only in the tab label; keep workspace and worktree labels emoji-free. Keep the status emoji at the beginning and use a concise task or step name.
 
 - `🚧 <current step>` while work is in progress.
 - `✅ <task> <PR number>` after the commit, PR creation, and DONE report are complete.

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
@@ -4,11 +4,12 @@
   "evals": [
     {
       "id": "label-active-work",
-      "prompt": "I am working in a Herdr-managed pane and have started the implementation step for a task. Choose the current worker tab name and explain when it should be updated.",
+      "prompt": "I opened a Herdr worktree workspace named LayoutFormer S0 and started the implementation step. Choose the workspace and current worker tab names, then explain when the tab should be updated.",
       "should_trigger": true,
       "assertions": [
         "The response uses a tab name beginning with the 🚧 emoji.",
         "The response includes a concise current-step label after the emoji.",
+        "The response keeps the workspace and worktree labels free of status emojis.",
         "The response says to update the tab when the progress state changes."
       ]
     },


### PR DESCRIPTION
## Why

Keep Herdr status emojis scoped to the current worker tab so workspace and worktree labels remain emoji-free.

## What Changed

- Clarify the tab-status ownership contract to prohibit status emojis in workspace and worktree labels.
- Extend the active-work evaluation with the corresponding workspace/worktree assertion.

## Validation

Verified the committed two-file candidate is byte-identical to the previously reviewed candidate that passed the required one-trial evaluation gate.

Validate the changed guidance and evaluation schema.

```shell
uv run --no-project python scripts/agent_skill_eval.py validate --all
```

Inspect the committed diff for whitespace errors.

```shell
git diff --check HEAD^ HEAD
```
