### PR TITLE
feat(skills): add shunk031-doc-slop-review thin skill

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-doc-slop-review/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-doc-slop-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: shunk031-doc-slop-review
+description: Review reader-facing text with the repository's two-tier slop review before publishing it. Use when writing or editing documentation, README or TRAINING files, issue bodies and comments, pull request bodies and descriptions, or status reports that another person will read. Runs deterministic checks and one blind model judge over the draft, quotes each problem, and produces a PASS or FAIL to attach to the publish report.
+---
+
+# Document Slop Review
+
+## 読了時の応答
+
+- この skill を読んだら、`🧹 私は shunk031-doc-slop-review を読みました。` と応答する。
+
+## The command
+
+Run `scripts/doc_slop_review.py` from the dotfiles repository checkout:
+
+```bash
+cd "$(chezmoi source-path)"   # typically ~/.local/share/chezmoi
+uv run --python 3.14.6 --no-project python scripts/doc_slop_review.py DRAFT.md
+```
+
+Give this command to the user when you report the work. Do not paraphrase it
+and do not ask the reader to reconstruct it from a description.
+
+## When to use
+
+Run this before publishing any text a person will read: repository
+documentation, `README.md` and `TRAINING.md` style files, issue bodies and
+comments, pull request bodies, and status or completion reports.
+
+Skip it for code-only changes, machine-readable data, and ordinary
+conversational replies. A commit message body is optional; review it when it
+carries the explanation a reader depends on.
+
+## Flow
+
+1. Write the draft to a file, or pipe it in. Do not publish first and review
+   after.
+2. Run the review on the draft with the command above.
+3. Address every finding, or state why a finding does not apply. A finding you
+   disagree with is answered in the report, not ignored silently.
+4. Re-run until it reports PASS, then attach that verdict to the publish
+   report. If publishing with a FAIL, record the waiver and its reason in the
+   same report.
+
+## Where the script lives
+
+The script is `scripts/doc_slop_review.py` in the dotfiles **repository
+checkout**, not in this applied skill tree. It imports the repository's
+`scripts/agent_guidance_eval.py` for its Codex conventions, so it only runs
+from that checkout. That is why the command changes directory first.
+
+## More command shapes
+
+Review a pull request body before creating or editing it:
+
+```bash
+gh pr view 123 --json body --jq .body | \
+  uv run --python 3.14.6 --no-project python scripts/doc_slop_review.py
+```
+
+Review only the prose a change adds:
+
+```bash
+git diff -- '*.md' | \
+  uv run --python 3.14.6 --no-project python scripts/doc_slop_review.py --diff
+```
+
+Useful flags: `--json` for machine-readable output, `--skip-model` for the
+deterministic tier alone when no model call is available. On a host without
+unprivileged user namespaces, export
+`AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access` first.
+
+Exit codes are `0` for PASS, `1` for FAIL, and `2` when the review could not
+run. A `2` is not a PASS; report it as a failed review.
+
+## Reading the output
+
+Each finding names its rubric category, quotes the offending text, explains the
+problem, and proposes a fix. Findings marked `regex` come from the
+deterministic tier; findings marked `model` come from the judge.
+
+A model finding is discarded when its quoted excerpt does not appear in the
+document, which keeps the output specific. The report counts those in
+`discarded_model_findings`; a nonzero count means the judge saw something it
+could not quote, so read the draft again rather than treating it as noise.
+
+## Related skills
+
+- `shunk031-ai-slop-checklist-ja` owns the Japanese review criteria and the
+  five-axis scoring. The rubric this script uses is derived from it; consult
+  that skill for the detailed criteria and for manual Japanese review.
+- `shunk031-structured-writing` owns how to compose and organize the text.
+  Use it while drafting; use this skill to check the draft before publishing.
+- `shunk031-humanizer-ja` owns rewriting Japanese prose once a problem is found.

--- a/home/dot_config/exact_agents/skills/shunk031-doc-slop-review/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-doc-slop-review/evals/evals.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "skill": "shunk031-doc-slop-review",
+  "evals": [
+    {
+      "id": "training-doc-draft",
+      "prompt": "I need to add a TRAINING.md to a package in this repository describing how to reproduce our training runs. Draft it and tell me how you would finish the job before I publish it.",
+      "should_trigger": true,
+      "assertions": [
+        "The response reviews the drafted document before treating it as ready to publish.",
+        "The response names the repository's document slop review script as the tool to run on the draft.",
+        "The response says a failing review is fixed, or waived with a recorded reason, before publication."
+      ]
+    },
+    {
+      "id": "issue-body-draft",
+      "prompt": "Write the issue body for a bug where our nightly job silently skips half its inputs, then open it. Tell me what you do before it goes up, and tell me what you will do if the review reports findings before you open the issue.",
+      "should_trigger": true,
+      "assertions": [
+        "The response reviews the issue body before the issue is created rather than after.",
+        "The response names the repository's document slop review script as the tool to run on the body.",
+        "The response says a failing review is fixed, or waived with a recorded reason, before the issue is opened."
+      ]
+    },
+    {
+      "id": "pull-request-body-draft",
+      "prompt": "I am about to open a pull request for a change that reworks our retry logic. Write the pull request description and explain how you check it before publishing, and tell me what you will do if the review reports findings before you publish it.",
+      "should_trigger": true,
+      "assertions": [
+        "The response checks the pull request description before the pull request is created or updated.",
+        "The response names the repository's document slop review script as the tool to run on the description.",
+        "The response says a failing review is fixed, or waived with a recorded reason, before publishing."
+      ]
+    },
+    {
+      "id": "code-only-change-negative-control",
+      "prompt": "Rename the variable `tmp` to `buffer` in this function and return only the updated code:\n\ndef read(path):\n    tmp = open(path).read()\n    return tmp",
+      "should_trigger": false,
+      "assertions": [
+        "The response returns the updated code with the variable renamed.",
+        "The response does not introduce a document review step for a code-only change."
+      ]
+    },
+    {
+      "id": "conversational-answer-negative-control",
+      "prompt": "Quick question, no writing task: is a rebase or a merge better when my branch is behind main and nobody else has pulled it? Answer in a sentence or two.",
+      "should_trigger": false,
+      "assertions": [
+        "The response answers the question directly.",
+        "The response does not turn a conversational answer into a document review task."
+      ]
+    }
+  ]
+}

--- a/home/dot_gemini/config/skills/symlink_shunk031-doc-slop-review.tmpl
+++ b/home/dot_gemini/config/skills/symlink_shunk031-doc-slop-review.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shunk031-doc-slop-review

--- a/home/exact_dot_agents/skills/symlink_shunk031-doc-slop-review.tmpl
+++ b/home/exact_dot_agents/skills/symlink_shunk031-doc-slop-review.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.sourceDir }}/dot_config/exact_agents/skills/shunk031-doc-slop-review

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -265,7 +265,7 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F 'test_expected_thin_adapters_are_complete_and_exclusive' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
     [ "${status}" -eq 0 ]
-    run grep -F 'test_guidance_reverse_scan_has_all_seventeen_derived_paths' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
+    run grep -F 'test_guidance_reverse_scan_has_all_eighteen_derived_paths' "${AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH}"
     [ "${status}" -eq 0 ]
 }
 

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -705,8 +705,8 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
                     expected = adapter["occurrences"] if path == adapter["path"] else 0
                     self.assertEqual(text.count(adapter["text"]), expected)
 
-    def test_guidance_reverse_scan_has_all_seventeen_derived_paths(self) -> None:
-        self.assertEqual(len(self._guidance_paths()), 17)
+    def test_guidance_reverse_scan_has_all_eighteen_derived_paths(self) -> None:
+        self.assertEqual(len(self._guidance_paths()), 18)
 
     def test_third_party_research_has_one_routing_rule_and_skill_owner(self) -> None:
         agents_path = REPO_ROOT / "home/dot_config/exact_agents/AGENTS.md"

--- a/tests/python/test_doc_slop_review.py
+++ b/tests/python/test_doc_slop_review.py
@@ -223,6 +223,24 @@ class DocSlopReviewTest(unittest.TestCase):
 
         self.assertEqual(exit_code, 1)
 
+    def test_skill_references_the_script_instead_of_bundling_it(self) -> None:
+        """The skill tree is chezmoi-applied, so a bundled copy would deploy broken.
+
+        The script imports the repository's evaluator, which does not exist
+        under the applied skill tree, so the skill must point at the checkout.
+        """
+        skill_root = (
+            REPO_ROOT / "home/dot_config/exact_agents/skills/shunk031-doc-slop-review"
+        )
+        shipped = {path.name for path in skill_root.rglob("*") if path.is_file()}
+        skill_text = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+
+        self.assertEqual(shipped, {"SKILL.md", "evals.json"})
+        self.assertIn("scripts/doc_slop_review.py", skill_text)
+        self.assertIn("chezmoi source-path", skill_text)
+        self.assertTrue(SCRIPT_PATH.is_file())
+        self.assertTrue((REPO_ROOT / "scripts/doc_slop_rubric.json").is_file())
+
     def test_main_rejects_empty_input(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             path = Path(tempdir) / "empty.md"


### PR DESCRIPTION
## Summary

- Add the thin `shunk031-doc-slop-review` skill for reviewing reader-facing documentation, issue bodies, pull-request descriptions, and status reports before publication.
- The skill directs users to run the repository's deterministic and model-judged document review command, while keeping the applied skill tree free of a bundled script.
- It references the merged `scripts/doc_slop_review.py` from PR #639.
- Add focused positive and negative behavioral eval cases.

## Validation

`AGENT_GUIDANCE_EVAL_SANDBOX=danger-full-access prek run --all-files`

- `validate changed agent skills and guidance`: Passed
- `evaluate changed agent skills and guidance`: Passed