### PR TITLE
fix(evaluator): calibrate policy gate aggregation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     hooks:
       - id: agent-guidance-validate
         name: validate changed agent skills and guidance
-        entry: uv run --no-project python scripts/agent_guidance_eval.py validate --staged
+        entry: uv run --python 3.14.6 --no-project python scripts/agent_guidance_eval.py validate --staged
         language: system
         pass_filenames: false
         files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json|skills/)
 
       - id: agent-guidance-eval
         name: evaluate changed agent skills and guidance
-        entry: uv run --no-project python scripts/agent_guidance_eval.py eval --staged --trials 3 --jobs 2 --timeout 600
+        entry: uv run --python 3.14.6 --no-project python scripts/agent_guidance_eval.py eval --staged --trials 3 --jobs 2 --timeout 600
         language: system
         pass_filenames: false
-        files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json|skills/)
+        files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json|skills/[^/]+/(SKILL\.md|evals/evals\.json))$

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ setup:
 
 .PHONY: eval-guidance
 eval-guidance:
-	uv run --no-project python scripts/agent_guidance_eval.py eval --all --trials 3 --jobs 2 --timeout 600
+	uv run --python 3.14.6 --no-project python scripts/agent_guidance_eval.py eval --all --trials 3 --jobs 2 --timeout 600
 
 #
 # Docker

--- a/scripts/agent_guidance_eval.py
+++ b/scripts/agent_guidance_eval.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 
-"""Validate and evaluate agent skills and guidance with isolated Codex runs."""
+"""Validate and evaluate agent skills and guidance with isolated Codex runs.
+
+UNPROVEN_POLICY: If behavior-identical candidates produce contradictory real-model
+results, classify the candidate as UNPROVEN. Declare the acceptance rule before
+execution and do not retry an acceptance failure until the rule produces PASS.
+The default acceptance rule is per-case trial majority, complete coverage, and
+candidate_wins >= baseline_wins; ``--strict-all-trials`` restores the previous
+all-trials assertion rule.
+"""
 
 from __future__ import annotations
 
@@ -20,8 +28,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TypeVar
 
-import tomllib
-
 SKILLS_ROOT = Path("home/dot_config/exact_agents/skills")
 GUIDANCE_PATH = Path("home/dot_config/exact_agents/AGENTS.md")
 GUIDANCE_EVAL_PATH = Path("home/dot_config/exact_agents/AGENTS.evals.json")
@@ -36,6 +42,15 @@ TRANSIENT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 T = TypeVar("T")
+MINIMUM_PYTHON = (3, 11)
+
+
+def require_supported_python() -> None:
+    if sys.version_info < MINIMUM_PYTHON:
+        raise SystemExit(
+            "agent_guidance_eval.py requires Python 3.11+; "
+            "run the hook with uv --python 3.14.6 or set UV_PYTHON=3.14.6"
+        )
 
 
 @dataclass(frozen=True)
@@ -47,6 +62,7 @@ class EvalConfig:
     reasoning_effort: str = DEFAULT_TARGET_REASONING_EFFORT
     judge_model: str = DEFAULT_JUDGE_MODEL
     judge_reasoning_effort: str = DEFAULT_JUDGE_REASONING_EFFORT
+    strict_all_trials: bool = False
 
 
 @dataclass(frozen=True)
@@ -130,6 +146,25 @@ class ResultCache:
             json.dump(result, handle, ensure_ascii=False, sort_keys=True)
             temporary = Path(handle.name)
         temporary.replace(destination)
+
+    def evidence_path(self, key: str) -> Path:
+        """Return the canonical failure evidence path adjacent to the cache log."""
+        return self.root / f"{key}.evidence.json"
+
+    def store_evidence(self, key: str, evidence: dict[str, object]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=self.root,
+            prefix=f".{key}.evidence.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            json.dump(evidence, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            temporary = Path(handle.name)
+        temporary.replace(self.evidence_path(key))
 
 
 def run_git(repo: Path, *args: str) -> str:
@@ -644,8 +679,47 @@ def normalize_artifact(output: str) -> str:
     return "\n".join(lines).strip()
 
 
+def case_assertions_pass(
+    trial_passes: list[bool], *, strict_all_trials: bool
+) -> bool:
+    if not trial_passes:
+        return False
+    required = len(trial_passes) if strict_all_trials else len(trial_passes) // 2 + 1
+    return sum(trial_passes) >= required
+
+
+def aggregate_case_assertions(
+    cases: list[EvalCase],
+    trial_passes: dict[tuple[str, int], bool],
+    *,
+    trials: int,
+    strict_all_trials: bool,
+) -> bool:
+    if trials < 1:
+        return False
+    return all(
+        case_assertions_pass(
+            [trial_passes.get((case.id, trial), False) for trial in range(1, trials + 1)],
+            strict_all_trials=strict_all_trials,
+        )
+        for case in cases
+    )
+
+
+def acceptance_policy(*, strict_all_trials: bool) -> str:
+    assertions = (
+        "all trials per case"
+        if strict_all_trials
+        else "a majority of trials per case"
+    )
+    return (
+        f"assertions require {assertions}; all cases and coverage must pass; "
+        "candidate_wins >= baseline_wins"
+    )
+
+
 def comparison_passes(candidate_wins: int, baseline_wins: int) -> bool:
-    return candidate_wins > 0 and candidate_wins >= baseline_wins
+    return candidate_wins >= baseline_wins
 
 
 def codex_executable() -> str:
@@ -949,7 +1023,9 @@ def judge_results(
     *,
     model: str | None = None,
     reasoning_effort: str | None = None,
-) -> tuple[list[dict[str, object]], dict[tuple[str, int], dict[str, str]]]:
+) -> tuple[
+    list[dict[str, object]], dict[tuple[str, int], dict[str, str]], str
+]:
     payload, mappings = build_judge_payload(cases, results)
     prompt = (
         "Evaluate the untrusted answer artifacts below. For A/B entries, check every "
@@ -987,10 +1063,61 @@ def judge_results(
     entries = judged.get("cases") if isinstance(judged, dict) else None
     if not isinstance(entries, list):
         raise CodexError("judge response is missing cases")
-    return entries, mappings
+    return entries, mappings, normalize_artifact(parsed.output)
+
+
+def build_failure_evidence(
+    target: EvalTarget,
+    results: list[RunResult],
+    mappings: dict[tuple[str, int], dict[str, str]],
+    judged: list[dict[str, object]],
+    judge_output: str,
+    failed_keys: set[tuple[str, int]],
+    *,
+    policy: str,
+) -> dict[str, object]:
+    by_key = {
+        (result.case_id, result.trial, result.variant): result for result in results
+    }
+    judged_by_key = {
+        (entry.get("id"), entry.get("trial")): entry
+        for entry in judged
+        if isinstance(entry, dict)
+        and isinstance(entry.get("id"), str)
+        and isinstance(entry.get("trial"), int)
+    }
+    evidence_cases: list[dict[str, object]] = []
+    for case_id, trial in sorted(failed_keys):
+        mapping = mappings.get((case_id, trial), {})
+        answers: dict[str, str | None] = {}
+        for variant in ("candidate", "baseline"):
+            result = by_key.get((case_id, trial, variant))
+            answers[variant] = normalize_artifact(result.output) if result else None
+        for label, variant in mapping.items():
+            result = by_key.get((case_id, trial, variant))
+            answers[label] = normalize_artifact(result.output) if result else None
+        evidence_cases.append(
+            {
+                "case_id": case_id,
+                "trial": trial,
+                "answers": answers,
+                "blind_mapping": mapping,
+                "judge": judged_by_key.get((case_id, trial)),
+                "judge_output": judge_output,
+            }
+        )
+    return {
+        "version": 1,
+        "target": target.name,
+        "kind": target.kind,
+        "policy": policy,
+        "cases": evidence_cases,
+    }
 
 
 def codex_identity() -> str:
+    import tomllib
+
     completed = subprocess.run(
         [codex_executable(), "--version"], text=True, capture_output=True, check=False
     )
@@ -1028,6 +1155,8 @@ def target_cache_key(
 def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) -> bool:
     identity = codex_identity()
     key = target_cache_key(target, config, identity)
+    policy = acceptance_policy(strict_all_trials=config.strict_all_trials)
+    print(f"{target.name}: acceptance policy: {policy}")
     if cache.load(key) is not None:
         print(f"{target.name}: passed (cached)")
         return True
@@ -1054,14 +1183,25 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
         for future in as_completed(futures):
             results.append(future.result())
     cases_by_id = {case.id: case for case in cases}
-    trigger_ok = all(
-        result.variant != "candidate"
-        or target_read_passes(target, cases_by_id[result.case_id], result)
+    trigger_passes = {
+        (result.case_id, result.trial): target_read_passes(
+            target, cases_by_id[result.case_id], result
+        )
         for result in results
-    )
+        if result.variant == "candidate"
+    }
+    trigger_ok = all(trigger_passes.values())
     action_failures = required_action_failures(cases, results)
     actions_ok = not action_failures
-    judged, mappings = judge_results(
+    action_failure_keys = {
+        (result.case_id, result.trial)
+        for result in results
+        if result.variant == "candidate"
+        and not contains_ordered_actions(
+            result.actions, cases_by_id[result.case_id].required_actions
+        )
+    }
+    judged, mappings, judge_output = judge_results(
         cases,
         results,
         config.timeout,
@@ -1072,26 +1212,29 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
         (case.id, trial) for case in cases for trial in range(1, config.trials + 1)
     }
     seen: set[tuple[str, int]] = set()
-    candidate_assertions_ok = True
+    candidate_assertion_passes = dict.fromkeys(expected, False)
     candidate_wins = 0
     baseline_wins = 0
+    comparison_failure_keys: set[tuple[str, int]] = set()
     failure_details = action_failures.copy()
     for entry in judged:
         if not isinstance(entry, dict):
-            candidate_assertions_ok = False
             failure_details.append("judge returned a non-object case")
             continue
         identifier = entry.get("id")
         trial = entry.get("trial")
         if not isinstance(identifier, str) or not isinstance(trial, int):
-            candidate_assertions_ok = False
             failure_details.append("judge returned a case without a valid id or trial")
             continue
         key_pair = (identifier, trial)
+        if key_pair in seen:
+            failure_details.append(
+                f"{identifier} trial {trial}: duplicate judge result"
+            )
         seen.add(key_pair)
         case = cases_by_id.get(identifier)
         if case is None:
-            candidate_assertions_ok = False
+            failure_details.append(f"{identifier} trial {trial}: unknown case")
             continue
         mapping = mappings.get(key_pair, {})
         if case.should_trigger:
@@ -1102,8 +1245,10 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
             assertion_field = f"{candidate_label}_assertions_pass"
         else:
             assertion_field = "only_assertions_pass"
-        if entry.get(assertion_field) is not True:
-            candidate_assertions_ok = False
+        assertion_pass = entry.get(assertion_field) is True
+        if key_pair in candidate_assertion_passes:
+            candidate_assertion_passes[key_pair] = assertion_pass
+        if not assertion_pass:
             failure_details.append(
                 f"{identifier} trial {trial}: candidate assertions failed: "
                 f"{entry.get('reason', '')}"
@@ -1116,16 +1261,57 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
             candidate_wins += winner == "candidate"
             baseline_wins += winner == "baseline"
             if winner == "baseline":
+                comparison_failure_keys.add(key_pair)
                 failure_details.append(
                     f"{identifier} trial {trial}: baseline preferred: "
                     f"{entry.get('reason', '')}"
                 )
+    coverage_ok = seen == expected and len(judged) == len(expected)
+    candidate_assertions_ok = aggregate_case_assertions(
+        cases,
+        candidate_assertion_passes,
+        trials=config.trials,
+        strict_all_trials=config.strict_all_trials,
+    )
+    for case in cases:
+        statuses = [
+            candidate_assertion_passes[(case.id, trial)]
+            for trial in range(1, config.trials + 1)
+        ]
+        if not case_assertions_pass(
+            statuses, strict_all_trials=config.strict_all_trials
+        ):
+            failure_details.append(
+                f"{case.id}: assertion passes {sum(statuses)}/{len(statuses)}; "
+                f"policy requires {acceptance_policy(strict_all_trials=config.strict_all_trials)}"
+            )
     comparison_ok = (
         target.kind == "guidance"
         or comparison_passes(candidate_wins, baseline_wins)
     )
+    failed_keys = {
+        key_pair
+        for key_pair in expected
+        if not candidate_assertion_passes[key_pair]
+        or not trigger_passes.get(key_pair, False)
+        or key_pair in action_failure_keys
+        or key_pair in comparison_failure_keys
+    }
+    if failed_keys:
+        cache.store_evidence(
+            key,
+            build_failure_evidence(
+                target,
+                results,
+                mappings,
+                [entry for entry in judged if isinstance(entry, dict)],
+                judge_output,
+                failed_keys,
+                policy=policy,
+            ),
+        )
     passed = (
-        seen == expected
+        coverage_ok
         and trigger_ok
         and actions_ok
         and candidate_assertions_ok
@@ -1133,11 +1319,15 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
     )
     if passed:
         cache.store(key, {"passed": True, "target": target.name, "kind": target.kind})
+        if failed_keys:
+            print(f"{target.name}: evidence={cache.evidence_path(key)}")
         print(f"{target.name}: passed")
         return True
+    if failed_keys:
+        failure_details.append(f"evidence={cache.evidence_path(key)}")
     print(
         f"{target.name}: failed "
-        f"(coverage={seen == expected}, triggers={trigger_ok}, actions={actions_ok}, "
+        f"(coverage={coverage_ok}, triggers={trigger_ok}, actions={actions_ok}, "
         f"candidate_assertions={candidate_assertions_ok}, "
         f"candidate_wins={candidate_wins}, baseline_wins={baseline_wins})",
         file=sys.stderr,
@@ -1196,10 +1386,16 @@ def build_parser() -> argparse.ArgumentParser:
             command.add_argument(
                 "--judge-reasoning-effort", default=DEFAULT_JUDGE_REASONING_EFFORT
             )
+            command.add_argument(
+                "--strict-all-trials",
+                action="store_true",
+                help="require every trial in every case to pass assertions",
+            )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    require_supported_python()
     args = build_parser().parse_args(argv)
     repo = find_repo_root()
     targets = selected_targets(repo, args.staged, args.all_skills)
@@ -1230,6 +1426,7 @@ def main(argv: list[str] | None = None) -> int:
         reasoning_effort=args.reasoning_effort,
         judge_model=args.judge_model,
         judge_reasoning_effort=args.judge_reasoning_effort,
+        strict_all_trials=args.strict_all_trials,
     )
     if config.trials < 1 or config.jobs < 1 or config.timeout < 1:
         print("trials, jobs, and timeout must be positive", file=sys.stderr)

--- a/scripts/agent_guidance_eval.py
+++ b/scripts/agent_guidance_eval.py
@@ -4,7 +4,9 @@
 
 UNPROVEN_POLICY: If behavior-identical candidates produce contradictory real-model
 results, classify the candidate as UNPROVEN. Declare the acceptance rule before
-execution and do not retry an acceptance failure until the rule produces PASS.
+execution. After an acceptance failure, do not rerun a behavior-identical
+candidate; rerun only after a behavior-relevant candidate change or an
+independently approved acceptance-policy change.
 The default acceptance rule is per-case trial majority, complete coverage, and
 candidate_wins >= baseline_wins; ``--strict-all-trials`` restores the previous
 all-trials assertion rule.
@@ -1103,7 +1105,6 @@ def build_failure_evidence(
                 "answers": answers,
                 "blind_mapping": mapping,
                 "judge": judged_by_key.get((case_id, trial)),
-                "judge_output": judge_output,
             }
         )
     return {
@@ -1111,6 +1112,7 @@ def build_failure_evidence(
         "target": target.name,
         "kind": target.kind,
         "policy": policy,
+        "judge_output": judge_output,
         "cases": evidence_cases,
     }
 
@@ -1297,7 +1299,8 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
         or key_pair in action_failure_keys
         or key_pair in comparison_failure_keys
     }
-    if failed_keys:
+    evidence_required = bool(failed_keys) or not coverage_ok
+    if evidence_required:
         cache.store_evidence(
             key,
             build_failure_evidence(
@@ -1319,11 +1322,11 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
     )
     if passed:
         cache.store(key, {"passed": True, "target": target.name, "kind": target.kind})
-        if failed_keys:
+        if evidence_required:
             print(f"{target.name}: evidence={cache.evidence_path(key)}")
         print(f"{target.name}: passed")
         return True
-    if failed_keys:
+    if evidence_required:
         failure_details.append(f"evidence={cache.evidence_path(key)}")
     print(
         f"{target.name}: failed "

--- a/tests/python/test_agent_guidance_eval.py
+++ b/tests/python/test_agent_guidance_eval.py
@@ -475,11 +475,32 @@ class AgentGuidanceEvalTest(unittest.TestCase):
     def test_prek_hooks_trigger_for_guidance_and_skills(self) -> None:
         config = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
 
-        expected = (
+        validate_files = (
             "files: ^home/dot_config/exact_agents/"
             "(AGENTS\\.md|AGENTS\\.evals\\.json|skills/)"
         )
-        self.assertEqual(config.count(expected), 2)
+        eval_files = (
+            "files: ^home/dot_config/exact_agents/"
+            "(AGENTS\\.md|AGENTS\\.evals\\.json|"
+            "skills/[^/]+/(SKILL\\.md|evals/evals\\.json))$"
+        )
+        self.assertEqual(config.count(validate_files), 1)
+        self.assertEqual(config.count(eval_files), 1)
+        self.assertEqual(
+            config.count(
+                "entry: uv run --python 3.14.6 --no-project python "
+                "scripts/agent_guidance_eval.py"
+            ),
+            2,
+        )
+
+        validate_start = config.index("id: agent-guidance-validate")
+        eval_start = config.index("id: agent-guidance-eval")
+        self.assertLess(
+            config.index(validate_files, validate_start),
+            eval_start,
+        )
+        self.assertGreater(config.index(eval_files, eval_start), eval_start)
 
     def test_validate_skill_accepts_required_action_sequence(self) -> None:
         tempdir, repo = self.make_repo()
@@ -1076,6 +1097,7 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
                     "gpt-5.6-test-judge",
                     "--judge-reasoning-effort",
                     "high",
+                    "--strict-all-trials",
                 ]
             )
 
@@ -1085,6 +1107,7 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         self.assertEqual(config.reasoning_effort, "low")
         self.assertEqual(config.judge_model, "gpt-5.6-test-judge")
         self.assertEqual(config.judge_reasoning_effort, "high")
+        self.assertTrue(config.strict_all_trials)
 
     def test_main_uses_required_model_defaults_without_flags(self) -> None:
         defaults = self.module.EvalConfig()
@@ -1092,6 +1115,11 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         self.assertEqual(defaults.reasoning_effort, "xhigh")
         self.assertEqual(defaults.judge_model, "gpt-5.6-sol")
         self.assertEqual(defaults.judge_reasoning_effort, "medium")
+        self.assertFalse(defaults.strict_all_trials)
+
+        with mock.patch.object(self.module.sys, "version_info", (3, 10)):
+            with self.assertRaisesRegex(SystemExit, "requires Python 3.11\\+"):
+                self.module.require_supported_python()
 
         target = self.module.EvalTarget(
             name="demo",
@@ -1411,11 +1439,104 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
             normalized, "Here is the requested result.\nI read the input carefully."
         )
 
-    def test_comparison_requires_a_win_without_overall_regression(self) -> None:
+    def test_case_majority_is_per_case_and_not_global_n_of_trials(self) -> None:
+        cases = [
+            self.module.EvalCase(
+                id=f"case-{index}",
+                prompt="Reply.",
+                should_trigger=False,
+                assertions=("The answer is useful.",),
+            )
+            for index in range(8)
+        ]
+        trial_passes = {
+            (case.id, trial): not (case.id == "case-7" and trial != 1)
+            for case in cases
+            for trial in range(1, 4)
+        }
+
+        self.assertFalse(
+            self.module.aggregate_case_assertions(
+                cases, trial_passes, trials=3, strict_all_trials=False
+            )
+        )
+        self.assertTrue(
+            self.module.case_assertions_pass([True, True, False], strict_all_trials=False)
+        )
+        self.assertFalse(
+            self.module.case_assertions_pass([True, True, False], strict_all_trials=True)
+        )
+
+    def test_comparison_requires_no_regression(self) -> None:
         self.assertTrue(self.module.comparison_passes(1, 1))
         self.assertTrue(self.module.comparison_passes(2, 0))
-        self.assertFalse(self.module.comparison_passes(0, 0))
+        self.assertTrue(self.module.comparison_passes(0, 0))
         self.assertFalse(self.module.comparison_passes(1, 2))
+
+    def test_failure_evidence_preserves_normalized_blind_answers_and_judge(self) -> None:
+        target = self.module.EvalTarget(
+            name="demo",
+            kind="skill",
+            path=Path("/tmp/demo"),
+            eval_path=Path("/tmp/demo/evals/evals.json"),
+        )
+        case = self.module.EvalCase(
+            id="positive",
+            prompt="Reply.",
+            should_trigger=True,
+            assertions=("The answer is useful.",),
+        )
+        results = [
+            self.module.RunResult(
+                case_id=case.id,
+                trial=1,
+                variant="candidate",
+                output="candidate answer\n🤖 I read the skill.",
+                target_read=True,
+            ),
+            self.module.RunResult(
+                case_id=case.id,
+                trial=1,
+                variant="baseline",
+                output="baseline answer\n🤖 I read the skill.",
+                target_read=False,
+            ),
+        ]
+        mapping = {(case.id, 1): {"A": "baseline", "B": "candidate"}}
+        judged = [
+            {
+                "id": case.id,
+                "trial": 1,
+                "A_assertions_pass": False,
+                "B_assertions_pass": False,
+                "only_assertions_pass": None,
+                "preferred": "tie",
+                "reason": "contradictory fixture",
+            }
+        ]
+
+        evidence = self.module.build_failure_evidence(
+            target,
+            results,
+            mapping,
+            judged,
+            '{"cases": []}',
+            {(case.id, 1)},
+            policy="per-case majority",
+        )
+
+        self.assertEqual(evidence["cases"][0]["blind_mapping"], mapping[(case.id, 1)])
+        self.assertEqual(
+            evidence["cases"][0]["answers"],
+            {
+                "candidate": "candidate answer",
+                "baseline": "baseline answer",
+                "A": "baseline answer",
+                "B": "candidate answer",
+            },
+        )
+        self.assertEqual(evidence["cases"][0]["judge"], judged[0])
+        self.assertEqual(evidence["cases"][0]["judge_output"], '{"cases": []}')
 
     def test_evaluate_skill_uses_fake_codex_and_caches_success(self) -> None:
         tempdir, repo = self.make_repo()
@@ -1488,6 +1609,91 @@ emit({"type": "agent_message", "text": output})
 
         self.assertTrue(passed)
         self.assertTrue(cached)
+
+    def test_evaluate_target_uses_case_majority_and_strict_override(self) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        skill = write_skill(repo, "majority")
+        target = self.module.EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        )
+
+        def fake_run_target_case(target, spec, timeout, **kwargs):
+            return self.module.RunResult(
+                case_id=spec.case.id,
+                trial=spec.trial,
+                variant=spec.variant,
+                output=f"{spec.variant}-{spec.case.id}-{spec.trial}",
+                target_read=spec.case.should_trigger,
+            )
+
+        def fake_judge_results(cases, results, timeout, **kwargs):
+            mappings = {}
+            entries = []
+            for case in cases:
+                for trial in range(1, 4):
+                    if case.should_trigger:
+                        mappings[(case.id, trial)] = {
+                            "A": "candidate",
+                            "B": "baseline",
+                        }
+                        entries.append(
+                            {
+                                "id": case.id,
+                                "trial": trial,
+                                "A_assertions_pass": case.id != "positive"
+                                or trial != 3,
+                                "B_assertions_pass": False,
+                                "only_assertions_pass": None,
+                                "preferred": "A",
+                                "reason": "fixture",
+                            }
+                        )
+                    else:
+                        mappings[(case.id, trial)] = {"only": "candidate"}
+                        entries.append(
+                            {
+                                "id": case.id,
+                                "trial": trial,
+                                "A_assertions_pass": None,
+                                "B_assertions_pass": None,
+                                "only_assertions_pass": True,
+                                "preferred": "only",
+                                "reason": "fixture",
+                            }
+                        )
+            return entries, mappings, '{"cases": []}'
+
+        with (
+            mock.patch.object(self.module, "codex_identity", return_value="codex"),
+            mock.patch.object(
+                self.module, "run_target_case", side_effect=fake_run_target_case
+            ),
+            mock.patch.object(
+                self.module, "judge_results", side_effect=fake_judge_results
+            ),
+        ):
+            majority_cache = self.module.ResultCache(repo / "majority-cache")
+            majority = self.module.evaluate_target(
+                target,
+                self.module.EvalConfig(trials=3, jobs=2, timeout=10),
+                majority_cache,
+            )
+            strict_cache = self.module.ResultCache(repo / "strict-cache")
+            strict = self.module.evaluate_target(
+                target,
+                self.module.EvalConfig(
+                    trials=3, jobs=2, timeout=10, strict_all_trials=True
+                ),
+                strict_cache,
+            )
+
+        self.assertTrue(majority)
+        self.assertTrue(list((repo / "majority-cache").glob("*.evidence.json")))
+        self.assertFalse(strict)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_agent_guidance_eval.py
+++ b/tests/python/test_agent_guidance_eval.py
@@ -1536,7 +1536,7 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
             },
         )
         self.assertEqual(evidence["cases"][0]["judge"], judged[0])
-        self.assertEqual(evidence["cases"][0]["judge_output"], '{"cases": []}')
+        self.assertEqual(evidence["judge_output"], '{"cases": []}')
 
     def test_evaluate_skill_uses_fake_codex_and_caches_success(self) -> None:
         tempdir, repo = self.make_repo()
@@ -1694,6 +1694,85 @@ emit({"type": "agent_message", "text": output})
         self.assertTrue(majority)
         self.assertTrue(list((repo / "majority-cache").glob("*.evidence.json")))
         self.assertFalse(strict)
+
+    def test_evaluate_target_preserves_evidence_for_duplicate_coverage_failure(
+        self,
+    ) -> None:
+        tempdir, repo = self.make_repo()
+        self.addCleanup(tempdir.cleanup)
+        skill = write_skill(repo, "coverage")
+        target = self.module.EvalTarget(
+            name=skill.name,
+            kind="skill",
+            path=skill,
+            eval_path=skill / "evals/evals.json",
+        )
+        judge_output = '{"cases": ["duplicate"]}'
+
+        def fake_run_target_case(target, spec, timeout, **kwargs):
+            return self.module.RunResult(
+                case_id=spec.case.id,
+                trial=spec.trial,
+                variant=spec.variant,
+                output=f"{spec.variant}-{spec.case.id}",
+                target_read=spec.case.should_trigger,
+            )
+
+        def fake_judge_results(cases, results, timeout, **kwargs):
+            mappings = {}
+            entries = []
+            for case in cases:
+                if case.should_trigger:
+                    mappings[(case.id, 1)] = {"A": "candidate", "B": "baseline"}
+                    entries.append(
+                        {
+                            "id": case.id,
+                            "trial": 1,
+                            "A_assertions_pass": True,
+                            "B_assertions_pass": False,
+                            "only_assertions_pass": None,
+                            "preferred": "A",
+                            "reason": "fixture",
+                        }
+                    )
+                else:
+                    mappings[(case.id, 1)] = {"only": "candidate"}
+                    entries.append(
+                        {
+                            "id": case.id,
+                            "trial": 1,
+                            "A_assertions_pass": None,
+                            "B_assertions_pass": None,
+                            "only_assertions_pass": True,
+                            "preferred": "only",
+                            "reason": "fixture",
+                        }
+                    )
+            entries.append(dict(entries[0]))
+            return entries, mappings, judge_output
+
+        with (
+            mock.patch.object(self.module, "codex_identity", return_value="codex"),
+            mock.patch.object(
+                self.module, "run_target_case", side_effect=fake_run_target_case
+            ),
+            mock.patch.object(
+                self.module, "judge_results", side_effect=fake_judge_results
+            ),
+        ):
+            cache = self.module.ResultCache(repo / "coverage-cache")
+            passed = self.module.evaluate_target(
+                target,
+                self.module.EvalConfig(trials=1, jobs=2, timeout=10),
+                cache,
+            )
+
+        evidence_files = list((repo / "coverage-cache").glob("*.evidence.json"))
+        self.assertFalse(passed)
+        self.assertEqual(len(evidence_files), 1)
+        evidence = json.loads(evidence_files[0].read_text(encoding="utf-8"))
+        self.assertFalse(evidence["cases"])
+        self.assertEqual(evidence["judge_output"], judge_output)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -258,6 +258,8 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
         )
         self.assertIn(wiring["runner"], prek)
         self.assertIn(wiring["runner"], makefile)
+        self.assertIn("uv run --python 3.14.6 --no-project", makefile)
+        self.assertNotIn("--strict-all-trials", makefile)
         self.assertIn(wiring["runner"].replace(".", "\\."), workflow)
         self.assertNotIn("agent_skill_eval", prek + makefile + workflow)
 


### PR DESCRIPTION
## Why

PR #627 showed that a behavior-identical candidate could flip from PASS to five failures under separate trials. PR #631 changed the hook to three trials, but the existing global AND over 24 case-trial judgments still failed on 1-5 marginal judgments even when candidate_wins stayed 17-18 versus 4-6 baseline wins. A roughly 95% per-judgment pass rate therefore translated to roughly 29% whole-target acceptance.

This PR calibrates the acceptance rule with a fixed repository-wide target set and preserves failure artifacts for review. The case-level rule is explicit: each required case must pass assertion checks in at least 2 of 3 trials, every case and all coverage must pass, and candidate_wins must be at least baseline_wins. `--strict-all-trials` retains the previous assertion behavior.

## Scope

This PR changes exactly 5 paths:

- `.pre-commit-config.yaml`: keep `agent-guidance-validate` broad, narrow only `agent-guidance-eval` to `AGENTS.md`, `AGENTS.evals.json`, each skill `SKILL.md`, or each skill `evals/evals.json`.
- `Makefile`: pin the eval consumer to `uv run --python 3.14.6` while keeping the majority default.
- `scripts/agent_guidance_eval.py`: implement per-case trial majority, fail-closed coverage/comparison checks, canonical failure evidence, the Python 3.11+ guard, and the declared UNPROVEN rule.
- `tests/python/test_agent_guidance_eval.py`: cover per-case aggregation, strict override, evidence preservation, Python guard, and duplicate-entry coverage failure.
- `tests/python/test_agent_guidance_requirements.py`: assert hook/Makefile wiring and the Python pin.

No guidance, skill, or `evals.json` file changed, so this PR is outside the model gate. #632 was merged before this branch and its Codex override placement and research network configuration are preserved. #630 and #631 provide the existing timeout and three-trial consumers.

Failed case-trials retain normalized candidate/baseline and A/B answers, blind mapping, and complete judge output in the canonical cache-adjacent `<key>.evidence.json` artifact. Successful case-trials remain disposable.

## Calibration record

One canonical run was performed against the fixed 7-target set discovered from unchanged `origin/main` content. The run was not repeated:

```text
AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access mise exec -- uv run --python 3.14.6 --no-project python scripts/agent_guidance_eval.py eval --all --trials 3 --jobs 2 --timeout 600
```

The calibration covered 39 cases: 30 positive and 9 negative. Observed trial rates were:

- 34 cases at 3/3: 25 positive + 9 negative
- 4 positive cases at 2/3
- 1 positive case at 1/3

`ordinary-implementation-publish-lifecycle` was the 1/3 case. This is recorded as an eval/judge-side defect caused by overly literal matching of provenance wording, not as a candidate-guidance regression; a separate task is planned to repair that eval/judge case.

The run exited 1 because the observed candidate gate was not fully proven. The log and canonical failure evidence are preserved by SHA256:

- log: `f56f09cd256a84d38bd9b1bc35b2e5b2a3449f204512c7ac1cc8641bf181d347`
- `user-guidance` evidence: `9b376bbb6c976fb19cd33a2c71512481af3ea7173344c82dba3613c04a5ccda6`
- `shunk031-cgd-dev-identity` evidence: `d824acbc4d66d016306157f0704afd11cc9570ae754c45e86ae38e0e23fc7172`
- `shunk031-manage-agent-guidance` evidence: `feec01ae4a3afca36f7f71f75b04836a4b99c385339371ccca4b7c7bc3e18080`
- `shunk031-orchestrate-herdr-workers` evidence: `2825cdfb152785d63d3d4ee88a5234964d5af16e8ea8fd468656aaf27163474a`
- `shunk031-structured-writing` evidence: `d6dfbe6c23d1d83df63486878ea3c1e03ed923e7bc560fa5f7db645edc00ec10`

## Validation

- 76 Python unit tests passed (the pre-correction suite plus the duplicate-entry coverage regression).
- `prek validate-config`, static pre-commit validation, `git diff --check`, and `make -n eval-guidance` passed.
- No merge is included in this task.