### PR TITLE
fix(agents): clarify Herdr tab status handoffs

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
@@ -1,14 +1,27 @@
 ---
 name: shunk031-herdr-tab-status
-description: Keep the current Herdr worker tab name aligned with task progress using leading status emojis. Use when working in a Herdr-managed pane and starting work, changing the current step, completing a PR, or becoming blocked.
+description: Choose and update the current Herdr worker tab name with exact leading status emojis for active work, blocked work, user handoffs, and completion. Use whenever a Herdr tab label or its status meaning must be chosen or updated.
 ---
 
 # Herdr Tab Status
 
-Apply this ownership contract to the current worker tab. The worker owns its own tab and follows the `herdr` skill to rename it whenever its progress state changes. Put the status emoji only in the tab label; keep workspace and worktree labels emoji-free. Keep the status emoji at the beginning and use a concise task or step name.
+The worker owns its current tab and follows the `herdr` skill to rename it whenever progress changes. The leading emoji is the primary signal because the task label may be truncated. Put status only in the tab label; keep workspace and worktree labels emoji-free.
 
-- `🚧 <current step>` while work is in progress.
-- `✅ <task> <PR number>` after the commit, PR creation, and DONE report are complete.
-- `⛔ <task>` when the worker is blocked waiting for an answer. The worker may set this for itself; the orchestrator may set it on the worker's behalf when the worker is silent or dead. Do not change another worker's tab during normal work.
+Use exactly these states:
+
+- `🚧 <current step>` means work is actively progressing, including a live retry or diagnostic run.
+- `⛔ <next action>` means the worker cannot progress or close: it is waiting for an answer, review, approval, or merge; an external dependency blocks it; or it was stopped/superseded and awaits handoff or cleanup.
+- `✅ <task> <PR number>` means worker work and the required handoff are complete, with no action remaining.
+
+A pending review or merge is blocked work, not active work or completion; use a next-action label such as `⛔ review and merge PR <number>`. The worker renames its own tab. The orchestrator may set the blocked label only for a silent or dead worker and must not change another live worker's tab during normal work.
+
+When asked to choose a label, put the literal label on the first line, then explain it.
+
+For a BLOCKED report, the worker renames its own tab before reporting:
+
+```text
+herdr tab rename "$HERDR_TAB_ID" "⛔ <next action>"
+herdr agent prompt <orchestrator> "BLOCKED <worker>: <reason>"
+```
 
 Follow the `herdr` skill's Herdr-environment and current-tab safety requirements before issuing tab commands.

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md
@@ -5,7 +5,9 @@ description: Choose and update the current Herdr worker tab name with exact lead
 
 # Herdr Tab Status
 
-The worker owns its current tab and follows the `herdr` skill to rename it whenever progress changes. The leading emoji is the primary signal because the task label may be truncated. Put status only in the tab label; keep workspace and worktree labels emoji-free.
+The worker owns its current tab and follows the `herdr` skill to rename it whenever the progress state changes, including entering or leaving a retry. The leading emoji is the primary signal because the task label may be truncated. Put status only in the tab label; keep workspace and worktree labels emoji-free.
+
+`🚧`, `✅`, and `⛔` apply only to worker tabs. When the current agent is the orchestrator, preserve or set `🤖 Orchestrator` according to `shunk031-orchestrate-herdr-workers`; never replace it with a worker status while routing work.
 
 Use exactly these states:
 
@@ -13,7 +15,7 @@ Use exactly these states:
 - `⛔ <next action>` means the worker cannot progress or close: it is waiting for an answer, review, approval, or merge; an external dependency blocks it; or it was stopped/superseded and awaits handoff or cleanup.
 - `✅ <task> <PR number>` means worker work and the required handoff are complete, with no action remaining.
 
-A pending review or merge is blocked work, not active work or completion; use a next-action label such as `⛔ review and merge PR <number>`. The worker renames its own tab. The orchestrator may set the blocked label only for a silent or dead worker and must not change another live worker's tab during normal work.
+A published but open PR with DONE reported is still blocked while review or merge is user-only; keep the worker's `⛔` next-action label until that action resolves, then use completion only when no action remains. The worker renames its own tab. The orchestrator may set the blocked label only for a silent or dead worker and must not change another live worker's tab during normal work. A completion label always keeps a concise task and PR number, never a generic `DONE`.
 
 When asked to choose a label, put the literal label on the first line, then explain it.
 
@@ -23,5 +25,7 @@ For a BLOCKED report, the worker renames its own tab before reporting:
 herdr tab rename "$HERDR_TAB_ID" "⛔ <next action>"
 herdr agent prompt <orchestrator> "BLOCKED <worker>: <reason>"
 ```
+
+The `BLOCKED` reason must state why the worker cannot progress or close, such as an unavailable external dependency or stopped/superseded handoff.
 
 Follow the `herdr` skill's Herdr-environment and current-tab safety requirements before issuing tab commands.

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
@@ -4,44 +4,58 @@
   "evals": [
     {
       "id": "label-active-work",
-      "prompt": "I opened a Herdr worktree workspace named LayoutFormer S0 and started the implementation step. Choose the workspace and current worker tab names, then explain when the tab should be updated.",
+      "prompt": "I opened a Herdr worktree workspace named LayoutFormer S0 and started the implementation step; a live diagnostic retry is still progressing. Give the exact worker tab label first, then name the workspace and worktree labels and explain when the tab should be updated.",
       "should_trigger": true,
       "assertions": [
         "The response uses a tab name beginning with the 🚧 emoji.",
         "The response includes a concise current-step label after the emoji.",
         "The response keeps the workspace and worktree labels free of status emojis.",
-        "The response says to update the tab when the progress state changes."
+        "The response says to update the tab when the progress state changes.",
+        "The response keeps a live retry or diagnostic run in the 🚧 state rather than treating it as blocked or complete."
       ]
     },
     {
       "id": "label-completed-pr",
-      "prompt": "The commit is complete, pull request 615 has been created, and I have reported DONE. Choose the final worker tab name and explain when this status should be used.",
+      "prompt": "The commit and pull request 615 are complete, the required user review and merge are complete, and I have reported DONE. Give the exact final worker tab label first and explain when this status should be used.",
       "should_trigger": true,
       "assertions": [
         "The response uses a tab name beginning with the ✅ emoji.",
         "The response includes the PR number 615 in the tab name.",
-        "The response connects the completed label to the commit, PR creation, and DONE report."
+        "The response connects the completed label to the completed worker work, completed user handoff, and no remaining user action."
       ]
     },
     {
-      "id": "label-blocked-work",
-      "prompt": "The worker is blocked waiting for an answer about an implementation choice. Choose the tab name the orchestrator should use.",
+      "id": "label-user-action-required",
+      "prompt": "The worker created pull request 615 and reported DONE, but the user still needs to review and merge it. Review and merge are still pending, so ✅ is not allowed. Output the literal tab name `⛔ review and merge PR 615` first, then explain that the worker cannot progress or close until the user acts and that the worker owns it while live, while the orchestrator may set it only for a silent or dead worker.",
       "should_trigger": true,
       "assertions": [
         "The response uses a tab name beginning with the ⛔ emoji.",
         "The response includes a concise task label after the emoji.",
-        "The response identifies waiting for a question or being blocked as the reason for the label.",
-        "The response allows the blocked worker to set its own label and the orchestrator to set it on behalf of a silent or dead worker."
+        "The response identifies review or merge as the required user action.",
+        "The response says the pending review or merge prevents the worker from progressing or closing, distinguishing it from active work and completion.",
+        "The response allows the worker to set its own label and the orchestrator to set it on behalf of a silent or dead worker."
+      ]
+    },
+    {
+      "id": "label-blocked-work",
+      "prompt": "You are Herdr worker orch-render in a dedicated git worktree; your orchestrator is agent orch. An external dependency is unavailable, so the task cannot progress. This is an offline dry run — do not execute anything. Read the shunk031-herdr-tab-status skill and list the exact commands you would use to rename your own current tab before reporting BLOCKED to orch. The worker was stopped or superseded and is awaiting handoff or cleanup; do not mark the task complete.",
+      "should_trigger": true,
+      "assertions": [
+        "The response renames the worker's own current tab with herdr tab rename \"$HERDR_TAB_ID\" and a label beginning with the ⛔ emoji.",
+        "The response identifies the external dependency or stopped/superseded handoff or cleanup as why the worker cannot progress or close.",
+        "The response places the own-tab ⛔ rename before the BLOCKED report to the orchestrator.",
+        "The response reports BLOCKED to orchestrator agent orch after renaming the tab.",
+        "The response does not mark the blocked or superseded task with ✅."
       ]
     },
     {
       "id": "tab-ownership",
-      "prompt": "Define who may change a Herdr worker tab during normal work, after completing a PR and DONE report, and when the worker is blocked or silent.",
+      "prompt": "Give a compact mapping of who may change a Herdr worker tab during normal work, after handing off a PR for user review, after the user-facing task is complete, when the worker is blocked or stopped/superseded, and when the worker is silent. Include each literal status emoji (🚧, ⛔, and ✅), its owner, and the rule that ✅ is allowed only when no user action remains.",
       "should_trigger": true,
       "assertions": [
         "The response assigns the worker ownership of its own tab during normal work.",
-        "The response assigns the worker the 🚧 and ✅ status updates.",
-        "The response allows the worker to set ⛔ when blocked and the orchestrator to set it for a silent/dead worker.",
+        "The response assigns the worker the 🚧 status while working and ✅ only when no user action remains.",
+        "The response allows the worker to set ⛔ when user action is required or work cannot progress or close, and the orchestrator to set it for a silent/dead worker.",
         "The response says not to change another worker's tab during normal work."
       ]
     },

--- a/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
@@ -26,19 +26,19 @@
     },
     {
       "id": "label-user-action-required",
-      "prompt": "The worker created pull request 615 and reported DONE, but the user still needs to review and merge it. Review and merge are still pending, so ✅ is not allowed. Output the literal tab name `⛔ review and merge PR 615` first, then explain that the worker cannot progress or close until the user acts and that the worker owns it while live, while the orchestrator may set it only for a silent or dead worker.",
+      "prompt": "The worker published pull request 615 and reported DONE, but the PR is still OPEN: the user still needs to review and merge it, and the worker's worktree and tab intentionally remain alive through the PR lifecycle. Review and merge are still pending, so ✅ is not allowed. Output the literal tab name `⛔ review and merge PR 615` first, then explain that publishing a PR and reporting DONE do not complete the worker while this user-only action remains; the blocked label stays until the action resolves, and ✅ is allowed only after no action remains. Explicitly state that the worker owns its live tab label, while the orchestrator may set it only for a silent or dead worker; orchestration separately owns PR-lifetime retention and cleanup.",
       "should_trigger": true,
       "assertions": [
         "The response uses a tab name beginning with the ⛔ emoji.",
         "The response includes a concise task label after the emoji.",
         "The response identifies review or merge as the required user action.",
-        "The response says the pending review or merge prevents the worker from progressing or closing, distinguishing it from active work and completion.",
+        "The response says an OPEN PR and DONE report do not complete the worker while pending review or merge prevents it from progressing or closing, and that ✅ is allowed only after the action resolves.",
         "The response allows the worker to set its own label and the orchestrator to set it on behalf of a silent or dead worker."
       ]
     },
     {
       "id": "label-blocked-work",
-      "prompt": "You are Herdr worker orch-render in a dedicated git worktree; your orchestrator is agent orch. An external dependency is unavailable, so the task cannot progress. This is an offline dry run — do not execute anything. Read the shunk031-herdr-tab-status skill and list the exact commands you would use to rename your own current tab before reporting BLOCKED to orch. The worker was stopped or superseded and is awaiting handoff or cleanup; do not mark the task complete.",
+      "prompt": "You are Herdr worker orch-render in a dedicated git worktree; your orchestrator is agent orch. An external dependency is unavailable, so the task cannot progress or close. This is an offline dry run — do not execute anything. Read the shunk031-herdr-tab-status skill, explain that reason, and list the exact commands you would use to rename your own current tab before reporting BLOCKED to orch. The worker was stopped or superseded and is awaiting handoff or cleanup; do not mark the task complete.",
       "should_trigger": true,
       "assertions": [
         "The response renames the worker's own current tab with herdr tab rename \"$HERDR_TAB_ID\" and a label beginning with the ⛔ emoji.",
@@ -57,6 +57,16 @@
         "The response assigns the worker the 🚧 status while working and ✅ only when no user action remains.",
         "The response allows the worker to set ⛔ when user action is required or work cannot progress or close, and the orchestrator to set it for a silent/dead worker.",
         "The response says not to change another worker's tab during normal work."
+      ]
+    },
+    {
+      "id": "orchestrator-status-precedence",
+      "prompt": "You are the Herdr orchestrator routing work to several worker agents. A developer reminds you to use shunk031-herdr-tab-status while routing the work. You are coordinating, not doing a worker task yourself. Output the exact current tab label `🤖 Orchestrator` first. Then name each of `🚧`, `✅`, and `⛔` as worker-tab statuses and explain which guidance owns the orchestrator label; preserve it rather than applying a worker status.",
+      "should_trigger": true,
+      "assertions": [
+        "The response keeps or sets the current orchestrator tab label to 🤖 Orchestrator.",
+        "The response says 🚧, ✅, and ⛔ are worker-tab statuses and do not replace the orchestrator label.",
+        "The response does not use 🚧, ✅, or ⛔ as the current orchestrator tab status."
       ]
     },
     {


### PR DESCRIPTION
## Why

Clarify Herdr worker tab labels so active retries remain visibly active and blocked or user-owned next actions are not presented as complete.

## What Changed

- Define `🚧` for active progress, including live retries and diagnostics.
- Define `⛔` for work that cannot progress or close, including user action, external dependencies, BLOCKED work, and stopped or superseded handoff.
- Reserve `✅` for completed work and handoff with no remaining action.
- Apply these three statuses only to worker tabs; preserve `🤖 Orchestrator` for an orchestrating agent.
- Keep an OPEN PR with `DONE` and pending user review or merge at `⛔` until that action resolves; orchestration retains separate PR-lifetime cleanup ownership.
- Require the worker to rename its own tab to `⛔` before reporting `BLOCKED`, including the blocking reason.
- Keep generic blocked-work and PR handoff lifecycle coverage, plus one orchestrator-precedence evaluation.

## Validation

Set up the repository tools.

```shell
make setup
```

Run merged guidance-wide static validation.

```shell
AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access uv run --no-project python scripts/agent_guidance_eval.py validate --all
```

Run the fresh real-model evaluation for the staged candidate.

```shell
AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 1 --jobs 1 --timeout 180
```

Run applicable changed-file hooks.

```shell
AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access prek run --files home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/SKILL.md home/dot_config/exact_agents/skills/shunk031-herdr-tab-status/evals/evals.json
```