### PR TITLE
feat(herdr): sync upstream skill from installed binary

### DIFF
--- a/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
@@ -4,12 +4,15 @@
 # @brief Install pinned mise tools after `chezmoi apply`.
 # @description
 #   Keeps mise itself and mise-managed tools aligned with the applied pinned
-#   versions after every `chezmoi apply`.
+#   versions after every `chezmoi apply`, then syncs release-matched Herdr
+#   skill instructions when Herdr is installed.
 
 set -Eeuo pipefail
 
 # shellcheck source=/dev/null
 source "{{ .chezmoi.sourceDir }}/../install/common/mise.sh"
+# shellcheck source=/dev/null
+source "{{ .chezmoi.sourceDir }}/../install/common/herdr.sh"
 
 ensure_mise_min_version
 
@@ -22,3 +25,7 @@ if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh > /dev/null 2>&1; then
 fi
 
 run_mise_install
+
+if "${MISE_BIN}" exec -- herdr --version > /dev/null 2>&1; then
+    sync_herdr_skill
+fi

--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -4,7 +4,7 @@
 # @brief Install Herdr integrations and skill assets.
 # @description
 #   Activates `mise` when available, installs Herdr integrations for configured
-#   coding agents, and installs the shared Herdr skill globally.
+#   coding agents, and syncs the shared Herdr skill from the installed binary.
 
 set -Eeuo pipefail
 
@@ -13,12 +13,7 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 readonly MISE_BIN="${HOME}/.local/bin/mise"
-readonly HERDR_SKILL_REPO="ogulcancelik/herdr"
-readonly HERDR_SKILL_NAME="herdr"
-readonly HERDR_SKILL_AGENTS=(
-    claude-code
-    antigravity-cli
-)
+readonly HERDR_SKILL_PATH="${HOME}/.agents/skills/herdr/SKILL.md"
 
 readonly HERDR_INTEGRATIONS=(
     claude
@@ -50,14 +45,21 @@ function install_herdr_integrations() {
 }
 
 #
-# @description Install the shared Herdr skill globally.
+# @description Sync the shared Herdr skill from the installed Herdr binary.
 #
-function install_herdr_skill() {
-    "${MISE_BIN}" exec -- skills add "${HERDR_SKILL_REPO}" \
-        --skill "${HERDR_SKILL_NAME}" \
-        --agent "${HERDR_SKILL_AGENTS[@]}" \
-        --global \
-        --yes
+function sync_herdr_skill() {
+    local skill_dir temp
+
+    skill_dir="$(dirname "${HERDR_SKILL_PATH}")"
+    mkdir -p "${skill_dir}"
+    temp="$(mktemp "${skill_dir}/.SKILL.md.XXXXXX")" || return 1
+
+    if ! "${MISE_BIN}" exec -- herdr --skill > "${temp}"; then
+        rm -f "${temp}"
+        return 1
+    fi
+
+    mv "${temp}" "${HERDR_SKILL_PATH}"
 }
 
 #
@@ -67,7 +69,7 @@ function main() {
     activate_mise
     install_herdr
     install_herdr_integrations
-    install_herdr_skill
+    sync_herdr_skill
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -166,29 +166,34 @@ EOF
     [ -f "${TMPL_SCRIPT_PATH}" ]
 }
 
-@test "[common] install_herdr_skill succeeds when the named npm runner is stale" {
+@test "[common] sync_herdr_skill succeeds when the named npm runner is stale" {
     mkdir -p "${BATS_TEST_TMPDIR}/bin"
     MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
-    SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt"
-    export MISE_CALLS_PATH SKILLS_CALLS_PATH
+    HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_args.txt"
+    export MISE_CALLS_PATH HERDR_CALLS_PATH
     write_mise_with_stale_named_runner
 
-    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
+    cat > "${BATS_TEST_TMPDIR}/bin/herdr" << 'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "$*" > "${SKILLS_CALLS_PATH}"
+printf '%s\n' "$*" > "${HERDR_CALLS_PATH}"
+printf '%s\n' 'generated Herdr skill'
 EOF
-    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+    chmod +x "${BATS_TEST_TMPDIR}/bin/herdr"
 
-    PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" run install_herdr_skill
+    PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" run sync_herdr_skill
     [ "${status}" -eq 0 ]
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${output}" = "exec -- herdr --skill" ]
 
-    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
+    run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${output}" = "--skill" ]
+
+    run cat "${HOME}/.agents/skills/herdr/SKILL.md"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "generated Herdr skill" ]
 }
 
 @test "[common] activate_mise evaluates mise activation output" {
@@ -229,16 +234,27 @@ EOF
     [ "${lines[0]}" = "exec -- herdr integration install claude" ]
 }
 
-@test "[common] install_herdr_skill installs the shared skill globally" {
+@test "[common] sync_herdr_skill writes the shared skill from Herdr" {
     MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
     export MISE_CALLS_PATH
-    write_mise_logger
+    cat > "${MISE_BIN}" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+if [ "$*" = "exec -- herdr --skill" ]; then
+    printf '%s\n' 'generated Herdr skill'
+fi
+EOF
+    chmod +x "${MISE_BIN}"
 
-    install_herdr_skill
+    sync_herdr_skill
 
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${output}" = "exec -- herdr --skill" ]
+
+    run cat "${HOME}/.agents/skills/herdr/SKILL.md"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "generated Herdr skill" ]
 }
 
 @test "[common] herdr script runs full installation workflow" {
@@ -262,21 +278,17 @@ EOF
     cat > "${BATS_TEST_TMPDIR}/bin/herdr" << 'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${HERDR_CALLS_PATH}"
+if [ "$*" = "--skill" ]; then
+    printf '%s\n' "$*"
+fi
 EOF
     chmod +x "${BATS_TEST_TMPDIR}/bin/herdr"
-
-    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "${HERDR_TEST_MISE_ACTIVATED:-unset}|$*" > "${SKILLS_CALLS_PATH}"
-EOF
-    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
 
     run env \
         DOTFILES_DEBUG=1 \
         HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_args.txt" \
         HOME="${HOME}" \
         MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt" \
-        SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt" \
         PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
         bash "${SCRIPT_PATH}"
     [ "${status}" -eq 0 ]
@@ -286,13 +298,14 @@ EOF
     [ "${lines[0]}" = "activate bash" ]
     [ "${lines[1]}" = "install herdr" ]
     [ "${lines[2]}" = "exec -- herdr integration install claude" ]
-    [ "${lines[3]}" = "exec -- skills add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${lines[3]}" = "exec -- herdr --skill" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "integration install claude" ]
+    [ "${lines[1]}" = "--skill" ]
 
-    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
+    run cat "${HOME}/.agents/skills/herdr/SKILL.md"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "1|add ogulcancelik/herdr --skill herdr --agent claude-code antigravity-cli --global --yes" ]
+    [ "${output}" = "--skill" ]
 }

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -60,6 +60,26 @@ function render_run_after_template() {
     chmod +x "${RUN_AFTER_SCRIPT}"
 }
 
+function write_herdr_stub() {
+    local herdr_path="${TEST_BIN_DIR}/herdr"
+
+    cat > "${herdr_path}" << 'EOF'
+#!/usr/bin/env bash
+
+printf '%s\n' "$*" >> "${HERDR_CALLS_PATH}"
+case "$*" in
+    --version)
+        printf '%s\n' 'herdr 0.8.0'
+        ;;
+    --skill)
+        printf '%s\n' 'generated Herdr skill'
+        ;;
+esac
+EOF
+
+    chmod +x "${herdr_path}"
+}
+
 function write_mise_stub() {
     local version="${1:-2026.6.13}"
 
@@ -82,6 +102,13 @@ case "\$1" in
         printf 'MISE_CURRENT_VERSION=%s\\n' "\${MISE_CURRENT_VERSION:-}" >> "\${MISE_CALLS_PATH}"
         printf 'MISE_VERSION=%s\\n' "\${MISE_VERSION:-}" >> "\${MISE_CALLS_PATH}"
         printf 'GITHUB_TOKEN=%s\\n' "\${GITHUB_TOKEN:-}" >> "\${MISE_CALLS_PATH}"
+        ;;
+    exec)
+        printf 'exec %s\\n' "\${*:2}" >> "\${MISE_CALLS_PATH}"
+        if [ "\${2:-}" = "--" ]; then
+            shift 2
+            "\$@"
+        fi
         ;;
 esac
 EOF
@@ -128,6 +155,13 @@ case "$1" in
         printf 'MISE_CURRENT_VERSION=%s\n' "${MISE_CURRENT_VERSION:-}" >> "${MISE_CALLS_PATH}"
         printf 'MISE_VERSION=%s\n' "${MISE_VERSION:-}" >> "${MISE_CALLS_PATH}"
         printf 'GITHUB_TOKEN=%s\n' "${GITHUB_TOKEN:-}" >> "${MISE_CALLS_PATH}"
+        ;;
+    exec)
+        printf 'exec %s\n' "${*:2}" >> "${MISE_CALLS_PATH}"
+        if [ "${2:-}" = "--" ]; then
+            shift 2
+            "$@"
+        fi
         ;;
 esac
 MISE
@@ -374,7 +408,28 @@ EOF
     [ "${status}" -eq 0 ]
 }
 
-@test "[common] run_after template installs pinned mise tools after apply" {
+@test "[common] run_after template installs pinned mise tools and syncs Herdr skill after apply" {
+    write_mise_stub
+    write_herdr_stub
+    export HERDR_CALLS_PATH="${BATS_TEST_TMPDIR}/herdr_calls.txt"
+
+    run bash "${RUN_AFTER_SCRIPT}"
+    [ "${status}" -eq 0 ]
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=\nexec -- herdr --version\nexec -- herdr --skill' ]
+
+    run cat "${HERDR_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = $'--version\n--skill' ]
+
+    run cat "${HOME}/.agents/skills/herdr/SKILL.md"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "generated Herdr skill" ]
+}
+
+@test "[common] run_after template skips Herdr skill sync when Herdr is unavailable" {
     write_mise_stub
 
     run bash "${RUN_AFTER_SCRIPT}"
@@ -382,7 +437,8 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=\nexec -- herdr --version' ]
+    [ ! -e "${HOME}/.agents/skills/herdr/SKILL.md" ]
 }
 
 @test "[common] run_after template bootstraps mise when it is not installed" {

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -449,7 +449,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=\nexec -- herdr --version' ]
     [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
 }
 
@@ -462,7 +462,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=\nexec -- herdr --version' ]
     [ -e "${BATS_TEST_TMPDIR}/curl_args.txt" ]
 }
 
@@ -476,7 +476,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=existing-token' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=existing-token\nexec -- herdr --version' ]
     [ ! -e "${GH_CALLS_PATH}" ]
 }
 
@@ -489,7 +489,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=stub-token' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=stub-token\nexec -- herdr --version' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }
 
@@ -502,6 +502,6 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=' ]
+    [ "${output}" = $'install\nMISE_CURRENT_VERSION=\nMISE_VERSION=\nGITHUB_TOKEN=\nexec -- herdr --version' ]
     [ "$(< "${GH_CALLS_PATH}")" = "auth token" ]
 }


### PR DESCRIPTION
## Why

Keep the runtime Herdr skill aligned with the installed Herdr release. Herdr's installed binary is the source of truth.

## What Changed

- This PR does NOT commit `home/dot_config/exact_agents/skills/herdr/SKILL.md`; no `home/dot_config/exact_agents/skills/herdr/SKILL.md` is tracked.
- Removed the repo-managed Herdr skill, its adapter, evals, and symlink templates.
- After `mise install`, if Herdr is available, dotfiles syncs `herdr --skill` into runtime `~/.agents/skills/herdr/SKILL.md`.
- Initial Herdr install does the same through `install/common/herdr.sh`.
- No `home/dot_config/exact_agents/skills/herdr/SKILL.md` is tracked.

## Validation

Author validation completed after the correction: shell syntax for the Herdr installation and recurring mise-install scripts passed.

```shell
bash -n install/common/herdr.sh install/common/mise.sh home/.chezmoiscripts/common/run_after_20-install-mise-tools.sh.tmpl
```

Author validation completed after the correction: the staged diff passed the whitespace check.

```shell
git diff --cached --check
```

Author validation completed after the correction: the Python unit-test suite passed.

```shell
python3 -m unittest discover -s tests/python
```

Author validation completed after the correction: repository pre-commit checks passed; the guidance hooks were skipped because no matching managed guidance or skill files remain.

```shell
prek run
```

Local Bats was not run because `AGENTS.md` forbids it; Bats validation is deferred to GitHub Actions. Reviewers should wait for the GitHub Actions Bats job to pass before approving.
