### PR TITLE
fix(evaluator): record trigger outcomes in failure evidence

### DIFF
--- a/scripts/agent_guidance_eval.py
+++ b/scripts/agent_guidance_eval.py
@@ -1077,6 +1077,8 @@ def build_failure_evidence(
     failed_keys: set[tuple[str, int]],
     *,
     policy: str,
+    trigger_passes: dict[tuple[str, int], bool],
+    trigger_ok: bool,
 ) -> dict[str, object]:
     by_key = {
         (result.case_id, result.trial, result.variant): result for result in results
@@ -1098,6 +1100,7 @@ def build_failure_evidence(
         for label, variant in mapping.items():
             result = by_key.get((case_id, trial, variant))
             answers[label] = normalize_artifact(result.output) if result else None
+        candidate = by_key.get((case_id, trial, "candidate"))
         evidence_cases.append(
             {
                 "case_id": case_id,
@@ -1105,9 +1108,11 @@ def build_failure_evidence(
                 "answers": answers,
                 "blind_mapping": mapping,
                 "judge": judged_by_key.get((case_id, trial)),
+                "trigger_passed": trigger_passes.get((case_id, trial), False),
+                "target_read": candidate.target_read if candidate else None,
             }
         )
-    return {
+    evidence: dict[str, object] = {
         "version": 1,
         "target": target.name,
         "kind": target.kind,
@@ -1115,6 +1120,23 @@ def build_failure_evidence(
         "judge_output": judge_output,
         "cases": evidence_cases,
     }
+    if not trigger_ok:
+        # A trigger-only failure can leave every assertion passing, so the failed
+        # cases alone do not show which trials read the target.
+        evidence["trigger_outcomes"] = [
+            {
+                "case_id": case_id,
+                "trial": trial,
+                "trigger_passed": passed,
+                "target_read": (
+                    by_key[(case_id, trial, "candidate")].target_read
+                    if (case_id, trial, "candidate") in by_key
+                    else None
+                ),
+            }
+            for (case_id, trial), passed in sorted(trigger_passes.items())
+        ]
+    return evidence
 
 
 def codex_identity() -> str:
@@ -1311,6 +1333,8 @@ def evaluate_target(target: EvalTarget, config: EvalConfig, cache: ResultCache) 
                 judge_output,
                 failed_keys,
                 policy=policy,
+                trigger_passes=trigger_passes,
+                trigger_ok=trigger_ok,
             ),
         )
     passed = (

--- a/tests/python/test_agent_guidance_eval.py
+++ b/tests/python/test_agent_guidance_eval.py
@@ -1523,6 +1523,8 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
             '{"cases": []}',
             {(case.id, 1)},
             policy="per-case majority",
+            trigger_passes={(case.id, 1): True},
+            trigger_ok=True,
         )
 
         self.assertEqual(evidence["cases"][0]["blind_mapping"], mapping[(case.id, 1)])
@@ -1537,6 +1539,98 @@ print(json.dumps({{"type": "item.completed", "item": {{"type": "agent_message", 
         )
         self.assertEqual(evidence["cases"][0]["judge"], judged[0])
         self.assertEqual(evidence["judge_output"], '{"cases": []}')
+        self.assertTrue(evidence["cases"][0]["trigger_passed"])
+        self.assertTrue(evidence["cases"][0]["target_read"])
+        self.assertNotIn("trigger_outcomes", evidence)
+
+    def test_failure_evidence_names_trigger_only_failure_and_lists_all_cases(
+        self,
+    ) -> None:
+        target = self.module.EvalTarget(
+            name="demo",
+            kind="guidance",
+            path=Path("/tmp/demo"),
+            eval_path=Path("/tmp/demo/evals/evals.json"),
+        )
+        passing = self.module.EvalCase(
+            id="passing",
+            prompt="Reply.",
+            should_trigger=True,
+            assertions=("The answer is useful.",),
+        )
+        failing = self.module.EvalCase(
+            id="failing",
+            prompt="Reply.",
+            should_trigger=True,
+            assertions=("The answer is useful.",),
+        )
+        results = [
+            self.module.RunResult(
+                case_id=passing.id,
+                trial=1,
+                variant="candidate",
+                output="answer\n🤖 I read the skill.",
+                target_read=True,
+            ),
+            self.module.RunResult(
+                case_id=failing.id,
+                trial=1,
+                variant="candidate",
+                output="answer without the receipt",
+                target_read=False,
+            ),
+        ]
+        judged = [
+            {
+                "id": passing.id,
+                "trial": 1,
+                "only_assertions_pass": True,
+                "reason": "fine",
+            },
+            {
+                "id": failing.id,
+                "trial": 1,
+                "only_assertions_pass": True,
+                "reason": "fine",
+            },
+        ]
+        trigger_passes = {(passing.id, 1): True, (failing.id, 1): False}
+
+        evidence = self.module.build_failure_evidence(
+            target,
+            results,
+            {},
+            judged,
+            '{"cases": []}',
+            {(failing.id, 1)},
+            policy="per-case majority",
+            trigger_passes=trigger_passes,
+            trigger_ok=False,
+        )
+
+        self.assertEqual(
+            [(case["case_id"], case["trial"]) for case in evidence["cases"]],
+            [(failing.id, 1)],
+        )
+        self.assertFalse(evidence["cases"][0]["trigger_passed"])
+        self.assertFalse(evidence["cases"][0]["target_read"])
+        self.assertEqual(
+            evidence["trigger_outcomes"],
+            [
+                {
+                    "case_id": failing.id,
+                    "trial": 1,
+                    "trigger_passed": False,
+                    "target_read": False,
+                },
+                {
+                    "case_id": passing.id,
+                    "trial": 1,
+                    "trigger_passed": True,
+                    "target_read": True,
+                },
+            ],
+        )
 
     def test_evaluate_skill_uses_fake_codex_and_caches_success(self) -> None:
         tempdir, repo = self.make_repo()


### PR DESCRIPTION
## Why

The failure evidence JSON introduced in #634 persists the candidate/baseline
answers, the blind mapping, and the judge output, but it never records the
per-trial trigger result. `evaluate_target` already puts trigger failures into
`failed_keys`, so a trigger-only failure does produce evidence — but that
evidence looks identical to a healthy run, because every stored field can be
fine while the trigger check is what failed.

The practical cost is diagnosis by elimination. A gate reporting
`triggers=False` with all assertions passing gives no artifact naming which
case or trial failed to read the target, so the only way to localize it is to
rule out the other gate rules by hand. That is currently blocking a skill PR
that failed `triggers=False` three times with every assertion passing.

## What Changed

`scripts/agent_guidance_eval.py`, in `build_failure_evidence`:

- Each failed case entry now records `trigger_passed` (from the same
  `trigger_passes` map the aggregate check uses) and `target_read` from the
  candidate `RunResult`.
- When the aggregate trigger check fails, the evidence additionally carries a
  top-level `trigger_outcomes` list covering **every** case and trial, not only
  the failed ones. This is the blind spot the failed-case scope cannot cover: a
  trigger-only failure can leave all assertions passing, so the failed-case
  entries alone do not show which trials read the target and which did not.

`build_failure_evidence` takes `trigger_passes` and `trigger_ok` as required
keyword arguments, supplied at the single call site in `evaluate_target` from
values it already computes. No new helper or framework was added, evidence stays
failed-case scoped, and the existing fields are unchanged. The additive fields
leave `version` at 1 so existing readers keep working.

## Validation

Confirm the change is limited to the evaluator and its tests.

```shell
git diff --stat origin/main...HEAD
```

Run the two evidence tests: one asserts a trigger-only failure names the failing
case/trial and lists all cases, the other asserts previously stored evidence
content is unchanged and that `trigger_outcomes` is absent when triggers pass.

```shell
python3 -m unittest tests.python.test_agent_guidance_eval -k failure_evidence -v
```

Run the full suite exactly as CI invokes it.

```shell
python3 -m unittest discover -s tests/python
```

Check the hook configuration still parses and that this PR touches no guidance
or skill target, so no real-model gate applies.

```shell
prek validate-config .pre-commit-config.yaml
prek run --files scripts/agent_guidance_eval.py tests/python/test_agent_guidance_eval.py
```

Results: both evidence tests pass; the full suite reports `Ran 77 tests ... OK`;
`prek validate-config` reports all configs valid; and both guidance hooks report
`(no files to check) Skipped`, confirming no behavioral target changed.
