### PR TITLE
fix(skills): keep CLI on activated Node runtime

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -138,7 +138,7 @@ function activate_mise() {
 # @arg $@ string Arguments forwarded to the CLI.
 #
 function skills_cli() {
-    "${MISE_BIN}" exec -- skills "$@"
+    skills "$@"
 }
 
 #

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -20,17 +20,45 @@ function teardown() {
     export PATH
 }
 
-# @description Install a `mise` stub that records its arguments.
+# @description Install `mise` and `skills` stubs that record their arguments.
 # @arg $1 exit_code The status the stub exits with; defaults to 0.
 function write_mise_stub() {
     local exit_code="${1:-0}"
+    local stub_bin="${BATS_TEST_TMPDIR}/bin"
 
     cat > "${MISE_BIN}" << EOF
 #!/usr/bin/env bash
+if [ "\$*" = "activate bash" ]; then
+    printf 'export PATH="%s:\$PATH"\n' "${stub_bin}"
+    exit 0
+fi
 printf '%s\n' "\$*" >> "\${MISE_CALLS_PATH}"
 exit ${exit_code}
 EOF
     chmod +x "${MISE_BIN}"
+
+    mkdir -p "${stub_bin}"
+    cat > "${stub_bin}/skills" << EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\${MISE_CALLS_PATH}"
+exit ${exit_code}
+EOF
+    chmod +x "${stub_bin}/skills"
+    PATH="${stub_bin}:${PATH}"
+    export PATH
+}
+
+@test "[common] skills CLI uses the active tool without re-entering mise" {
+    write_mise_stub
+    PATH="${PATH#"${BATS_TEST_TMPDIR}/bin:"}"
+    export PATH
+
+    activate_mise
+    skills_cli --version
+
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "--version" ]
 }
 
 @test "[common] skills reconcile template exists and runs after the mise tools script" {
@@ -129,7 +157,7 @@ EOF
 
     run cat "${MISE_CALLS_PATH}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "exec -- skills remove --skill shunk031-retired --agent claude-code --agent codex --global --yes" ]
+    [ "${output}" = "remove --skill shunk031-retired --agent claude-code --agent codex --global --yes" ]
 }
 
 @test "[common] prune never targets the agents rooted at the private config tree" {


### PR DESCRIPTION
## Why

`activate_mise` already selects Node 24 in the current shell. Re-entering `mise exec -- skills` reconstructs `PATH`, allowing NVM Node 18 to run a CLI that requires Node >=22.20.0.

## What Changed

Invoke the active `skills` command directly after mise activation, keeping one runtime-resolution boundary. Add a regression test that verifies the CLI is called from the activated environment without re-entering mise.

## Relationship to [#567](https://github.com/shunk031/dotfiles/pull/567)

[#567](https://github.com/shunk031/dotfiles/pull/567) intentionally replaced the stale named `mise exec npm:skills -- skills` runner with `mise exec -- skills`. This PR neither restores that named runner nor bypasses mise: every production entrypoint first performs same-shell `activate_mise` and then calls the activated, pinned `skills` directly. `${MISE_BIN} exec --` remains appropriate for an unactivated one-shot command; it is removed only from this path because every production entrypoint has already performed same-shell `activate_mise`. The current `skills` executable is a shell wrapper whose child `node` lookup sees the child `PATH` reconstructed by a second `mise exec` boundary, which can reselect NVM Node 18; direct invocation after activation preserves Node 24.

## Validation

Runtime reproduction passed: with Node 18 placed first on `PATH`, `activate_mise` selected Node `v24.18.0` and `skills 1.5.20`.

Adversarial checks passed: an inherited polluted environment reproduced the failure only for nested execution; a fresh noninteractive shell started on Node 18, then activation selected Node `v24.18.0` and `skills 1.5.20`. `MISE_ACTIVATE_AGGRESSIVE` is rejected because official documentation scopes it to activation ordering, and there is no explicit `mise exec` test contract for this child `node` resolution.

Check shell formatting.

```shell
shfmt --indent 4 --space-redirects --diff install/common/skills.sh tests/install/common/skills.bats
```

Check the installer script with ShellCheck.

```shell
shellcheck install/common/skills.sh
```

Check the installer script syntax.

```shell
bash -n install/common/skills.sh
```

Check the change for whitespace errors.

```shell
git diff --check
```

Local Bats was deliberately not run under the repository policy; GitHub Actions will run the hosted suite.
