### PR TITLE
perf(skills): install each source in one call instead of one per skill

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -187,6 +187,58 @@ function allowlist_entry_skill() {
 }
 
 #
+# @description Print every source a subscription installs from.
+# @description
+#   Deduplicated, because `skills add` clones the repository it is given. One
+#   call per skill re-clones the same repository for every entry it holds.
+# @stdout Newline-separated `<owner>/<repo>[#<ref>]`, sorted and unique.
+#
+function declared_sources() {
+    local entry
+
+    local -a subscriptions=()
+    read_lines_into subscriptions < <(declared_subscriptions)
+    if [ "${#subscriptions[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    for entry in "${subscriptions[@]}"; do
+        allowlist_entry_source "${entry}"
+    done | LC_ALL=C sort -u
+}
+
+#
+# @description Print `--skill <name>` flags for one source's missing skills.
+# @description
+#   `skills add` takes `--skill` repeatably, so a source installs in one call.
+#   A source with nothing missing yields nothing, and the caller skips it, which
+#   is what keeps a steady-state apply off the network.
+# @arg $1 source string An `<owner>/<repo>[#<ref>]`.
+# @stdout Alternating `--skill` and skill-name lines, or nothing.
+#
+function missing_skill_flags() {
+    local source="$1"
+    local entry skill
+
+    local -a subscriptions=()
+    read_lines_into subscriptions < <(declared_subscriptions)
+    if [ "${#subscriptions[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    for entry in "${subscriptions[@]}"; do
+        [ "$(allowlist_entry_source "${entry}")" = "${source}" ] || continue
+
+        skill="$(allowlist_entry_skill "${entry}")"
+        if pool_has_skill "${skill}"; then
+            continue
+        fi
+
+        printf -- '--skill\n%s\n' "${skill}"
+    done
+}
+
+#
 # @description Print every skill name in the allowlist, one per line.
 # @stdout Newline-separated skill names.
 #
@@ -280,6 +332,20 @@ function pool_has_skill() {
 #
 # @description Install every allowlisted skill that is not already in the pool.
 # @description
+#   One call per source, not per skill. `skills add` clones the repository it is
+#   given, so calling it per skill re-clones the same repository for every entry
+#   it holds: 19 clones for 19 public entries, where 2 will do. Measured at 8
+#   seconds for three skills installed separately against 2 seconds for the same
+#   three in one call.
+#
+#   Batching does not coarsen failure. A name the repository does not have is
+#   skipped and the rest still install, with a zero exit; and a clone that fails
+#   outright would have failed for every skill of that source anyway, because
+#   each per-skill call cloned it too.
+#
+#   The same skipping means a typo in the allowlist is silent. The name simply
+#   never arrives, and every apply retries it.
+#
 #   `skills add` replaces a legacy symlink with a real directory without
 #   following it, so no separate cleanup step is needed. Leaving the symlink in
 #   place until the install succeeds is also what keeps an offline apply
@@ -287,35 +353,34 @@ function pool_has_skill() {
 # @exitcode 0 Always; individual failures are reported and counted.
 #
 function install_missing_skills() {
-    local entry source skill
+    local source
     local failures=0
 
-    local -a subscriptions=()
-    read_lines_into subscriptions < <(declared_subscriptions)
-    if [ "${#subscriptions[@]}" -eq 0 ]; then
+    local -a sources=()
+    read_lines_into sources < <(declared_sources)
+    if [ "${#sources[@]}" -eq 0 ]; then
         return 0
     fi
 
-    for entry in "${subscriptions[@]}"; do
-        source="$(allowlist_entry_source "${entry}")"
-        skill="$(allowlist_entry_skill "${entry}")"
-
-        if pool_has_skill "${skill}"; then
+    for source in "${sources[@]}"; do
+        local -a flags=()
+        read_lines_into flags < <(missing_skill_flags "${source}")
+        if [ "${#flags[@]}" -eq 0 ]; then
             continue
         fi
 
         if ! skills_cli add "${source}" \
-            --skill "${skill}" \
+            "${flags[@]}" \
             "${SKILLS_AGENT_FLAGS[@]}" \
             --global \
             --yes; then
-            echo "skills: failed to install ${skill} from ${source}" >&2
+            echo "skills: failed to install from ${source}" >&2
             failures=$((failures + 1))
         fi
     done
 
     if [ "${failures}" -gt 0 ]; then
-        echo "skills: ${failures} skill(s) could not be installed; the next apply retries" >&2
+        echo "skills: ${failures} repository/repositories could not be installed; the next apply retries" >&2
     fi
 }
 

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -186,7 +186,13 @@ EOF
 
     install_missing_skills
 
-    run grep -c -- 'add shunk031/skills --skill shunk031-humanizer-ja --agent claude-code --agent codex --global --yes' "${MISE_CALLS_PATH}"
+    # The name still goes to the CLI: a symlink is not a real installation, so
+    # `pool_has_skill` rejects it and the skill stays in the batch. The call now
+    # carries every missing skill from that source rather than only this one.
+    run grep -c -- '--skill shunk031-humanizer-ja' "${MISE_CALLS_PATH}"
+    [ "${output}" = "1" ]
+
+    run grep -c -- 'add shunk031/skills .*--agent claude-code --agent codex --global --yes' "${MISE_CALLS_PATH}"
     [ "${output}" = "1" ]
 }
 

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -190,6 +190,47 @@ EOF
     [ "${output}" = "1" ]
 }
 
+@test "[common] install issues one call per repository, not per skill" {
+    # `skills add` takes --skill repeatably and clones the repository once per
+    # call, so one call per skill re-clones the same repository for every entry.
+    write_mise_stub
+
+    install_missing_skills
+
+    # Every public entry comes from one of two repositories.
+    run grep -c '^add ' "${MISE_CALLS_PATH}"
+    [ "${output}" -le 2 ]
+
+    run grep -c -- '--skill shunk031-humanizer-ja' "${MISE_CALLS_PATH}"
+    [ "${output}" = "1" ]
+    run grep -c -- '--skill shunk031-structured-writing' "${MISE_CALLS_PATH}"
+    [ "${output}" = "1" ]
+}
+
+@test "[common] a repository is called with only the skills still missing" {
+    write_mise_stub
+    mkdir -p "${SKILLS_POOL}/shunk031-humanizer-ja"
+
+    install_missing_skills
+
+    run grep -c -- '--skill shunk031-humanizer-ja' "${MISE_CALLS_PATH}"
+    [ "${output}" = "0" ]
+    run grep -c -- '--skill shunk031-structured-writing' "${MISE_CALLS_PATH}"
+    [ "${output}" = "1" ]
+}
+
+@test "[common] a repository with nothing missing is not called at all" {
+    write_mise_stub
+    local name
+    while IFS= read -r name; do
+        mkdir -p "${SKILLS_POOL}/${name}"
+    done < <(allowlist_skill_names)
+
+    install_missing_skills
+
+    [ ! -f "${MISE_CALLS_PATH}" ]
+}
+
 @test "[common] a failing install is reported without aborting the apply" {
     write_mise_stub 1
 


### PR DESCRIPTION
`skills add` clones the repository it is given. Calling it once per skill re-cloned the same repository for every entry it held: 19 clones for the 19 public entries, where 2 would do. `--skill` is repeatable, so a source installs in one call.

## Measurement

Against a throwaway `HOME`, installing three skills from `shunk031/skills`:

| | calls | elapsed |
| --- | --- | --- |
| one per skill | 3 | 8s |
| one per source | 1 | 2s |

With a stub recording invocations, reconciling the full allowlist goes from **19 calls to 2**. With a private allowlist applied it is 3. When the pool is already complete it is **0**, which is what keeps a steady-state apply off the network.

## Batching does not coarsen failure

This looks like the obvious cost, and it is not one.

A name the repository does not have is skipped and the rest still install, with a zero exit. Verified by passing a nonexistent name alongside two real ones: both real skills landed, the bad name was ignored, exit 0.

A clone that fails outright would have failed for every skill of that source anyway, because each per-skill call cloned it too. There is no case where the old shape installed more.

That skipping behaviour does mean a typo in the allowlist is silent — the name never arrives and every apply retries it. That is pre-existing, not introduced here, and is now recorded in the function's comment.

## Pinned refs

The `#<ref>` suffix stays part of the source, so `owner/repo:a` and `owner/repo#branch:b` group separately. Merging them would install whichever revision won rather than the one each entry declared.

## Testing

Three bats tests: one call per source, only the skills still missing are passed, and no call at all when nothing is missing.

They are **unrun** — this repository forbids running bats locally and CI owns them. The same logic was exercised directly by sourcing the script against a stub `mise` that records its arguments, which is where the call counts above come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
