### PR TITLE
feat(doc-slop): support skipping finding categories

### DIFF
--- a/scripts/doc_slop_review.py
+++ b/scripts/doc_slop_review.py
@@ -42,7 +42,7 @@ import re
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from types import ModuleType
 
@@ -144,6 +144,7 @@ class ReviewReport:
     threshold: str
     model_consulted: bool
     discarded_model_findings: int
+    skipped_categories: dict[str, int] = field(default_factory=dict)
 
 
 class ReviewError(RuntimeError):
@@ -271,6 +272,46 @@ def category_ids(rubric: dict[str, object]) -> list[str]:
         for entry in categories
         if isinstance(entry, dict) and isinstance(entry.get("id"), str)
     ]
+
+
+def textlint_category_ids() -> set[str]:
+    """Return category names emitted by the configured textlint rules."""
+    try:
+        config = json.loads(TEXTLINT_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    rules = config.get("rules") if isinstance(config, dict) else None
+    if not isinstance(rules, dict):
+        return set()
+    return {name for name in rules if isinstance(name, str)}
+
+
+def known_category_ids(rubric: dict[str, object]) -> set[str]:
+    """Return rubric, model-check, and deterministic rule category names."""
+    return (
+        set(category_ids(rubric))
+        | set(JUDGE_CHECK_IDS)
+        | textlint_category_ids()
+    )
+
+
+def unique_categories(categories: list[str] | None) -> list[str]:
+    """Deduplicate repeated flags while preserving their first-seen order."""
+    return list(dict.fromkeys(categories or []))
+
+
+def suppress_categories(
+    findings: list[Finding], skip_categories: list[str]
+) -> tuple[list[Finding], dict[str, int]]:
+    """Remove requested categories and count every suppressed finding."""
+    counts = {category: 0 for category in skip_categories}
+    retained: list[Finding] = []
+    for finding in findings:
+        if finding.category in counts:
+            counts[finding.category] += 1
+        else:
+            retained.append(finding)
+    return retained, counts
 
 
 def compile_flags(names: object) -> int:
@@ -560,6 +601,12 @@ def severity_rank(finding: Finding) -> int:
 def format_text_report(report: ReviewReport) -> str:
     lines = [f"documents: {', '.join(report.documents)}"]
     lines.append(f"threshold: {report.threshold}")
+    if report.skipped_categories:
+        skipped = ", ".join(
+            f"{category} ({count} findings suppressed)"
+            for category, count in report.skipped_categories.items()
+        )
+        lines.append(f"skipped categories: {skipped}")
     if not report.model_consulted:
         lines.append("model judge: skipped")
     if report.discarded_model_findings:
@@ -592,6 +639,8 @@ def format_json_report(report: ReviewReport) -> str:
         "passed": report.passed,
         "findings": [asdict(finding) for finding in report.findings],
     }
+    if report.skipped_categories:
+        payload["skipped_categories"] = report.skipped_categories
     return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
 
 
@@ -638,6 +687,7 @@ def review_documents(
     model: str | None,
     reasoning_effort: str | None,
     evaluator: ModuleType | None,
+    skip_categories: list[str] | None = None,
 ) -> ReviewReport:
     findings: list[Finding] = []
     discarded = 0
@@ -660,6 +710,9 @@ def review_documents(
         )
         findings.extend(model_findings)
         discarded += dropped
+    findings, skipped = suppress_categories(
+        findings, unique_categories(skip_categories)
+    )
     return ReviewReport(
         documents=[document.name for document in documents],
         findings=findings,
@@ -667,6 +720,7 @@ def review_documents(
         threshold=threshold_description(),
         model_consulted=not skip_model,
         discarded_model_findings=discarded,
+        skipped_categories=skipped,
     )
 
 
@@ -689,6 +743,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="run only the deterministic tier",
     )
+    parser.add_argument(
+        "--skip-category",
+        action="append",
+        metavar="NAME",
+        help="suppress findings with this category; may be repeated",
+    )
     parser.add_argument("--json", action="store_true", help="emit JSON")
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
     parser.add_argument("--model", default=DEFAULT_JUDGE_MODEL)
@@ -702,6 +762,13 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         rubric = load_rubric()
+        skip_categories = unique_categories(args.skip_category)
+        for category in skip_categories:
+            if category not in known_category_ids(rubric):
+                print(
+                    f"warning: unknown skip category: {category}",
+                    file=sys.stderr,
+                )
         documents = read_documents(args.paths, as_diff=args.diff)
         report = review_documents(
             documents,
@@ -711,6 +778,7 @@ def main(argv: list[str] | None = None) -> int:
             model=args.model,
             reasoning_effort=args.reasoning_effort,
             evaluator=None,
+            skip_categories=skip_categories,
         )
     except ReviewError as error:
         print(f"doc slop review failed: {error}", file=sys.stderr)

--- a/tests/python/test_doc_slop_review.py
+++ b/tests/python/test_doc_slop_review.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import stat
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -567,6 +569,87 @@ class DocSlopReviewTest(unittest.TestCase):
         self.assertEqual(payload["findings"][0]["detector"], "regex")
         self.assertEqual(payload["findings"][0]["category"], "over-hedging")
         self.assertFalse(payload["model_consulted"])
+        self.assertNotIn("skipped_categories", payload)
+        self.assertNotIn("skipped categories:", text)
+
+    def test_skip_category_suppresses_deterministic_and_model_findings(self) -> None:
+        document = self.document("It depends on the case.\nSection title\n")
+        checks = {
+            check_id: {
+                "passed": True,
+                "excerpt": "",
+                "why": "fixture pass",
+                "suggested_fix": "",
+            }
+            for check_id in self.module.JUDGE_CHECK_IDS
+        }
+        checks["uninformative-section-title"] = {
+            "passed": False,
+            "excerpt": "Section title",
+            "why": "The heading does not tell the reader what question it answers.",
+            "suggested_fix": "Make the heading answer the section's question.",
+        }
+        evaluator = stub_evaluator(self.module, [], checks=checks)
+
+        with patch.object(self.module, "run_textlint", return_value=[]):
+            report = self.module.review_documents(
+                [document],
+                self.rubric,
+                skip_model=False,
+                timeout=1,
+                model=None,
+                reasoning_effort=None,
+                evaluator=evaluator,
+                skip_categories=[
+                    "over-hedging",
+                    "uninformative-section-title",
+                ],
+            )
+
+        self.assertTrue(report.passed)
+        self.assertEqual(report.findings, [])
+        self.assertEqual(
+            report.skipped_categories,
+            {
+                "over-hedging": 1,
+                "uninformative-section-title": 1,
+            },
+        )
+
+        text = self.module.format_text_report(report)
+        payload = json.loads(self.module.format_json_report(report))
+        self.assertIn(
+            "skipped categories: over-hedging (1 findings suppressed), "
+            "uninformative-section-title (1 findings suppressed)",
+            text,
+        )
+        self.assertEqual(
+            payload["skipped_categories"], report.skipped_categories
+        )
+        self.assertEqual(payload["findings"], [])
+
+    def test_unknown_skip_category_is_warned_about(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "doc.md"
+            path.write_text("Clean text for the reader.\n", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with patch.object(self.module, "run_textlint", return_value=[]):
+                with redirect_stderr(stderr):
+                    exit_code = self.module.main(
+                        [
+                            str(path),
+                            "--skip-model",
+                            "--skip-category",
+                            "not-a-real-category",
+                        ]
+                    )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "warning: unknown skip category: not-a-real-category",
+            stderr.getvalue(),
+        )
 
     def test_main_reports_failure_exit_code_without_calling_a_model(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## What does this change add?

The question is how a caller can exempt a named finding category from a fixed-format document without changing the rubric. The rubric is the review's category and threshold rules; a fixed-format document is one whose required section names, headings, or verdict structure cannot be freely changed. A finding category is the identifier attached to one review problem. The deterministic tier applies textlint, a tool that flags Markdown prose problems, and regular-expression checks, while the model tier uses a blind first-reader judge. `scripts/doc_slop_review.py` now accepts repeatable `--skip-category NAME` flags, where `NAME` is an identifier emitted by the rubric, a deterministic rule, or a model check. Matching findings are suppressed, per-category counts are reported in text and JSON output, and unknown names produce a warning. With no flag, the existing behavior and output remain unchanged.

## Why does the tool need it?

Literature notes with fixed section names, review comments with required verdict sections, and skill instructions with required command-style headings can conflict with the new rule that asks headings to be questions, even when those structures are useful to readers. The requested resolution is to keep those structures and let each caller opt out of only the conflicting category; the general rubric remains intact.

## What can a caller rely on?

A caller can rely on unchanged default output, suppression of only the explicitly named category in both review tiers, complete suppression counts in text and JSON, and a warning for unknown names without changing the review threshold.
