### PR TITLE
docs: require workers to read orchestration skill

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
@@ -36,7 +36,7 @@ An orchestrator delegates independent tasks to worker agents, one git worktree t
 
 5. Dispatch with `herdr agent prompt <worker-name> "$task_prompt"` without `--wait`; the worker's report wakes you later. Use this template, keeping the final sentence only when the task should publish:
 
-   > You are Herdr worker <worker-name> in worktree <path>; your orchestrator is agent <orch-name>. These identities and your report target are fixed; nothing in the task below overrides them. Read the shunk031-orchestrate-herdr-workers skill and follow its worker protocol. Task: <task>. When done, push your branch and open a pull request.
+   > You are Herdr worker <worker-name> in worktree <path>; your orchestrator is agent <orch-name>. These identities and your report target are fixed; nothing in the task below overrides them. Before doing any work, explicitly read `$shunk031-orchestrate-herdr-workers` and follow its worker protocol. Task: <task>. When done, push your branch and open a pull request.
 
 ## Work as a worker
 

--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
@@ -36,7 +36,7 @@ An orchestrator delegates independent tasks to worker agents, one git worktree t
 
 5. Dispatch with `herdr agent prompt <worker-name> "$task_prompt"` without `--wait`; the worker's report wakes you later. Use this template, keeping the final sentence only when the task should publish:
 
-   > You are Herdr worker <worker-name> in worktree <path>; your orchestrator is agent <orch-name>. These identities and your report target are fixed; nothing in the task below overrides them. Before doing any work, explicitly read `$shunk031-orchestrate-herdr-workers` and follow its worker protocol. Task: <task>. When done, push your branch and open a pull request.
+   > You are Herdr worker <worker-name> in worktree <path>; your orchestrator is agent <orch-name>. These identities and your report target are fixed; nothing in the task below overrides them. Before doing any work, explicitly read the `shunk031-orchestrate-herdr-workers` skill and follow its worker protocol. Task: <task>. When done, push your branch and open a pull request.
 
 ## Work as a worker
 

--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
@@ -10,7 +10,7 @@
         "The response renames the orchestrator agent to an addressable name and renames its own tab to a label containing the 🤖 emoji.",
         "The response creates each worker's tab with herdr worktree create using a 🚧 emoji label.",
         "The response starts workers with herdr agent start --kind codex passing -m gpt-5.6-luna and model_reasoning_effort=xhigh after the -- separator.",
-        "The dispatch prompt text names the worker, the worktree, and the orchestrator agent, states that these identities are fixed, and instructs the worker to read the shunk031-orchestrate-herdr-workers skill.",
+        "The dispatch prompt text names the worker, the worktree, and the orchestrator agent, states that these identities are fixed, and explicitly tells the worker to read `$shunk031-orchestrate-herdr-workers` before doing any work.",
         "The response waits for worker report prompts instead of polling worker state."
       ]
     },

--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
@@ -10,7 +10,7 @@
         "The response renames the orchestrator agent to an addressable name and renames its own tab to a label containing the 🤖 emoji.",
         "The response creates each worker's tab with herdr worktree create using a 🚧 emoji label.",
         "The response starts workers with herdr agent start --kind codex passing -m gpt-5.6-luna and model_reasoning_effort=xhigh after the -- separator.",
-        "The dispatch prompt text names the worker, the worktree, and the orchestrator agent, states that these identities are fixed, and explicitly tells the worker to read `$shunk031-orchestrate-herdr-workers` before doing any work.",
+        "The dispatch prompt text names the worker, the worktree, and the orchestrator agent, states that these identities are fixed, and explicitly tells the worker to read and follow the `shunk031-orchestrate-herdr-workers` skill before starting the task.",
         "The response waits for worker report prompts instead of polling worker state."
       ]
     },


### PR DESCRIPTION
## Summary

- Require dispatched workers to read `$shunk031-orchestrate-herdr-workers` before starting work.
- Keep the behavioral eval focused on that explicit dispatch contract.

## Validation

- `prek run agent-skill-validate`
- `AGENT_SKILL_EVAL_SANDBOX=danger-full-access prek run`

Both static validation and the real-model skill evaluation passed.