### PR TITLE
feat(mise): manage textlint tools

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -57,6 +57,11 @@ sqlite = "3.53.3"
 "npm:pyright" = "1.1.411"
 "npm:skills" = "1.5.20"
 
+# textlint tools
+"npm:@cffnpwr/textlint-rule-no-arbitrary-line-break" = "1.1.0"
+"npm:textlint" = "15.8.0"
+"npm:textlint-rule-ja-space-between-half-and-full-width" = "3.0.3"
+
 [settings]
 idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"


### PR DESCRIPTION
## What Changed

- Added `npm:textlint` to the mise-managed tools.
- Added the two textlint rule packages already referenced by `home/dot_config/textlint/config.json`.
- Kept the textlint packages grouped together under the npm tools section.

## Verification

- `make setup`
- `MISE_CONFIG_FILE="$PWD/home/dot_mise/config.toml" mise config ls | rg -n "textlint|cffnpwr|ja-space|npm:"`
- `MISE_CONFIG_FILE="$PWD/home/dot_mise/config.toml" mise exec -- textlint --version`
- `printf 'これは textlint の検証です。\n' | MISE_CONFIG_FILE="$PWD/home/dot_mise/config.toml" mise exec -- textlint --format json --config home/dot_config/textlint/config.json --stdin --stdin-filename sample.md`
- `git diff --check`
- `MISE_CONFIG_FILE="$PWD/home/dot_mise/config.toml" mise exec -- prek run --files home/dot_mise/config.toml`

Local Bats was not run because this repository forbids local Bats runs.
