### PR TITLE
fix(guidance): enforce research evidence and validation guardrails

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -40,6 +40,7 @@
 - Before modifying tracked files, inspect the branch and worktree. Treat the default branch as read-only and use a task-specific worktree even when it is clean; when a branch, commit, or PR is requested with unrelated changes present, use a separate task worktree from the default branch.
 - Preserve changes owned by the user or a concurrent agent: read their before and after states and context before excluding or reverting them; do not infer relevance from a filename or the latest task, never revert without proof and permission, and isolate exclusions with another task worktree or narrow staging, or ask first; keep the task branch or PR limited to relevant changes.
 - Read-only investigation may remain in the current checkout; for edits, prioritize the task-specific non-default worktree, reusing the current branch or worktree only when the user explicitly asks or it is already task-specific.
+- Never bypass repository hooks or validation with `--no-verify` or an equivalent. If a hook fails, hangs, or reports no matching targets, stop and report it instead of treating validation as successful.
 - If an operation accidentally removes uncommitted work, report it to the user immediately and attempt recovery from the preceding diff, editor history, shell output, stash, or subagent output. Do not perform additional overwrites before recovery.
 
 ## Working Style

--- a/home/dot_config/exact_agents/skills/shunk031-research-before-implementation/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-research-before-implementation/SKILL.md
@@ -11,6 +11,6 @@ Treat research as a gate, not a recommendation. Before any design decision or fi
 2. Only after those results return, call the native web search tool again with results restricted to `github.com`. Inspect representative implementation code or configuration and operational patterns, not only repository descriptions.
 3. Compare the documented behavior with the GitHub examples. Resolve version, platform, and maintenance differences before choosing the design.
 4. Implement and verify the change based on that evidence.
-5. In the final response, name and link the web sources and GitHub examples consulted and state how they affected the implementation.
+5. In the final response, name and link the web sources and GitHub examples consulted and state how they affected the implementation. The final response must list at least one official non-GitHub URL and one representative GitHub URL, and explain how each source affected the implementation. The GitHub URL must point directly to implementation code or configuration, not only a README, release, or marketplace page.
 
-Do not edit files until both tool calls are complete. Do not substitute memory or local repository inspection for either external research stage. If a required source cannot be accessed, report the limitation before implementation instead of silently skipping the stage.
+Do not edit files until both tool calls are complete. Do not substitute memory or local repository inspection for either external research stage. If either stage fails, returns no usable sources, or cannot be accessed, stop before designing or editing; report the limitation instead of continuing with an implementation.

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -727,9 +727,35 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
         self.assertLess(web_search, github_search)
         self.assertLess(github_search, implementation)
         self.assertIn("Do not edit files until both tool calls are complete", skill)
+        self.assertIn("stop before designing or editing", skill)
         self.assertIn(
             "In the final response, name and link the web sources and GitHub examples consulted",
             skill,
+        )
+        self.assertIn(
+            "The final response must list at least one official non-GitHub URL and one representative GitHub URL",
+            skill,
+        )
+        self.assertIn(
+            "explain how each source affected the implementation",
+            skill,
+        )
+        self.assertIn(
+            "The GitHub URL must point directly to implementation code or configuration",
+            skill,
+        )
+
+    def test_work_safety_rejects_hook_bypass_and_targetless_validation(self) -> None:
+        agents = (REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md").read_text(
+            encoding="utf-8"
+        )
+        guardrail = (
+            "Never bypass repository hooks or validation with `--no-verify` or an equivalent."
+        )
+        self.assertEqual(agents.count(guardrail), 1)
+        self.assertIn(
+            "If a hook fails, hangs, or reports no matching targets, stop and report it",
+            agents,
         )
 
     def test_manage_agent_guidance_route_has_one_working_style_owner(self) -> None:


### PR DESCRIPTION
## Summary

- Make research-before-implementation fail closed when either external research stage fails or returns no usable sources.
- Require final reports to name an official non-GitHub source and a direct GitHub implementation or configuration URL, with the impact of each source.
- Add a reusable no-hook-bypass and validation-failure guardrail to shared agent guidance.
- Add exact-string regression coverage.

## Validation

- `uv run --no-project python -m unittest discover -s tests/python` — 71 passed
- `uv run --no-project python scripts/agent_guidance_eval.py validate --staged` — passed
- Real model evaluation with `gpt-5.5` / `medium` — passed
- `prek validate-config` — passed
- `prek run --all-files` — validate and evaluate hooks passed
- Commit hooks ran normally; no `--no-verify` or `SKIP` bypass was used.

The current Gateway default target model timed out during the hook, so the successful local model evaluation used the existing `AGENT_GUIDANCE_EVAL_CODEX` executable override to run the entitled `gpt-5.5` / `medium` path. No model or credential configuration was changed in this PR.

## Scope

This PR is separate from open PR #628 and does not merge or modify it.