### PR TITLE
docs(orchestration): add worker behavior rules

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
@@ -22,11 +22,14 @@ An orchestrator delegates independent tasks to worker agents, one git worktree t
 
 ## Launch each worker
 
-3. Before any task edits, create each worker with `herdr worktree create`; do not substitute manual `git worktree add` plus `herdr tab create`. Unless the user explicitly requested another workspace, immediately move the returned root pane into a new tab in the orchestrator's existing workspace before starting the agent. Read the destination tab and pane IDs from the move response and use those destination IDs for all subsequent commands:
+3. Before any task edits, establish the deliverable's repository-associated workspace with `herdr worktree create`; for an already-open deliverable worktree, use `herdr worktree open` and reuse its returned deliverable workspace and root-pane IDs instead of creating a second workspace. Do not substitute manual `git worktree add` plus `herdr tab create`. For every implementer, reviewer, or other related tab for that deliverable, move the returned root pane into a new tab in that deliverable workspace before starting the agent; keep the orchestrator workspace for the orchestrator only. Read the returned deliverable workspace, destination tab, and pane IDs from each response and use those destination IDs for all subsequent commands:
 
    ```bash
+   # Choose exactly one for the deliverable:
    herdr worktree create --cwd "$PWD" --branch <topic-branch> --label "🚧 <short task>" --no-focus
-   herdr pane move <returned-root-pane-id> --new-tab --workspace "$HERDR_WORKSPACE_ID" --label "🚧 <short task>" --no-focus
+   # For an already-open deliverable worktree, use this instead of create:
+   herdr worktree open --cwd "$PWD" --branch <topic-branch> --label "🚧 <short task>" --no-focus
+   herdr pane move <returned-root-pane-id> --new-tab --workspace <returned-deliverable-workspace-id> --label "🚧 <short task>" --no-focus
    ```
 
 4. Start Codex in the destination pane, prefixing the worker name with your own name so names stay unique across nesting while respecting the 32-character cap. Do not reuse the pre-move root pane ID:
@@ -59,7 +62,25 @@ An orchestrator delegates independent tasks to worker agents, one git worktree t
 
    An actionable `REJECT` from an independent review worker is non-terminal: before reporting or waiting, verify the live task/PR owner, consolidate the findings, and route them immediately to that owner with the existing quoted `herdr agent prompt <owner> "$answer"` path; use the step-5 receipt contract, record the exact rejected head and `re-review pending`, and after the owner publishes a corrected head route that exact head back to the same reviewer with the same contract. Only `ACCEPT` permits a user merge handoff.
 
+   When a `DONE`, `BLOCKED`, `STATUS`, or `OBSERVER` report arrives, send the answer or next instruction with `herdr agent prompt <worker-name> "$prompt"` in that turn, or state the concrete reason for waiting; a decision without a prompt or wait reason leaves the turn incomplete.
+
+   When explaining a constraint's provenance, check the transcript, distinguish the user instruction, worker prompt, and orchestrator addition, state only the observed origin, and do not infer motive.
+
+   Process queued worker reports during the same user turn; do not defer them until after answering the user.
+
+   Treat each deliverable that will become one pull request as one workspace, and open its implementer and reviewer tabs there. Rename the workspace with `herdr workspace rename <workspace-id> "WIP <topic>"`, then `herdr workspace rename <workspace-id> "Issue#<N> <topic>"`, then `herdr workspace rename <workspace-id> "PR#<N> <topic>"`; perform the Issue or PR rename in the same turn that receives its URL, and leave tab labels worker-owned under `shunk031-herdr-tab-status`.
+
+   For worktree work, establish or reuse the deliverable's repo-associated workspace with `herdr worktree create --cwd "$PWD" ...` or `herdr worktree open --cwd "$PWD" ...`; use the returned deliverable workspace ID and returned root-pane ID, and for every related implementer or reviewer tab move that pane with `herdr pane move <pane-id> --new-tab --workspace <returned-deliverable-workspace-id>`. Reuse the open response's existing workspace and root-pane IDs instead of creating a second workspace. Never target `$HERDR_WORKSPACE_ID` for worker tabs or construct a workspace with `herdr pane move <pane-id> --new-workspace`.
+
+   An orchestrator session is disposable: if context degrades through repeated meta-discussion or an unprocessed queue, hand off to a new session. Herdr, git, and pull-request state are the truth, so this handoff is safe.
+
 10. On BLOCKED, build your answer in a variable and reply with `herdr agent prompt <worker-name> "$answer"`; use that same quoted-variable command sequence, `herdr agent prompt <worker-name> "$prompt"`, without substituting another Herdr command, whenever routing an owned task or PR action—including the user's authorization for a merge—back to a live worker. On DONE, reconstruct each claimed contract from its source of truth, inspect the diff and evidence, and verify tests exercise the actual package or production path against an independent reference before accepting the result; treat worker summaries, test names, pass counts, manifests, CI, and artifact hashes as candidate evidence only, not acceptance. Reject and redispatch claims based on test-local reconstructions or runtime paths that do not exist or are not exercised. Each agent owns its own tab label. Once a live worker owns a task or PR, route later task-scoped implementation and GitHub lifecycle actions—including rebase, push, PR update, merge, and CI or merge-queue follow-up—back to that worker; the coordinator may inspect read-only state, review, and relay user decisions but must not execute those owned actions, and may take over only after verifying the worker is unavailable or the user explicitly directs it to act. If a worker dies or goes silent behind a stale label, set its tab to "⛔ <task>" and inspect it with `herdr agent get` and `herdr agent read`. When several workers fail the same way at once — gateway auth or rate-limit errors, say — the cause is shared, not per-task: rotate or fix the credential in the runtime config workers actually read (a variable exported only in your own shell reaches nothing already running), then reconcile as usual; workers that were merely retrying recover on their own, and dead ones restart with their worktree state intact.
+
+   When two streams show the same failure signature, transfer the diagnosis between them and consider a generalized meta issue.
+
+   Recompute every numeric heading in a worker report from its raw data before relaying it or using it for a decision.
+
+   Escalate user-owned decisions about compute scale, deletion, license or provenance, and scope immediately with concrete options and numbers while keeping other streams moving; never put internal infrastructure identifiers such as mount paths, internal hostnames, or IP addresses in repository artifacts, including docs, PR bodies, issue comments, or commit messages.
 
 11. When every worker is done, keep your 🤖 label, summarize per worker with PR links, and announce with `herdr notification show "Workers done" --sound done`. End this and every later report with the list of unresolved items only the user can decide or perform — PR merges, unanswered ⛔ questions, dirty worktrees you kept, credential rotation — one line each with the exact command or link and what it blocks; repeat the list until each item is verified done, and omit it when nothing is pending.
 

--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
@@ -4,11 +4,11 @@
   "evals": [
     {
       "id": "fan-out-parallel-workers",
-      "prompt": "We are inside a Herdr session. First read .agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md, then follow it to plan the orchestration of a refactor split into three independent tasks run by parallel Codex workers in separate Herdr worktree tabs within the orchestrator's existing workspace/window. Show the complete sequence for all three workers, not only one: for each worker, create the worktree, immediately move its returned root pane into a new tab in the existing workspace, start the agent in the returned destination pane, and dispatch that worker's prompt. Only after all three dispatches are complete, wait for all three worker report prompts. For every worker, the command order must be herdr worktree create, immediately herdr pane move <returned-root-pane-id> --new-tab --workspace \"$HERDR_WORKSPACE_ID\", then herdr agent start using the destination pane ID returned by the move rather than the original root pane ID. This is an offline dry run: Herdr is unavailable for execution, but the command syntax shown in the named skill is authoritative and must be reproduced in your answer; do not refuse or ask for the skill text because execution or readback is unavailable, and do not execute or verify anything — write out the exact herdr commands you would run and the exact dispatch prompt text you would send to one worker.",
+      "prompt": "We are inside a Herdr session. First read .agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md, then follow it to plan the orchestration of a refactor split into three independent tasks run by parallel Codex workers in separate Herdr worktree tabs, with each worker's tab inside that worker's returned repository-associated deliverable workspace and the orchestrator workspace reserved for the orchestrator. Show the complete sequence for all three workers, not only one: for each worker, create or open the deliverable worktree, capture its returned deliverable workspace and root pane IDs, immediately move its returned root pane into a new tab targeted at that returned deliverable workspace, start the agent in the returned destination pane, and dispatch that worker's prompt. Only after all three dispatches are complete, wait for all three worker report prompts. For every worker, the command order must be herdr worktree create or open, immediately herdr pane move <returned-root-pane-id> --new-tab --workspace <returned-deliverable-workspace-id>, then herdr agent start using the destination pane ID returned by the move rather than the original root pane ID. This is an offline dry run: Herdr is unavailable for execution, but the command syntax shown in the named skill is authoritative and must be reproduced in your answer; do not refuse or ask for the skill text because execution or readback is unavailable, and do not execute or verify anything — write out the exact herdr commands you would run and the exact dispatch prompt text you would send to one worker.",
       "should_trigger": true,
       "assertions": [
         "The response renames the orchestrator agent to an addressable name and renames its own tab to a label containing the 🤖 emoji.",
-        "The response performs the exact topology sequence for each worker: herdr worktree create, immediately herdr pane move <returned-root-pane-id> --new-tab --workspace \"$HERDR_WORKSPACE_ID\" into the orchestrator's existing workspace before any herdr agent start, then starts the agent with the destination pane ID returned by the move rather than the pre-move root pane ID.",
+        "The response performs the exact topology sequence for each worker: herdr worktree create or open establishes or reuses that worker's deliverable workspace, immediately herdr pane move <returned-root-pane-id> --new-tab --workspace <returned-deliverable-workspace-id> into that returned deliverable workspace before any herdr agent start, then starts the agent with the destination pane ID returned by the move rather than the pre-move root pane ID.",
         "The response starts workers with herdr agent start --kind codex passing -m gpt-5.6-luna and model_reasoning_effort=xhigh after the -- separator.",
         "Each worker gets a separately built dispatch prompt with its own fixed identity and task/report target, explicitly telling it to read and follow the `shunk031-orchestrate-herdr-workers` skill before starting; no prompt is reused.",
         "The response keeps normal completion report-driven without polling worker reports.",
@@ -85,6 +85,84 @@
         "The response treats REJECT as nonterminal, stores the consolidated findings in a shell variable, and routes them to supplied live owner orch264-adopt-report with `herdr agent prompt orch264-adopt-report`, passing that variable as one quoted argument without shell expansion.",
         "The response records rejected head `cc5a008abc33ef68d07b30ee57c11ed93a3571c3` as re-review pending and says that, after orch264-adopt-report publishes a corrected head, that exact head is routed to the same reviewer orch264-pr627-review.",
         "The response blocks user merge handoff until that reviewer reports ACCEPT and does not merge the PR."
+      ]
+    },
+    {
+      "id": "same-turn-report-routing",
+      "prompt": "You are orchestrator agent orch264 in a Herdr session. During one user turn, the durable queue delivers these reports: orch-build sends DONE but its source-of-truth acceptance is still pending; orch-data is BLOCKED asking whether to use 8 or 16 GPUs; orch-adopt sends STATUS saying it is still working; and an OBSERVER advisory says orch-review has no new report. The user also asks, ‘What is the current status?’ This is an offline dry run; describe the concrete routing actions and wait reasons before ending the same turn, but do not execute commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response processes all four worker events and answers the user's status question during the same turn instead of deferring the queue.",
+        "For each actionable event, the response gives a concrete routing action or a specific report-driven wait reason."
+      ]
+    },
+    {
+      "id": "orchestrator-provenance",
+      "prompt": "Following the `shunk031-orchestrate-herdr-workers` skill, you are orchestrator agent orch264 in a Herdr session. A worker asks why a constraint appears in its task prompt. The supplied transcript excerpt says: User: ‘Run the package-loader acceptance check.’ Worker prompt: ‘Compare the production loader with an independent reference.’ Orchestrator note: ‘I added this comparison constraint after reviewing the worker report.’ Explain the constraint's provenance using those transcript facts, without executing commands or inventing missing context.",
+      "should_trigger": true,
+      "assertions": [
+        "The response distinguishes the user's instruction from the separately added orchestrator constraint by checking the transcript rather than treating both as user requirements.",
+        "The response explains the constraint's source from the supplied transcript without relying on an unsupported source.",
+        "The response does not present an inferred motive as an observed fact."
+      ]
+    },
+    {
+      "id": "queue-over-conversation",
+      "prompt": "You are orchestrator agent orch264 in a Herdr session. During one user turn, the durable queue delivers these reports: orch-build sends DONE, claims the diff and production-path trace are ready for source-of-truth acceptance, and gives a review link; orch-data sends BLOCKED and asks whether to use 8 or 16 GPUs. The user also asks, ‘Are we on track?’ This is an offline dry run; describe the concrete routing actions and wait reasons before ending the same turn, but do not execute commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response handles both worker reports in the same user turn while also answering the user's status question.",
+        "The response performs or routes the DONE source-of-truth acceptance, answers or escalates the BLOCKED question, and answers the user's status question without deferring any of them."
+      ]
+    },
+    {
+      "id": "deliverable-workspace-lifecycle",
+      "prompt": "You are orchestrator agent orch264 in a Herdr session coordinating one implementation worker and one independent reviewer for a deliverable that will become a single pull request. In an offline dry run, describe the workspace and tab lifecycle from task start through receiving an issue URL and then a pull-request URL; do not execute commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response places the implementer and reviewer tabs in one workspace for the single deliverable rather than creating a workspace per tab.",
+        "The response changes the workspace label in order from WIP topic to Issue number and topic to PR number and topic, and performs each URL-triggered rename in the same turn as receiving that URL.",
+        "The response keeps tab-label changes under the worker-owned `shunk031-herdr-tab-status` responsibility rather than renaming worker tabs as the coordinator."
+      ]
+    },
+    {
+      "id": "worktree-workspace-topology",
+      "prompt": "Following the `shunk031-orchestrate-herdr-workers` skill, you are orchestrator agent orch264 in a Herdr session. A deliverable needs a repository-associated worktree workspace. For a new or already-open deliverable worktree, create or open it, use the returned deliverable workspace and root pane IDs, move the returned root pane into a new tab targeted at that returned deliverable workspace before starting the worker, and keep the orchestrator workspace for the orchestrator only. This is an offline dry run; show the command sequence without executing it, including how you handle an already-open worktree without creating a second workspace.",
+      "should_trigger": true,
+      "assertions": [
+        "The response establishes or reuses the deliverable's repository-associated workspace with `herdr worktree create` or `herdr worktree open`, uses the returned deliverable workspace and root pane IDs, and does not create a second workspace on the open/reuse path.",
+        "The response moves the returned pane only after the deliverable workspace exists, using `herdr pane move <pane-id> --new-tab --workspace <returned-deliverable-workspace-id>` for the destination tab, starts the worker in the returned destination pane, and keeps the orchestrator workspace separate.",
+        "The response does not construct the worktree workspace with `herdr pane move <pane-id> --new-workspace`."
+      ]
+    },
+    {
+      "id": "cross-stream-failure-synthesis",
+      "prompt": "Following the `shunk031-orchestrate-herdr-workers` skill, you are orchestrator agent orch264 in a Herdr session. Two independent worker streams report the same failure signature in separate tasks. This is an offline dry run; describe the coordination response and what durable follow-up you create, without executing commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response recognizes the matching signature as a cross-stream pattern rather than treating the failures as unrelated task-local defects.",
+        "The response transfers the useful diagnosis or diagnostic method from one stream to the other and keeps both owners informed through the normal routing path.",
+        "The response considers a generalized meta issue for the shared failure instead of recording only two isolated fixes."
+      ]
+    },
+    {
+      "id": "recompute-report-numbers",
+      "prompt": "Following the `shunk031-orchestrate-herdr-workers` skill, you are orchestrator agent orch264 in a Herdr session. A worker report headline claims 12 passed and 0 skipped, but the attached raw result rows contain 11 passing rows and 1 skipped row. This is an offline dry run; state what you relay and whether you use the report for a decision, without executing commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response recomputes the headline from the raw rows and identifies that the reported counts do not match.",
+        "The response does not relay or accept the inconsistent headline for a decision and treats the result as unresolved.",
+        "The response treats the raw report data as the basis for the numeric check rather than trusting the worker's summary."
+      ]
+    },
+    {
+      "id": "immediate-user-escalation",
+      "prompt": "Following the `shunk031-orchestrate-herdr-workers` skill, you are orchestrator agent orch264 in a Herdr session. A worker asks the user to choose between 8 or 16 GPUs, decide whether to delete an 18 GB artifact, and choose one family or all 12 families for scope. Another independent stream can continue. The raw report facts include the mount path `/mnt/internal/run-264`, internal host `gpu17.internal.example`, and IP `10.24.8.17`. This is an offline dry run; describe the immediate escalation and parallel coordination response without executing commands.",
+      "should_trigger": true,
+      "assertions": [
+        "The response immediately escalates the user-owned decisions with the concrete alternatives and numbers, without choosing on the user's behalf.",
+        "The response keeps the independent stream moving while waiting for the user's decision instead of blocking all orchestration.",
+        "The supplied mount path, internal hostname, and IP address do not appear in any proposed repository artifact content for docs, PR text, issue comments, or commit messages."
       ]
     },
     {


### PR DESCRIPTION
## Summary

Add eight orchestrator behavior rules and one disposable-session operations note to shunk031-orchestrate-herdr-workers. The rules were extracted from today's real Herdr orchestration incidents and outcomes:

1. same-turn routing for DONE/BLOCKED/STATUS/OBSERVER reports, with a concrete prompt or explicit wait reason;
2. transcript-backed provenance for user instructions, worker prompts, and orchestrator additions;
3. processing queued worker reports during the same user turn as the user's question;
4. one workspace per deliverable/PR, with WIP -> Issue -> PR workspace labels and worker-owned tab labels;
5. repository-associated deliverable workspaces created/reused with herdr worktree create/open, with related panes moved there;
6. transferring diagnosis across streams with matching failure signatures and considering a meta issue;
7. recomputing report headline numbers from raw data before decisions;
8. immediately escalating user-owned compute, deletion, license/provenance, and scope decisions while keeping other streams moving, and excluding internal infrastructure identifiers from repository artifacts.

The operations note records that an orchestrator session is disposable when context degrades; durable Herdr, git, and PR state make handoff safe.

## Topology unification

The merged #633 guidance moved worker panes into the orchestrator's existing workspace. Today's established operation uses a repository-associated workspace per deliverable instead: herdr worktree create/open returns the deliverable workspace and root pane, related implementer/reviewer tabs stay there, and the orchestrator workspace remains for the orchestrator. This change replaces the conflicting #633 topology wording and makes the returned deliverable workspace ID explicit, including the open/reuse path.

## Evaluation and calibration

Each new rule has an evaluation case with observable assertions. The cases avoid answer-loading, supplied-fact repetition, literal variable/phrase requirements, and unobservable internal-state claims. Trigger evidence was added in #635, per-case positive-trigger majority was introduced in #637, and the topology scenario was corrected through the #636 independent review after identifying the residual #633 contradiction. Static validation and the authorized canonical gate passed.

Related work: #627, #633, #634, #635, #636, #637.