### PR TITLE
feat(skills): subscribe to the split skill repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
           - '@cffnpwr/textlint-rule-no-arbitrary-line-break@1.1.0'
           - textlint-rule-ja-space-between-half-and-full-width@3.0.3
         types: [markdown]
+        # Test fixtures are frozen inputs whose exact bytes are the contract the
+        # tests assert against. Auto-fixing them rewrites the very prose a
+        # fixture exists to hold still.
+        exclude: ^tests/fixtures/

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ setup:
 eval-guidance:
 	uv run --python 3.14.6 --no-project python scripts/agent_guidance_eval.py eval --all --trials 3 --jobs 2 --timeout 600
 
+# Reconciliation throttles `skills update` to once a day so that `make watch`
+# does not fetch on every file save. This forces the update now.
+.PHONY: skills-update
+skills-update:
+	DOTFILES_SKILLS_FORCE_UPDATE=1 bash install/common/skills.sh
+
 #
 # Docker
 #

--- a/home/.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# @file home/.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl
+# @brief Reconcile the shared skills pool on every `chezmoi apply`.
+# @description
+#   Runs at `30` rather than earlier because it depends on
+#   `run_after_20-install-mise-tools` having installed the pinned `skills` CLI
+#   and written the generated `herdr` pool entry. chezmoi orders `after`
+#   scripts by target name, so the numeric prefix is the ordering contract.
+
+{{ if ne (env "CI") "true" -}}
+set -Eeuo pipefail
+
+# shellcheck source=/dev/null
+source "{{ .chezmoi.sourceDir }}/../install/common/skills.sh"
+
+# `gh` backs the git credential helper that authenticates the private skills
+# repository, so the toolchain has to be on PATH before reconciling.
+activate_mise
+reconcile_agent_skills
+{{ end -}}

--- a/home/.chezmoitemplates/chezmoiignore.d/common
+++ b/home/.chezmoitemplates/chezmoiignore.d/common
@@ -9,6 +9,7 @@ plugin.jupyterlab-settings
 .tmux.conf.d/
 .agents/README.md
 .agents/.skill-lock.json
+.agents/skills
 .claude/README.md
 .codex/README.md
 .config/agents

--- a/home/dot_gemini/config/skills.json
+++ b/home/dot_gemini/config/skills.json
@@ -1,0 +1,7 @@
+{
+  "entries": [
+    {
+      "path": "~/.agents/skills"
+    }
+  ]
+}

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -395,6 +395,20 @@ function remove_pool_entry() {
 #   not allowlisted" would delete the generated `herdr` entry and any skill a
 #   different installer owns.
 #
+#   An absent private allowlist unsubscribes its skills, and that is the
+#   intended behaviour rather than an oversight. The file is the declaration:
+#   no declaration means no subscription, which is exactly how a removed public
+#   entry behaves. It is also the posture the public/private split exists for,
+#   since private skill content should not outlive a machine's access to the
+#   private source.
+#
+#   Ordinary applies never hit that path. `run_once_after_01` applies the
+#   private source, and chezmoi orders `after` scripts by target name, so the
+#   file is on disk before `run_after_30` first reconciles. `make watch`
+#   applies only the public source, but by then the file is already there. The
+#   only way to reach this case is for the private source to be gone or to have
+#   failed to apply, and then removal is the correct answer.
+#
 function prune_unlisted_skills() {
     local name
 

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -1,10 +1,29 @@
 #!/usr/bin/env bash
 
 # @file install/common/skills.sh
-# @brief Install upstream agent skills.
+# @brief Reconcile the shared skills pool against a declared allowlist.
 # @description
-#   Activates `mise` when available and installs installer-managed skills with
-#   the pinned `skills` CLI.
+#   Skill content lives in `shunk031/skills` and `shunk031/skills-private`.
+#   These dotfiles subscribe to those repositories rather than carrying the
+#   skills themselves: `SKILLS_ALLOWLIST` declares what should be installed,
+#   and `reconcile_agent_skills` makes `~/.agents/skills` match it on every
+#   `chezmoi apply`.
+#
+#   Reconciliation is install, update, and prune. It is written to be safe to
+#   run on every apply, which means it must be quiet when nothing changed and
+#   must never remove an entry it did not install:
+#
+#   * Install skips names already materialized in the pool, so a steady-state
+#     apply performs no network access.
+#   * Update runs on a 24-hour stamp because `make watch` applies on every file
+#     save. `DOTFILES_SKILLS_FORCE_UPDATE=1` overrides the throttle.
+#   * Prune consults a manifest of what the previous run installed. Without
+#     that manifest it removes nothing, because "everything not in the
+#     allowlist" would delete the private skills and the generated `herdr`
+#     entry.
+#
+#   A failed install is reported and does not abort the apply. Losing one skill
+#   is better than failing the whole apply, and the next reconcile retries.
 
 set -Eeuo pipefail
 
@@ -13,9 +32,105 @@ if [ "${DOTFILES_DEBUG:-}" ]; then
 fi
 
 readonly MISE_BIN="${HOME}/.local/bin/mise"
+readonly SKILLS_POOL="${HOME}/.agents/skills"
+readonly SKILLS_STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/dotfiles"
+# The manifest deliberately lives outside `~/.agents`. That tree is applied
+# with `exact_` semantics, so a state file written inside it would be deleted
+# on the next apply unless it also earned a chezmoiignore entry.
+readonly SKILLS_MANIFEST="${SKILLS_STATE_DIR}/managed-skills"
+readonly SKILLS_UPDATE_STAMP="${SKILLS_STATE_DIR}/skills-update-stamp"
+readonly SKILLS_UPDATE_INTERVAL_SECONDS=86400
+
+# Scope every CLI call to the agents these dotfiles own. This is not cosmetic:
+# an unscoped `skills remove` targets every agent in the CLI's registry, and
+# that registry maps `amp` and `universal` to `~/.config/agents/skills`, which
+# the private dotfiles manage. Codex is a "universal" agent, so its skills are
+# served from `~/.agents/skills` directly and no `~/.codex/skills` is created.
+readonly SKILLS_AGENT_FLAGS=(
+    --agent claude-code
+    --agent codex
+)
+
+# Pool entries written by an installer rather than by the skills CLI. The CLI
+# only links what it installed, so these need their own per-agent links.
+readonly SKILLS_GENERATED_ENTRIES=(
+    herdr
+)
+
+# Agent skills directories that are fed by symlinks into the pool. Codex is
+# absent on purpose: it reads the pool itself.
+readonly SKILLS_LINKED_AGENT_DIRS=(
+    "${HOME}/.claude/skills"
+)
+
+# Declared subscriptions, one skill per line, as `<owner>/<repo>[#<ref>]:<skill>`.
+# Keep sorted by repository, then by skill name.
+readonly SKILLS_ALLOWLIST=(
+    "anthropics/skills:skill-creator"
+    "shunk031/skills:shunk031-ai-slop-checklist-ja"
+    "shunk031/skills:shunk031-cgd-dev-identity"
+    "shunk031/skills:shunk031-codex-worker-prompting"
+    "shunk031/skills:shunk031-doc-slop-review"
+    "shunk031/skills:shunk031-gh-comment-attach-files"
+    "shunk031/skills:shunk031-herdr-tab-status"
+    "shunk031/skills:shunk031-high-impact-journal-publishing"
+    "shunk031/skills:shunk031-humanizer-ja"
+    "shunk031/skills:shunk031-manage-agent-guidance"
+    "shunk031/skills:shunk031-manage-public-private-dotfiles"
+    "shunk031/skills:shunk031-manage-public-private-skills"
+    "shunk031/skills:shunk031-orchestrate-herdr-workers"
+    "shunk031/skills:shunk031-python-uv-workflow"
+    "shunk031/skills:shunk031-research-before-implementation"
+    "shunk031/skills:shunk031-research-report-ja"
+    "shunk031/skills:shunk031-shdoc-shell-docs"
+    "shunk031/skills:shunk031-structured-writing"
+    "shunk031/skills:shunk031-transformers-convert"
+)
+
+# Private subscriptions, applied by the private dotfiles source. Absent on a
+# machine that has only the public source, in which case only public skills are
+# reconciled and nothing else changes.
+readonly SKILLS_PRIVATE_ALLOWLIST="${HOME}/.config/agents/skills-private.allowlist"
 
 #
-# @description Activate `mise` so skills resolve from the configured toolchain.
+# @description Read lines from standard input into a named array.
+# @description
+#   `mapfile` is Bash 4 only and macOS ships Bash 3.2.
+# @arg $1 array_name string The array to replace with the lines read.
+#
+function read_lines_into() {
+    local array_name="$1"
+    local line
+    eval "${array_name}=()"
+    while IFS= read -r line; do
+        [ -n "${line}" ] || continue
+        eval "${array_name}+=(\"\${line}\")"
+    done
+}
+
+#
+# @description Print every declared subscription, public and private.
+# @description
+#   The private entries are read at runtime rather than committed here, because
+#   this repository is public and a private skill's name is disclosure on its
+#   own. A missing file is normal, not an error.
+# @stdout One `<owner>/<repo>[#<ref>]:<skill>` entry per line.
+#
+function declared_subscriptions() {
+    if [ "${#SKILLS_ALLOWLIST[@]}" -gt 0 ]; then
+        printf '%s\n' "${SKILLS_ALLOWLIST[@]}"
+    fi
+    if [ -f "${SKILLS_PRIVATE_ALLOWLIST}" ]; then
+        # Drop whole-line comments and blank lines so the private file can
+        # explain itself. Only a leading `#` starts a comment: an entry may
+        # carry a `#<ref>` suffix pinning a branch or tag, and stripping from
+        # any `#` would silently rewrite such an entry to an unpinned one.
+        sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' -e 's/[[:space:]]//g' "${SKILLS_PRIVATE_ALLOWLIST}"
+    fi
+}
+
+#
+# @description Activate `mise` so the pinned `skills` CLI resolves.
 #
 function activate_mise() {
     if [ -x "${MISE_BIN}" ]; then
@@ -24,22 +139,373 @@ function activate_mise() {
 }
 
 #
-# @description Install upstream skills managed by tool-specific installers.
+# @description Run the pinned `skills` CLI.
+# @arg $@ string Arguments forwarded to the CLI.
 #
-function install_skills() {
-    "${MISE_BIN}" exec -- skills add anthropics/skills \
-        --skill skill-creator \
-        --agent claude-code \
-        --global \
-        --yes
+function skills_cli() {
+    "${MISE_BIN}" exec -- skills "$@"
 }
 
 #
-# @description Run the skills installation workflow.
+# @description Export a GitHub token so the private repository can be cloned.
+# @description
+#   The clone itself authenticates through git's credential helper. This export
+#   only covers hosts where the helper is not configured yet, which is the case
+#   part-way through a first bootstrap. A missing token is not fatal: the
+#   private source simply fails to clone and the failure is reported.
+#
+function export_github_token() {
+    if [ -n "${GH_TOKEN:-}" ]; then
+        return 0
+    fi
+    if ! command -v gh > /dev/null 2>&1; then
+        return 0
+    fi
+    if GH_TOKEN="$(gh auth token 2> /dev/null)" && [ -n "${GH_TOKEN}" ]; then
+        export GH_TOKEN
+    else
+        unset GH_TOKEN
+    fi
+}
+
+#
+# @description Print the source repository of an allowlist entry.
+# @arg $1 entry string An `<owner>/<repo>[#<ref>]:<skill>` entry.
+# @stdout The source repository, including any `#<ref>` suffix.
+#
+function allowlist_entry_source() {
+    printf '%s\n' "${1%:*}"
+}
+
+#
+# @description Print the skill name of an allowlist entry.
+# @arg $1 entry string An `<owner>/<repo>[#<ref>]:<skill>` entry.
+# @stdout The skill name.
+#
+function allowlist_entry_skill() {
+    printf '%s\n' "${1##*:}"
+}
+
+#
+# @description Print every skill name in the allowlist, one per line.
+# @stdout Newline-separated skill names.
+#
+function allowlist_skill_names() {
+    local entry
+
+    # Bash 3.2 with `set -u` aborts on an empty array expansion.
+    local -a subscriptions=()
+    read_lines_into subscriptions < <(declared_subscriptions)
+    if [ "${#subscriptions[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    for entry in "${subscriptions[@]}"; do
+        allowlist_entry_skill "${entry}"
+    done
+}
+
+#
+# @description Test whether a pool entry is written by an installer.
+# @description
+#   Prune must never touch these. Today they cannot reach the manifest, but
+#   that is an accident of how the manifest is built, and this is a `rm -rf`.
+#   The guarantee belongs next to the deletion, not in the caller.
+# @arg $1 name string The pool entry name.
+# @exitcode 0 When the entry is installer-generated.
+# @exitcode 1 When it is not.
+#
+function is_generated_pool_entry() {
+    local name="$1"
+    local generated
+
+    if [ "${#SKILLS_GENERATED_ENTRIES[@]}" -eq 0 ]; then
+        return 1
+    fi
+
+    for generated in "${SKILLS_GENERATED_ENTRIES[@]}"; do
+        if [ "${generated}" = "${name}" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+#
+# @description Test whether a skill name is declared in the allowlist.
+# @arg $1 name string The skill name.
+# @exitcode 0 When the name is declared.
+# @exitcode 1 When it is not.
+#
+function allowlist_contains() {
+    local name="$1"
+    local entry
+
+    local -a subscriptions=()
+    read_lines_into subscriptions < <(declared_subscriptions)
+    if [ "${#subscriptions[@]}" -eq 0 ]; then
+        return 1
+    fi
+
+    for entry in "${subscriptions[@]}"; do
+        if [ "$(allowlist_entry_skill "${entry}")" = "${name}" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+#
+# @description Test whether the CLI has materialized a skill in the pool.
+# @description
+#   A symlink does not count. During the migration a pool entry may still be a
+#   legacy adapter pointing into a chezmoi source tree, and that has to be
+#   replaced by a real installation rather than mistaken for one.
+# @arg $1 name string The skill name.
+# @exitcode 0 When a real directory exists for the skill.
+# @exitcode 1 Otherwise.
+#
+function pool_has_skill() {
+    local entry="${SKILLS_POOL}/$1"
+
+    if [ -L "${entry}" ]; then
+        return 1
+    fi
+
+    [ -d "${entry}" ]
+}
+
+#
+# @description Install every allowlisted skill that is not already in the pool.
+# @description
+#   `skills add` replaces a legacy symlink with a real directory without
+#   following it, so no separate cleanup step is needed. Leaving the symlink in
+#   place until the install succeeds is also what keeps an offline apply
+#   harmless: the old adapter keeps working.
+# @exitcode 0 Always; individual failures are reported and counted.
+#
+function install_missing_skills() {
+    local entry source skill
+    local failures=0
+
+    local -a subscriptions=()
+    read_lines_into subscriptions < <(declared_subscriptions)
+    if [ "${#subscriptions[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    for entry in "${subscriptions[@]}"; do
+        source="$(allowlist_entry_source "${entry}")"
+        skill="$(allowlist_entry_skill "${entry}")"
+
+        if pool_has_skill "${skill}"; then
+            continue
+        fi
+
+        if ! skills_cli add "${source}" \
+            --skill "${skill}" \
+            "${SKILLS_AGENT_FLAGS[@]}" \
+            --global \
+            --yes; then
+            echo "skills: failed to install ${skill} from ${source}" >&2
+            failures=$((failures + 1))
+        fi
+    done
+
+    if [ "${failures}" -gt 0 ]; then
+        echo "skills: ${failures} skill(s) could not be installed; the next apply retries" >&2
+    fi
+}
+
+#
+# @description Test whether the throttled update window has elapsed.
+# @exitcode 0 When an update should run.
+# @exitcode 1 When the previous update is still recent.
+#
+function skills_update_is_due() {
+    local stamp now
+
+    if [ "${DOTFILES_SKILLS_FORCE_UPDATE:-}" = "1" ]; then
+        return 0
+    fi
+
+    if [ ! -f "${SKILLS_UPDATE_STAMP}" ]; then
+        return 0
+    fi
+
+    stamp="$(cat "${SKILLS_UPDATE_STAMP}" 2> /dev/null || true)"
+    case "${stamp}" in
+    '' | *[!0-9]*)
+        # An unreadable or corrupt stamp should not wedge updates forever.
+        return 0
+        ;;
+    esac
+
+    now="$(date +%s)"
+    [ "$((now - stamp))" -ge "${SKILLS_UPDATE_INTERVAL_SECONDS}" ]
+}
+
+#
+# @description Update installed skills at most once per day.
+# @exitcode 0 Always; a failed update is reported and retried later.
+#
+function update_installed_skills() {
+    if ! skills_update_is_due; then
+        return 0
+    fi
+
+    if ! skills_cli update --global --yes; then
+        echo "skills: update failed; the next apply retries" >&2
+        return 0
+    fi
+
+    mkdir -p "${SKILLS_STATE_DIR}"
+    date +%s > "${SKILLS_UPDATE_STAMP}"
+}
+
+#
+# @description Remove a pool entry this script installed.
+# @description
+#   `skills remove` cannot be relied on to clear the canonical directory. It
+#   keeps that directory whenever any other detected agent still resolves to
+#   it, and every "universal" agent resolves to exactly this path, so the
+#   mere presence of `~/.gemini` is enough to make the removal a silent no-op.
+#   A symlink is never removed here: that is a legacy adapter, not ours.
+# @arg $1 name string The skill name.
+#
+function remove_pool_entry() {
+    local entry="${SKILLS_POOL}/$1"
+
+    if [ -L "${entry}" ]; then
+        return 0
+    fi
+
+    if [ -d "${entry}" ]; then
+        rm -rf "${entry}"
+    fi
+}
+
+#
+# @description Remove skills that the previous run installed and the allowlist
+#   no longer declares.
+# @description
+#   Scoped to the manifest on purpose. Pruning "everything in the pool that is
+#   not allowlisted" would delete the generated `herdr` entry and any skill a
+#   different installer owns.
+#
+function prune_unlisted_skills() {
+    local name
+
+    if [ ! -f "${SKILLS_MANIFEST}" ]; then
+        return 0
+    fi
+
+    while IFS= read -r name || [ -n "${name}" ]; do
+        if [ -z "${name}" ] ||
+            allowlist_contains "${name}" ||
+            is_generated_pool_entry "${name}"; then
+            continue
+        fi
+
+        if ! skills_cli remove \
+            --skill "${name}" \
+            "${SKILLS_AGENT_FLAGS[@]}" \
+            --global \
+            --yes; then
+            echo "skills: could not unregister ${name}" >&2
+        fi
+
+        remove_pool_entry "${name}"
+    done < "${SKILLS_MANIFEST}"
+}
+
+#
+# @description Link pool entries that no skills CLI install created.
+# @description
+#   `install/common/herdr.sh` writes `~/.agents/skills/herdr/SKILL.md` straight
+#   into the pool from the installed binary, so the CLI never learns about it
+#   and never links it. A real entry already present in an agent directory is
+#   left alone.
+#
+function link_generated_pool_entries() {
+    local name entry agent_dir target
+
+    if [ "${#SKILLS_GENERATED_ENTRIES[@]}" -eq 0 ] ||
+        [ "${#SKILLS_LINKED_AGENT_DIRS[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    for name in "${SKILLS_GENERATED_ENTRIES[@]}"; do
+        entry="${SKILLS_POOL}/${name}"
+        [ -d "${entry}" ] || continue
+
+        for agent_dir in "${SKILLS_LINKED_AGENT_DIRS[@]}"; do
+            mkdir -p "${agent_dir}"
+            target="${agent_dir}/${name}"
+
+            if [ -e "${target}" ] && [ ! -L "${target}" ]; then
+                echo "skills: ${target} is a real entry, keeping it" >&2
+                continue
+            fi
+
+            ln -sfn "${entry}" "${target}"
+        done
+    done
+}
+
+#
+# @description Record the allowlisted skills that are present in the pool.
+# @description
+#   Only what is actually installed is recorded, so a skill that failed to
+#   install is retried next time instead of being pruned later.
+#
+function write_managed_skills_manifest() {
+    local name temp
+
+    mkdir -p "${SKILLS_STATE_DIR}"
+    temp="$(mktemp "${SKILLS_MANIFEST}.XXXXXX")" || return 1
+
+    while IFS= read -r name; do
+        if pool_has_skill "${name}"; then
+            printf '%s\n' "${name}"
+        fi
+    done < <(allowlist_skill_names) > "${temp}"
+
+    mv "${temp}" "${SKILLS_MANIFEST}"
+}
+
+#
+# @description Make the shared skills pool match the declared allowlist.
+#
+function reconcile_agent_skills() {
+    if [ ! -x "${MISE_BIN}" ]; then
+        echo "skills: ${MISE_BIN} is not executable, skipping reconciliation" >&2
+        return 0
+    fi
+
+    # Refuse to run unscoped. Without `--agent` flags the CLI targets every
+    # agent it knows, including the ones rooted at `~/.config/agents/skills`.
+    if [ "${#SKILLS_AGENT_FLAGS[@]}" -eq 0 ]; then
+        echo "skills: no agents configured, refusing to reconcile" >&2
+        return 1
+    fi
+
+    export_github_token
+    prune_unlisted_skills
+    install_missing_skills
+    update_installed_skills
+    link_generated_pool_entries
+    write_managed_skills_manifest
+}
+
+#
+# @description Run the skills reconciliation workflow.
 #
 function main() {
     activate_mise
-    install_skills
+    reconcile_agent_skills
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -91,6 +91,35 @@ EOF
     [ ! -e "${SKILLS_POOL}/shunk031-retired" ]
 }
 
+@test "[common] prune unsubscribes a private skill once its allowlist is gone" {
+    # Intended, not incidental. The private allowlist is the declaration, so an
+    # absent file means no subscription, exactly as a removed public entry does.
+    # It also keeps private skill content from outliving a machine's access to
+    # the private source. Ordinary applies never reach this: `run_once_after_01`
+    # applies the private source before `run_after_30` first reconciles.
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/private-example"
+    printf '%s\n' private-example > "${SKILLS_MANIFEST}"
+    [ ! -f "${SKILLS_PRIVATE_ALLOWLIST}" ]
+
+    prune_unlisted_skills
+
+    [ ! -e "${SKILLS_POOL}/private-example" ]
+}
+
+@test "[common] prune keeps a private skill while its allowlist declares it" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/private-example"
+    mkdir -p "$(dirname -- "${SKILLS_PRIVATE_ALLOWLIST}")"
+    printf '%s\n' private-example > "${SKILLS_MANIFEST}"
+    printf 'owner/repo:private-example\n' > "${SKILLS_PRIVATE_ALLOWLIST}"
+
+    prune_unlisted_skills
+
+    [ -d "${SKILLS_POOL}/private-example" ]
+    [ ! -f "${MISE_CALLS_PATH}" ]
+}
+
 @test "[common] prune scopes every removal to the owned agents" {
     write_mise_stub
     mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -1,15 +1,18 @@
 #!/usr/bin/env bats
 
 readonly SCRIPT_PATH="./install/common/skills.sh"
-readonly MISE_HELPERS_PATH="./tests/install/common/mise_helpers.bash"
-readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_once_after_04-install-skills.sh.tmpl"
+readonly TMPL_SCRIPT_PATH="./home/.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl"
+readonly CHEZMOIIGNORE_PATH="./home/.chezmoitemplates/chezmoiignore.d/common"
+readonly GEMINI_SKILLS_CONFIG_PATH="./home/dot_gemini/config/skills.json"
 
 function setup() {
     export HOME="${BATS_TEST_TMPDIR}/home"
-    mkdir -p "${HOME}/.local/bin"
+    mkdir -p "${HOME}/.local/bin" "${HOME}/.agents/skills"
+
+    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
+    export MISE_CALLS_PATH
 
     source "${SCRIPT_PATH}"
-    source "${MISE_HELPERS_PATH}"
 }
 
 function teardown() {
@@ -17,108 +20,316 @@ function teardown() {
     export PATH
 }
 
-function write_mise_logger() {
-    cat > "${MISE_BIN}" << 'EOF'
+# @description Install a `mise` stub that records its arguments.
+# @arg $1 exit_code The status the stub exits with; defaults to 0.
+function write_mise_stub() {
+    local exit_code="${1:-0}"
+
+    cat > "${MISE_BIN}" << EOF
 #!/usr/bin/env bash
-printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
+printf '%s\n' "\$*" >> "\${MISE_CALLS_PATH}"
+exit ${exit_code}
 EOF
     chmod +x "${MISE_BIN}"
 }
 
-@test "[common] skills run-once template exists" {
+@test "[common] skills reconcile template exists and runs after the mise tools script" {
     [ -f "${TMPL_SCRIPT_PATH}" ]
+
+    # chezmoi orders `after` scripts by target name, and reconciliation needs
+    # the pinned skills CLI that `run_after_20-install-mise-tools` installs.
+    run bash -c "printf '%s\n' 20-install-mise-tools 30-reconcile-agent-skills | sort | head -n 1"
+    [ "${output}" = "20-install-mise-tools" ]
 }
 
-@test "[common] install_skills succeeds when the named npm runner is stale" {
-    mkdir -p "${BATS_TEST_TMPDIR}/bin"
-    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
-    SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt"
-    export MISE_CALLS_PATH SKILLS_CALLS_PATH
-    write_mise_with_stale_named_runner
+@test "[common] every allowlist entry parses into a source and a skill" {
+    [ "${#SKILLS_ALLOWLIST[@]}" -gt 0 ]
 
-    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" > "${SKILLS_CALLS_PATH}"
-EOF
-    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+    for entry in "${SKILLS_ALLOWLIST[@]}"; do
+        run allowlist_entry_source "${entry}"
+        [ "${status}" -eq 0 ]
+        [[ "${output}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+(#.+)?$ ]]
 
-    PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" run install_skills
-    [ "${status}" -eq 0 ]
-
-    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
-
-    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+        run allowlist_entry_skill "${entry}"
+        [ "${status}" -eq 0 ]
+        [ -n "${output}" ]
+        [[ "${output}" != *:* ]]
+    done
 }
 
-@test "[common] activate_mise evaluates mise activation output" {
-    cat > "${MISE_BIN}" << 'EOF'
-#!/usr/bin/env bash
-if [ "$*" = "activate bash" ]; then
-    printf '%s\n' 'export SKILLS_TEST_MISE_ACTIVATED=1'
-fi
-EOF
-    chmod +x "${MISE_BIN}"
+@test "[common] the allowlist subscribes to both skill repositories" {
+    run allowlist_skill_names
+    [ "${status}" -eq 0 ]
 
-    activate_mise
-
-    [ "${SKILLS_TEST_MISE_ACTIVATED}" = "1" ]
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills:'
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills-private:'
 }
 
-@test "[common] install_skills installs configured upstream skills globally" {
-    MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt"
-    export MISE_CALLS_PATH
-    write_mise_logger
-
-    install_skills
-
-    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
-    [ "${status}" -eq 0 ]
-    [ "${output}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+@test "[common] the allowlist holds no duplicate skill names" {
+    local duplicates
+    duplicates="$(allowlist_skill_names | sort | uniq -d)"
+    [ -z "${duplicates}" ]
 }
 
-@test "[common] skills script runs full installation workflow" {
-    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+@test "[common] prune removes nothing when no manifest exists" {
+    write_mise_stub
+    mkdir -p "${SKILLS_POOL}/shunk031-retired"
 
-    cat > "${MISE_BIN}" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "${MISE_CALLS_PATH}"
-if [ "$*" = "activate bash" ]; then
-    printf '%s\n' 'export SKILLS_TEST_MISE_ACTIVATED=1'
-    printf '%s\n' "export PATH=\"${HOME}/.local/bin:${PATH}\""
-fi
-if [ "$1" = "exec" ]; then
-    [ "${2:-}" = "--" ] || exit 1
-    shift 2
-    "$@"
-fi
-EOF
-    chmod +x "${MISE_BIN}"
+    prune_unlisted_skills
 
-    cat > "${BATS_TEST_TMPDIR}/bin/skills" << 'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "${SKILLS_TEST_MISE_ACTIVATED:-unset}|$*" > "${SKILLS_CALLS_PATH}"
-EOF
-    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+    [ -d "${SKILLS_POOL}/shunk031-retired" ]
+    [ ! -f "${MISE_CALLS_PATH}" ]
+}
 
-    run env \
-        DOTFILES_DEBUG=1 \
-        HOME="${HOME}" \
-        MISE_CALLS_PATH="${BATS_TEST_TMPDIR}/mise_args.txt" \
-        SKILLS_CALLS_PATH="${BATS_TEST_TMPDIR}/skills_args.txt" \
-        PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
-        bash "${SCRIPT_PATH}"
+@test "[common] prune removes a manifest skill the allowlist dropped" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"
+    printf '%s\n' shunk031-retired > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    [ ! -e "${SKILLS_POOL}/shunk031-retired" ]
+}
+
+@test "[common] prune scopes every removal to the owned agents" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"
+    printf '%s\n' shunk031-retired > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "exec -- skills remove --skill shunk031-retired --agent claude-code --agent codex --global --yes" ]
+}
+
+@test "[common] prune never targets the agents rooted at the private config tree" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"
+    printf '%s\n' shunk031-retired > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    # An unscoped `skills remove` walks the CLI's whole agent registry, and
+    # `amp` and `universal` resolve to `~/.config/agents/skills`, which the
+    # private dotfiles own.
+    run grep -c -E -- '--agent (amp|universal)' "${MISE_CALLS_PATH}"
+    [ "${output}" = "0" ]
+}
+
+@test "[common] prune never removes an installer-generated pool entry" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/herdr"
+    printf '%s\n' herdr > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    [ -d "${SKILLS_POOL}/herdr" ]
+    [ ! -f "${MISE_CALLS_PATH}" ]
+}
+
+@test "[common] prune leaves a legacy adapter symlink for chezmoi to own" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${BATS_TEST_TMPDIR}/source/shunk031-retired"
+    ln -s "${BATS_TEST_TMPDIR}/source/shunk031-retired" "${SKILLS_POOL}/shunk031-retired"
+    printf '%s\n' shunk031-retired > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    [ -L "${SKILLS_POOL}/shunk031-retired" ]
+    [ -d "${BATS_TEST_TMPDIR}/source/shunk031-retired" ]
+}
+
+@test "[common] install skips a skill already materialized in the pool" {
+    write_mise_stub
+    mkdir -p "${SKILLS_POOL}/shunk031-humanizer-ja"
+
+    install_missing_skills
+
+    run grep -c -- '--skill shunk031-humanizer-ja ' "${MISE_CALLS_PATH}"
+    [ "${output}" = "0" ]
+}
+
+@test "[common] install replaces a legacy symlink with a real installation" {
+    write_mise_stub
+    mkdir -p "${BATS_TEST_TMPDIR}/source/shunk031-humanizer-ja"
+    ln -s "${BATS_TEST_TMPDIR}/source/shunk031-humanizer-ja" "${SKILLS_POOL}/shunk031-humanizer-ja"
+
+    install_missing_skills
+
+    run grep -c -- 'add shunk031/skills --skill shunk031-humanizer-ja --agent claude-code --agent codex --global --yes' "${MISE_CALLS_PATH}"
+    [ "${output}" = "1" ]
+}
+
+@test "[common] a failing install is reported without aborting the apply" {
+    write_mise_stub 1
+
+    run install_missing_skills
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"could not be installed"* ]]
+}
+
+@test "[common] reconcile succeeds when every network call fails" {
+    write_mise_stub 1
+
+    run reconcile_agent_skills
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] reconcile is skipped when mise is not installed" {
+    rm -f "${MISE_BIN}"
+
+    run reconcile_agent_skills
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"skipping reconciliation"* ]]
+}
+
+@test "[common] generated pool entries are linked into the agent directory" {
+    mkdir -p "${SKILLS_POOL}/herdr"
+
+    link_generated_pool_entries
+
+    [ -L "${HOME}/.claude/skills/herdr" ]
+    [ "$(readlink "${HOME}/.claude/skills/herdr")" = "${SKILLS_POOL}/herdr" ]
+}
+
+@test "[common] a real agent entry is never replaced by a pool link" {
+    mkdir -p "${SKILLS_POOL}/herdr" "${HOME}/.claude/skills/herdr"
+    printf '%s\n' 'installer owned' > "${HOME}/.claude/skills/herdr/SKILL.md"
+
+    run link_generated_pool_entries
     [ "${status}" -eq 0 ]
 
-    run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
-    [ "${status}" -eq 0 ]
-    [ "${lines[0]}" = "activate bash" ]
-    [ "${lines[1]}" = "exec -- skills add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+    [ ! -L "${HOME}/.claude/skills/herdr" ]
+    [ -f "${HOME}/.claude/skills/herdr/SKILL.md" ]
+}
 
-    run cat "${BATS_TEST_TMPDIR}/skills_args.txt"
+@test "[common] the manifest records only skills that are really installed" {
+    mkdir -p "${SKILLS_POOL}/shunk031-humanizer-ja"
+    mkdir -p "${BATS_TEST_TMPDIR}/source/shunk031-doc-slop-review"
+    ln -s "${BATS_TEST_TMPDIR}/source/shunk031-doc-slop-review" "${SKILLS_POOL}/shunk031-doc-slop-review"
+
+    write_managed_skills_manifest
+
+    run grep -c '^shunk031-humanizer-ja$' "${SKILLS_MANIFEST}"
+    [ "${output}" = "1" ]
+    run grep -c '^shunk031-doc-slop-review$' "${SKILLS_MANIFEST}"
+    [ "${output}" = "0" ]
+}
+
+@test "[common] the manifest lives outside the exact_ agents tree" {
+    # `~/.agents` is applied with `exact_` semantics, so state written inside it
+    # would be deleted on the next apply.
+    [[ "${SKILLS_MANIFEST}" != "${HOME}/.agents/"* ]]
+    [[ "${SKILLS_MANIFEST}" == "${HOME}/.local/state/dotfiles/"* ]]
+}
+
+@test "[common] a recent update stamp throttles the update" {
+    mkdir -p "${SKILLS_STATE_DIR}"
+    date +%s > "${SKILLS_UPDATE_STAMP}"
+
+    run skills_update_is_due
+    [ "${status}" -eq 1 ]
+}
+
+@test "[common] a stale update stamp allows the update" {
+    mkdir -p "${SKILLS_STATE_DIR}"
+    printf '%s\n' 1 > "${SKILLS_UPDATE_STAMP}"
+
+    run skills_update_is_due
     [ "${status}" -eq 0 ]
-    [ "${output}" = "1|add anthropics/skills --skill skill-creator --agent claude-code --global --yes" ]
+}
+
+@test "[common] a corrupt update stamp does not wedge updates" {
+    mkdir -p "${SKILLS_STATE_DIR}"
+    printf '%s\n' 'not-a-timestamp' > "${SKILLS_UPDATE_STAMP}"
+
+    run skills_update_is_due
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] the force override beats the throttle" {
+    mkdir -p "${SKILLS_STATE_DIR}"
+    date +%s > "${SKILLS_UPDATE_STAMP}"
+
+    export DOTFILES_SKILLS_FORCE_UPDATE=1
+
+    run skills_update_is_due
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] a successful update refreshes the stamp" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}"
+    printf '%s\n' 1 > "${SKILLS_UPDATE_STAMP}"
+
+    update_installed_skills
+
+    run cat "${SKILLS_UPDATE_STAMP}"
+    [ "${output}" != "1" ]
+}
+
+@test "[common] a failed update leaves the stamp alone so the next apply retries" {
+    write_mise_stub 1
+    mkdir -p "${SKILLS_STATE_DIR}"
+    printf '%s\n' 1 > "${SKILLS_UPDATE_STAMP}"
+
+    run update_installed_skills
+    [ "${status}" -eq 0 ]
+
+    run cat "${SKILLS_UPDATE_STAMP}"
+    [ "${output}" = "1" ]
+}
+
+@test "[common] the shared pool is ignored by chezmoi" {
+    # `home/exact_dot_agents/skills/` still declares a symlink for each migrated
+    # skill. Without this ignore entry chezmoi reasserts those symlinks on every
+    # apply, overwriting the directories the skills CLI installed, and the two
+    # mechanisms flip the same paths back and forth.
+    run grep -Fx '.agents/skills' "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] the skill lock file stays ignored by chezmoi" {
+    # The CLI rewrites it on every add, remove, and update.
+    run grep -Fx '.agents/.skill-lock.json' "${CHEZMOIIGNORE_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] Antigravity reads the shared pool through one config entry" {
+    [ -f "${GEMINI_SKILLS_CONFIG_PATH}" ]
+
+    run grep -F '~/.agents/skills' "${GEMINI_SKILLS_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "the public allowlist names no private skill" {
+    # This repository is public. A private skill's name is disclosure on its
+    # own: it can carry an internal host, an internal service, or an internal
+    # process. Private subscriptions belong in the file the private dotfiles
+    # source applies, never in this one.
+    run grep -c 'skills-private:' "${REPO_ROOT}/install/common/skills.sh"
+    [ "${output}" = "0" ]
+}
+
+@test "a missing private allowlist is not an error" {
+    # A machine with only the public source has no private file, and must
+    # reconcile the public skills normally rather than failing the apply.
+    HOME="${BATS_TEST_TMPDIR}/no-private" run bash -c \
+        "source '${REPO_ROOT}/install/common/skills.sh'; declared_subscriptions | grep -c 'skills-private:' || true"
+    [ "${output}" = "0" ]
+}
+
+@test "a private entry keeps its pinned ref through comment stripping" {
+    # Entries may carry a `#<ref>` suffix pinning a branch or tag. Stripping
+    # from any `#` would rewrite such an entry to an unpinned one and silently
+    # install a different revision than the one declared.
+    local private_dir="${BATS_TEST_TMPDIR}/pinned/.config/agents"
+    mkdir -p "${private_dir}"
+    printf '# a comment\n\nowner/repo#some-branch:pinned-example\n' \
+        > "${private_dir}/skills-private.allowlist"
+
+    HOME="${BATS_TEST_TMPDIR}/pinned" run bash -c \
+        "source '${REPO_ROOT}/install/common/skills.sh'; declared_subscriptions | grep '^owner/repo'"
+    [ "${output}" = "owner/repo#some-branch:pinned-example" ]
 }

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -57,12 +57,12 @@ EOF
     done
 }
 
-@test "[common] the allowlist subscribes to both skill repositories" {
+@test "[common] the allowlist subscribes to the public skill repositories" {
     run allowlist_skill_names
     [ "${status}" -eq 0 ]
 
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills:'
-    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills-private:'
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^anthropics/skills:'
 }
 
 @test "[common] the allowlist holds no duplicate skill names" {
@@ -303,33 +303,45 @@ EOF
     [ "${status}" -eq 0 ]
 }
 
-@test "the public allowlist names no private skill" {
+@test "[common] the public allowlist names no private skill" {
     # This repository is public. A private skill's name is disclosure on its
     # own: it can carry an internal host, an internal service, or an internal
     # process. Private subscriptions belong in the file the private dotfiles
     # source applies, never in this one.
-    run grep -c 'skills-private:' "${REPO_ROOT}/install/common/skills.sh"
+    run grep -c 'skills-private:' "${SCRIPT_PATH}"
     [ "${output}" = "0" ]
 }
 
-@test "a missing private allowlist is not an error" {
+@test "[common] a missing private allowlist is not an error" {
     # A machine with only the public source has no private file, and must
     # reconcile the public skills normally rather than failing the apply.
-    HOME="${BATS_TEST_TMPDIR}/no-private" run bash -c \
-        "source '${REPO_ROOT}/install/common/skills.sh'; declared_subscriptions | grep -c 'skills-private:' || true"
-    [ "${output}" = "0" ]
+    [ ! -f "${SKILLS_PRIVATE_ALLOWLIST}" ]
+
+    run declared_subscriptions
+    [ "${status}" -eq 0 ]
+    [ -n "${output}" ]
 }
 
-@test "a private entry keeps its pinned ref through comment stripping" {
-    # Entries may carry a `#<ref>` suffix pinning a branch or tag. Stripping
-    # from any `#` would rewrite such an entry to an unpinned one and silently
-    # install a different revision than the one declared.
-    local private_dir="${BATS_TEST_TMPDIR}/pinned/.config/agents"
-    mkdir -p "${private_dir}"
-    printf '# a comment\n\nowner/repo#some-branch:pinned-example\n' \
-        > "${private_dir}/skills-private.allowlist"
+@test "[common] private entries join the public ones when the file is applied" {
+    mkdir -p "$(dirname -- "${SKILLS_PRIVATE_ALLOWLIST}")"
+    printf 'owner/repo:private-example\n' > "${SKILLS_PRIVATE_ALLOWLIST}"
 
-    HOME="${BATS_TEST_TMPDIR}/pinned" run bash -c \
-        "source '${REPO_ROOT}/install/common/skills.sh'; declared_subscriptions | grep '^owner/repo'"
-    [ "${output}" = "owner/repo#some-branch:pinned-example" ]
+    run declared_subscriptions
+    [ "${status}" -eq 0 ]
+    printf '%s\n' "${output}" | grep -q '^owner/repo:private-example$'
+    printf '%s\n' "${output}" | grep -q '^shunk031/skills:'
+}
+
+@test "[common] a private entry keeps its pinned ref through comment stripping" {
+    # Entries may carry a `#<ref>` suffix pinning a branch or tag. Stripping
+    # from any `#` would rewrite such an entry to an unpinned one, which still
+    # parses and still installs — just from a revision nobody declared.
+    mkdir -p "$(dirname -- "${SKILLS_PRIVATE_ALLOWLIST}")"
+    printf '# a whole-line comment\n\nowner/repo#some-branch:pinned-example\n' \
+        > "${SKILLS_PRIVATE_ALLOWLIST}"
+
+    run declared_subscriptions
+    [ "${status}" -eq 0 ]
+    printf '%s\n' "${output}" | grep -q '^owner/repo#some-branch:pinned-example$'
+    ! printf '%s\n' "${output}" | grep -q '^#'
 }


### PR DESCRIPTION
Skill content moved to `shunk031/skills` and `shunk031/skills-private`. This adds the subscription side: a declarative allowlist in `install/common/skills.sh`, reconciled on every `chezmoi apply` through the pinned `skills` CLI.

**Additive only.** The in-tree skills, their 32 `symlink_*.tmpl` adapters, and `run_after_90-link-shared-skills.sh.tmpl` all stay and keep working. Removing them is a separate pull request, so a rollback here is one revert.

## The chezmoiignore line is why this is safe to land

`~/.agents/skills` is currently managed only because `home/exact_dot_agents/skills/` holds the per-skill templates. When those go, the source directory vanishes, and the `exact_dot_agents` parent removes unmanaged entries — the whole pool, including the 9 symlinks the *private* dotfiles own and the generated `herdr` entry.

Adding `.agents/skills` to the ignore template prevents that. The same file already ignores `.agents/README.md` and `.agents/.skill-lock.json` for exactly this reason. The lock file entry has to stay too: the CLI rewrites it on every add, remove, and update, and losing it would make the CLI forget everything it installed.

## Reconciliation is scoped, not absolute

Three places where "do the obvious thing" would reach too far:

**Removal passes `--agent claude-code --agent codex`.** Unscoped, `skills remove` targets every agent in the CLI's registry, and that registry maps `amp` and `universal` to `~/.config/agents/skills` — which the private dotfiles apply into.

**Pruning considers only names the previous successful run recorded**, in a manifest under `~/.local/state` rather than in the `exact_` `~/.agents` tree. Pruning "everything not in the allowlist" would delete the private skills and `herdr`. A missing manifest prunes nothing, so a first run cannot over-delete.

**Legacy pool entries are replaced only when allowlisted and currently a symlink.** A real directory is never touched, which is what protects `herdr` and anything hand-installed.

## Private subscriptions are not listed here

This repository is public. A private skill's name is disclosure on its own — the eight of them name internal host families, an internal gateway, and internal tooling — so the allowlist here holds only the public entries.

Private subscriptions live in `~/.config/agents/skills-private.allowlist`, applied by `shunk031/dotfiles-private` ([shunk031/dotfiles-private#175](https://github.com/shunk031/dotfiles-private/pull/175)), which already owns that directory. `declared_subscriptions` reads the applied file and appends its entries to the public list. A machine with only the public source has no such file and reconciles the public skills alone, which is normal rather than an error.

Only a leading `#` is a comment in that file. An entry may carry a `#<ref>` suffix pinning a branch or tag, and stripping from any `#` would quietly rewrite it to an unpinned one.

Two tests pin the boundary: this file names no private skill, and a missing private file reconciles cleanly. A third pins the ref suffix, since installing the wrong revision raises no error.

## Throttling

`make watch` runs `watchexec -- chezmoi apply`, so an unthrottled `skills update` would fetch from GitHub on every file save. It runs at most once a day. `make skills-update` forces it, which is the command to run after merging a skill change.

`skills add` is skipped for names already in the pool, so a steady-state apply performs no network access at all. A clone failure is reported and tolerated: a failed apply is worse than a stale skill, and the next apply retries.

## Two details worth stating

`skill-creator` is in the allowlist. The old `run_once_after_04` installer added it from `anthropics/skills`, and the later change deletes that script, so without an entry it would silently disappear.

Codex is deliberately absent from the per-agent link list. The pinned CLI treats it as a universal agent served from the pool directly and creates no `~/.codex/skills` — verified by installing into a throwaway `HOME`.

## Validation

`shellcheck` and `shfmt --diff` clean. The script is Bash 3.2 compatible: no `mapfile`, no `declare -A`, and every array expansion guarded, since `set -u` treats expanding an empty array as unbound.

The bats tests are **unrun**. This repository forbids running bats locally and CI owns them.

`chezmoi apply` has not been run. What the first apply will do is predicted, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
