### PR TITLE
fix(evaluator): run guidance eval hook with three trials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
 
       - id: agent-guidance-eval
         name: evaluate changed agent skills and guidance
-        entry: uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 1 --jobs 2 --timeout 600
+        entry: uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 3 --jobs 2 --timeout 600
         language: system
         pass_filenames: false
         files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json|skills/)


### PR DESCRIPTION
## Why

The `agent-guidance-eval` pre-commit hook decided pass/fail from a single trial.
A single trial cannot discriminate a real guidance defect from model and judge
variance: a behaviorally identical staged candidate produced one full PASS and
one 5-assertion FAIL under `--trials 1`. The hook's verdict was therefore
decided by run-to-run noise rather than by the guidance under test.

This does not invent a new acceptance rule. The repository already predeclares a
three-trial rule for the all-target evaluator: `make eval-guidance` runs
`--trials 3`, and `evaluate_target` aggregates every `(case, trial)` pair with
all-trials-must-pass semantics, both for the trigger check and for the judged
assertions. This PR applies that same predeclared rule to the pre-commit hook so
the staged path and the all-target path agree on what acceptance means.

Prescribed by an independent reviewer, and a prerequisite for the corrected
acceptance run of #627. It builds on #630, which raised the per-invocation
timeout to 600s.

## What Changed

One line in `.pre-commit-config.yaml`: the `agent-guidance-eval` hook entry now
passes `--trials 3` instead of `--trials 1`.

The `Makefile` is deliberately untouched, because its `eval-guidance` target
already uses `--trials 3`. The evaluator default in
`scripts/agent_guidance_eval.py` is also untouched, and no helper or adapter was
added.

Trade-off: hook runs become up to roughly three times longer, since each case is
now executed three times. Each individual trial stays bounded by the
`--timeout 600` budget established in #630.

<details>
<summary>Full diff</summary>

```diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index a0e570c..e715e9a 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:

       - id: agent-guidance-eval
         name: evaluate changed agent skills and guidance
-        entry: uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 1 --jobs 2 --timeout 600
+        entry: uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 3 --jobs 2 --timeout 600
         language: system
         pass_filenames: false
         files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json|skills/)
```

</details>

## Validation

Confirm the change is one line in one file and that the Makefile target and the
evaluator default were not modified.

```shell
git diff --stat origin/main...HEAD
grep -rn -- "--trials" .pre-commit-config.yaml Makefile scripts/agent_guidance_eval.py
```

Check that the modified pre-commit configuration still parses as a valid hook
configuration.

```shell
prek validate-config .pre-commit-config.yaml
```

Confirm the all-target evaluator invocation is unchanged and still declares three
trials, so both command consumers now agree.

```shell
make -n eval-guidance
```

Run the repository hooks against the changed file. This PR changes no guidance or
skill target, so the guidance eval hook correctly reports no changed behavioral
target and skips instead of running the real-model gate.

```shell
prek run --files .pre-commit-config.yaml
```

The all-trials-must-pass claim was verified by reading the aggregation in
`evaluate_target`, where the trigger check uses `all(...)` over every result and
a failing judged entry clears the assertion verdict for the whole target.

The full real-model eval gate was deliberately not run, since this PR changes no
behavioral target for it to evaluate.
