### PR TITLE
fix(claude): disable auto memory

### DIFF
--- a/home/dot_config/claude/settings.json
+++ b/home/dot_config/claude/settings.json
@@ -1,6 +1,7 @@
 {
   "model": "opusplan",
   "alwaysThinkingEnabled": true,
+  "autoMemoryEnabled": false,
   "disableClaudeAiConnectors": true,
   "env": {
     "DISABLE_AUTOUPDATER": "1",


### PR DESCRIPTION
## Summary

- Disable Claude Code built-in auto-memory with `autoMemoryEnabled: false`.
- Leave existing plugin settings unchanged.

## Validation

- `jq -e '.autoMemoryEnabled == false' home/dot_config/claude/settings.json`
- `git diff --check`
