### PR TITLE
feat(skills): subscribe to cursor unslop

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -68,6 +68,7 @@ readonly SKILLS_LINKED_AGENT_DIRS=(
 readonly SKILLS_ALLOWLIST=(
     "anthropics/skills:skill-creator"
     "coji/natural-japanese:natural-japanese"
+    "cursor/plugins:unslop"
     "shunk031/skills:shunk031-cgd-dev-identity"
     "shunk031/skills:shunk031-codex-worker-prompting"
     "shunk031/skills:shunk031-gh-comment-attach-files"

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -91,6 +91,7 @@ EOF
 
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills:'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^anthropics/skills:'
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^cursor/plugins:unslop$'
 }
 
 @test "[common] the allowlist holds no duplicate skill names" {


### PR DESCRIPTION
## Summary

- Subscribe the existing skill reconciler to `cursor/plugins:unslop`.
- Assert the subscription in the allowlist test.

The setup uses the mise-pinned `skills` CLI through `install/common/skills.sh`, which is equivalent to the requested `npx skills add ... --skill unslop` flow while preserving this repository's global reconciliation and agent scoping.

## Validation

- `bash -n install/common/skills.sh tests/install/common/skills.bats`
- `shellcheck install/common/skills.sh`
- Static allowlist uniqueness and placement checks
- `git diff --check`
- Bats was not run locally because the repository policy requires GitHub Actions for Bats.
- `prek --files install/common/skills.sh tests/install/common/skills.bats` found no matching hooks; this was not counted as a passing validation.
