### PR TITLE
docs(skills): document Node proxy requirement

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -135,6 +135,11 @@ function activate_mise() {
 
 #
 # @description Run the pinned `skills` CLI.
+# @description
+#   The CLI's GitHub tree check uses Node's `fetch`, which does not use
+#   `HTTP_PROXY` or `HTTPS_PROXY` unless `NODE_USE_ENV_PROXY=1` is set. In a
+#   proxied environment, force a fresh reconciliation with:
+#   `NODE_USE_ENV_PROXY=1 DOTFILES_SKILLS_FORCE_UPDATE=1 chezmoi apply`
 # @arg $@ string Arguments forwarded to the CLI.
 #
 function skills_cli() {


### PR DESCRIPTION
## Why

The `skills` CLI checks GitHub skill trees with Node's `fetch`. In proxied environments, `HTTP_PROXY` and `HTTPS_PROXY` alone are insufficient, so `chezmoi apply` can report fetch failures even when GitHub is reachable through Git and curl.

## What Changed

- Documented the `NODE_USE_ENV_PROXY=1` requirement next to `skills_cli`.
- Recorded the tested command for forcing a fresh reconciliation.

This is documentation-only; runtime behavior is unchanged.

## Validation

Check shell syntax.

```shell
bash -n install/common/skills.sh
```

Check the staged diff for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Run the repository hooks for the changed shell script.

```shell
prek run --files install/common/skills.sh
```

The target environment was also checked: Node's GitHub API request timed out without `NODE_USE_ENV_PROXY=1` and returned successfully with it.

The model-backed document review passed with an isolated temporary Codex home.
