### PR TITLE
fix(herdr): keep workspace labels free of status emoji

### DIFF
--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/SKILL.md
@@ -5,7 +5,7 @@ description: Orchestrate and coordinate coding workers in Herdr by spawning para
 
 # Orchestrate Herdr Workers
 
-An orchestrator delegates independent tasks to worker agents, one git worktree tab each; workers report back by prompting the orchestrator, and normal completion remains report-driven without coordinator polling. Read the herdr skill first: it owns all CLI mechanics, JSON responses, ID handling, and safety rules. This skill adds only the orchestration protocol. Build every peer prompt in a shell variable first (for example, with a quoted heredoc) and pass it as one argument; never let the shell expand task or report text.
+An orchestrator delegates independent tasks to worker agents, one git worktree tab each; workers report back by prompting the orchestrator, and normal completion remains report-driven without coordinator polling. Read this skill file and the herdr skill first: the herdr skill owns all CLI mechanics, JSON responses, ID handling, and safety rules. This skill adds only the orchestration protocol. Build every peer prompt in a shell variable first (for example, with a quoted heredoc) and pass it as one argument; never let the shell expand task or report text.
 
 ## Set up the orchestrator
 
@@ -26,9 +26,9 @@ An orchestrator delegates independent tasks to worker agents, one git worktree t
 
    ```bash
    # Choose exactly one for the deliverable:
-   herdr worktree create --cwd "$PWD" --branch <topic-branch> --label "🚧 <short task>" --no-focus
+   herdr worktree create --cwd "$PWD" --branch <topic-branch> --label "WIP <short task>" --no-focus
    # For an already-open deliverable worktree, use this instead of create:
-   herdr worktree open --cwd "$PWD" --branch <topic-branch> --label "🚧 <short task>" --no-focus
+   herdr worktree open --cwd "$PWD" --branch <topic-branch> --label "WIP <short task>" --no-focus
    herdr pane move <returned-root-pane-id> --new-tab --workspace <returned-deliverable-workspace-id> --label "🚧 <short task>" --no-focus
    ```
 

--- a/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
+++ b/home/dot_config/exact_agents/skills/shunk031-orchestrate-herdr-workers/evals/evals.json
@@ -132,7 +132,8 @@
       "assertions": [
         "The response establishes or reuses the deliverable's repository-associated workspace with `herdr worktree create` or `herdr worktree open`, uses the returned deliverable workspace and root pane IDs, and does not create a second workspace on the open/reuse path.",
         "The response moves the returned pane only after the deliverable workspace exists, using `herdr pane move <pane-id> --new-tab --workspace <returned-deliverable-workspace-id>` for the destination tab, starts the worker in the returned destination pane, and keeps the orchestrator workspace separate.",
-        "The response does not construct the worktree workspace with `herdr pane move <pane-id> --new-workspace`."
+        "The response does not construct the worktree workspace with `herdr pane move <pane-id> --new-workspace`.",
+        "Workspace labels use emoji-free WIP/Issue#/PR# forms, while status emojis appear only on tab labels such as the `herdr pane move ... --new-tab --label` example."
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Use `WIP <short task>` for worktree workspace labels.
- Keep `🚧 <short task>` on the `--new-tab` tab label.
- Add an eval guard for emoji-free workspace labels and tab-only status emojis.

## Validation

- `make setup` completed successfully.
- `prek` validation and evaluation hooks completed successfully.
- Local `bats` tests were not run, per repository policy; CI must confirm shell integration coverage.