### PR TITLE
fix(evaluator): apply research overrides to Codex exec

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-research-before-implementation/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-research-before-implementation/SKILL.md
@@ -7,8 +7,8 @@ description: Research current official web documentation and representative GitH
 
 Treat research as a gate, not a recommendation. Before any design decision or file edit, complete these tool stages in order:
 
-1. Call the agent's native web search tool (`web_search` in Codex) for current official sources. Inspect documentation, specifications, release notes, and recommended approaches from at least one relevant non-GitHub domain.
-2. Only after those results return, call the native web search tool again with results restricted to `github.com`. Inspect representative implementation code or configuration and operational patterns, not only repository descriptions.
+1. Use an available web-research capability for current official sources. Inspect documentation, specifications, release notes, and recommended approaches from at least one relevant non-GitHub domain.
+2. Only after those results return, use a GitHub search or inspect `github.com` sources. Inspect representative implementation code or configuration and operational patterns, not only repository descriptions.
 3. Compare the documented behavior with the GitHub examples. Resolve version, platform, and maintenance differences before choosing the design.
 4. Implement and verify the change based on that evidence.
 5. In the final response, name and link the web sources and GitHub examples consulted and state how they affected the implementation. The final response must list at least one official non-GitHub URL and one representative GitHub URL, and explain how each source affected the implementation. The GitHub URL must point directly to implementation code or configuration, not only a README, release, or marketplace page.

--- a/scripts/agent_guidance_eval.py
+++ b/scripts/agent_guidance_eval.py
@@ -569,6 +569,11 @@ def parse_trace(
                 target_read = True
             if re.search(r"\bgh\s+search\s+(?:code|repos?|commits?)\b", command):
                 actions.append("github_search")
+            elif "github.com" in command.lower() or "githubusercontent.com" in command.lower():
+                if re.search(r"\b(?:curl|wget|git\s+(?:clone|fetch)|gh\s+(?:api|browse|repo|search))\b", command):
+                    actions.append("github_search")
+            elif re.search(r"\b(?:curl|wget)\b.*https?://", command):
+                actions.append("web_search")
     return ParsedTrace(
         output=messages[-1] if messages else "",
         target_read=target_read,
@@ -647,34 +652,6 @@ def codex_executable() -> str:
     return os.environ.get("AGENT_GUIDANCE_EVAL_CODEX", "codex")
 
 
-def configured_model_provider() -> str | None:
-    config_path = Path.home() / ".codex/config.toml"
-    try:
-        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return None
-    provider = config.get("model_provider")
-    providers = config.get("model_providers")
-    if (
-        not isinstance(provider, str)
-        or not provider
-        or not isinstance(providers, dict)
-        or not isinstance(providers.get(provider), dict)
-    ):
-        return None
-    return provider
-
-
-def web_search_provider_override() -> str | None:
-    provider = configured_model_provider()
-    if provider is None:
-        return None
-    key = (
-        provider if re.fullmatch(r"[A-Za-z0-9_-]+", provider) else json.dumps(provider)
-    )
-    return f"model_providers.{key}.supports_standalone_web_search=true"
-
-
 def disabled_skill_override() -> str | None:
     paths: set[Path] = set()
     home = Path.home()
@@ -706,19 +683,24 @@ def invoke_codex(
     # sandbox at all; AGENT_GUIDANCE_EVAL_SANDBOX lets such hosts pick the
     # sandbox mode explicitly (for example danger-full-access).
     sandbox = os.environ.get("AGENT_GUIDANCE_EVAL_SANDBOX", sandbox)
-    command = [codex_executable(), "--disable", "plugins"]
+    command = [codex_executable(), "--disable", "plugins", "exec"]
+    command.extend(codex_model_arguments(model, reasoning_effort))
     if search:
-        command.append("--search")
-        provider_override = web_search_provider_override()
-        if provider_override:
-            command.extend(["-c", provider_override])
+        # Keep research evals independent of the provider's standalone search
+        # endpoint; shell-based URL retrieval is classified from the trace.
+        command.extend(
+            [
+                "-c",
+                'web_search="disabled"',
+                "-c",
+                "sandbox_workspace_write.network_access=true",
+            ]
+        )
     override = disabled_skill_override()
     if override:
         command.extend(["-c", override])
     command.extend(
         [
-            "exec",
-            *codex_model_arguments(model, reasoning_effort),
             "--ephemeral",
             "--json",
             "--sandbox",

--- a/tests/python/test_agent_guidance_eval.py
+++ b/tests/python/test_agent_guidance_eval.py
@@ -597,6 +597,40 @@ class AgentGuidanceEvalTest(unittest.TestCase):
             )
         )
 
+    def test_parse_trace_records_shell_research_before_file_change(self) -> None:
+        trace = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "curl -fsSL https://developers.openai.com/codex/codex-manual.md",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "curl -fsSL https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/web_search.rs",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "file_change", "changes": []},
+                    }
+                ),
+            ]
+        )
+
+        parsed = self.module.parse_trace(trace, "demo")
+
+        self.assertEqual(parsed.actions, ("web_search", "github_search", "file_change"))
+
     def test_parse_trace_recognizes_gh_code_search_as_github_research(self) -> None:
         trace = json.dumps(
             {
@@ -754,19 +788,6 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         )
         self.assertEqual(source_config.read_bytes(), config_bytes)
 
-    def test_web_search_override_enables_the_selected_custom_provider(self) -> None:
-        with mock.patch.object(
-            self.module,
-            "configured_model_provider",
-            return_value="custom-provider",
-        ):
-            override = self.module.web_search_provider_override()
-
-        self.assertEqual(
-            override,
-            "model_providers.custom-provider.supports_standalone_web_search=true",
-        )
-
     def test_sandbox_override_replaces_requested_sandbox(self) -> None:
         completed = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
@@ -792,20 +813,15 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         sandbox_index = command.index("--sandbox")
         self.assertEqual(command[sandbox_index + 1], "danger-full-access")
 
-    def test_invoke_places_global_search_config_before_exec(self) -> None:
+    def test_invoke_disables_native_search_for_research(self) -> None:
         completed = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
         with (
             mock.patch.object(
                 self.module,
-                "web_search_provider_override",
-                return_value="model_providers.custom.supports_standalone_web_search=true",
-            ),
-            mock.patch.object(
-                self.module,
                 "disabled_skill_override",
-                return_value='skills.config=[{path="/tmp/demo",enabled=false}]',
+                return_value="",
             ),
             mock.patch.object(
                 self.module.subprocess, "run", return_value=completed
@@ -815,17 +831,39 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
 
         command = run.call_args.args[0]
         exec_index = command.index("exec")
-        self.assertLess(command.index("--search"), exec_index)
-        disable_index = command.index("--disable")
-        self.assertEqual(command[disable_index + 1], "plugins")
-        self.assertLess(disable_index, exec_index)
+        self.assertNotIn("--search", command)
+        self.assertIn('web_search="disabled"', command)
+        self.assertIn("sandbox_workspace_write.network_access=true", command)
+        self.assertGreater(command.index('web_search="disabled"'), exec_index)
+        self.assertGreater(
+            command.index("sandbox_workspace_write.network_access=true"), exec_index
+        )
+        self.assertNotIn("supports_standalone_web_search", " ".join(command))
         self.assertTrue(
             all(
-                index < exec_index
+                index > exec_index
                 for index, value in enumerate(command)
                 if value == "-c"
             )
         )
+
+    def test_invoke_places_skill_override_after_exec(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with (
+            mock.patch.object(
+                self.module,
+                "disabled_skill_override",
+                return_value="skills.config=[]",
+            ),
+            mock.patch.object(self.module.subprocess, "run", return_value=completed) as run,
+        ):
+            self.module.invoke_codex(Path("/tmp"), "prompt", 10)
+
+        command = run.call_args.args[0]
+        exec_index = command.index("exec")
+        self.assertGreater(command.index("skills.config=[]"), exec_index)
 
     def test_invoke_adds_model_and_reasoning_effort_to_exec(self) -> None:
         completed = subprocess.CompletedProcess(
@@ -848,6 +886,7 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
             command[exec_index + 1 : exec_index + 5],
             ["--model", "gpt-5.6-luna", "-c", 'model_reasoning_effort="xhigh"'],
         )
+        self.assertNotIn("sandbox_workspace_write.network_access=true", command)
 
     def test_workspace_write_uses_cd_as_primary_codex_workspace(self) -> None:
         completed = subprocess.CompletedProcess(

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -714,11 +714,9 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
         )
         agents = agents_path.read_text(encoding="utf-8")
         skill = skill_path.read_text(encoding="utf-8")
-        web_search = skill.index(
-            "Call the agent's native web search tool (`web_search` in Codex)"
-        )
+        web_search = skill.index("Use an available web-research capability")
         github_search = skill.index(
-            "call the native web search tool again with results restricted to `github.com`"
+            "use a GitHub search or inspect `github.com` sources"
         )
         implementation = skill.index("Implement and verify")
 


### PR DESCRIPTION
## Summary

- Apply Codex configuration overrides after the `exec` subcommand, where Codex CLI 0.146.0 actually consumes them.
- Keep research evaluations independent of the provider standalone-search endpoint by disabling native search and enabling network access only for research candidates/baselines running in `workspace-write`.
- Classify shell-based official web and GitHub retrieval in the trace, and keep the research skill tool-neutral.

## Validation

- `uv run --no-project python -m unittest discover -s tests/python -p 'test_agent_guidance_eval.py'` (48 passed)\n- `uv run --no-project python -m unittest discover -s tests/python -p 'test_agent_guidance_requirements.py'` (19 passed)\n- `uv run --no-project python scripts/agent_guidance_eval.py validate --staged`\n- `prek run --files home/dot_config/exact_agents/skills/shunk031-research-before-implementation/SKILL.md` (validate and real model eval passed)\n- `uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 1 --jobs 2 --timeout 600` (passed)\n- Commit hook passed without `--no-verify`.\n\n## Research\n\n- Official Codex manual: https://developers.openai.com/codex/codex-manual.md\n- Codex configuration implementation: https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs\n- Codex web-search tests: https://github.com/openai/codex/blob/main/codex-rs/core/tests/suite/web_search.rs\n\nThe official manual documents that `workspace-write` disables network access by default and supports `sandbox_workspace_write.network_access=true`; the implementation and tests confirm the web-search mode and configuration behavior used by the runner.