### PR TITLE
feat(skills): subscribe to natural-japanese

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -335,9 +335,8 @@ function pool_has_skill() {
 # @description
 #   One call per source, not per skill. `skills add` clones the repository it is
 #   given, so calling it per skill re-clones the same repository for every entry
-#   it holds: 19 clones for 19 public entries, where 2 will do. Measured at 8
-#   seconds for three skills installed separately against 2 seconds for the same
-#   three in one call.
+#   it holds. Batching each source's skills into one call avoids that duplicate
+#   cloning while preserving the source-level failure boundary.
 #
 #   Batching does not coarsen failure. A name the repository does not have is
 #   skipped and the rest still install, with a zero exit; and a clone that fails

--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -67,6 +67,7 @@ readonly SKILLS_LINKED_AGENT_DIRS=(
 # Keep sorted by repository, then by skill name.
 readonly SKILLS_ALLOWLIST=(
     "anthropics/skills:skill-creator"
+    "coji/natural-japanese:natural-japanese"
     "shunk031/skills:shunk031-cgd-dev-identity"
     "shunk031/skills:shunk031-codex-worker-prompting"
     "shunk031/skills:shunk031-gh-comment-attach-files"

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -231,9 +231,12 @@ EOF
 
     install_missing_skills
 
-    # Every public entry comes from one of two repositories.
+    # Each distinct source should be cloned exactly once, with all of its
+    # missing skills batched into that call.
+    local expected_calls
+    expected_calls="$(declared_sources | awk 'NF { count++ } END { print count + 0 }')"
     run grep -c '^add ' "${MISE_CALLS_PATH}"
-    [ "${output}" -le 2 ]
+    [ "${output}" -eq "${expected_calls}" ]
 
     run grep -c -- '--skill shunk031-cgd-dev-identity' "${MISE_CALLS_PATH}"
     [ "${output}" = "1" ]


### PR DESCRIPTION
## Summary

- Subscribe the public skills reconciler to `coji/natural-japanese`.
- Keep the installed skill available through the normal `chezmoi apply` setup path.

## Validation

- `make setup`
- `shellcheck install/common/skills.sh`
- `shfmt --indent 4 --space-redirects --diff install/common/skills.sh`
- `bash -n install/common/skills.sh`
- `git diff --check`
- Allowlist contract check
- Bats not run, per repository policy
