### PR TITLE
feat(skills): subscribe to grill-me

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -69,6 +69,8 @@ readonly SKILLS_ALLOWLIST=(
     "anthropics/skills:skill-creator"
     "coji/natural-japanese:natural-japanese"
     "cursor/plugins:unslop"
+    "mattpocock/skills:grill-me"
+    "mattpocock/skills:grilling"
     "shunk031/skills:shunk031-cgd-dev-identity"
     "shunk031/skills:shunk031-codex-worker-prompting"
     "shunk031/skills:shunk031-gh-comment-attach-files"

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -92,6 +92,8 @@ EOF
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills:'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^anthropics/skills:'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^cursor/plugins:unslop$'
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^mattpocock/skills:grill-me$'
+    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^mattpocock/skills:grilling$'
 }
 
 @test "[common] the allowlist holds no duplicate skill names" {


### PR DESCRIPTION
## Why

The public skill allowlist needs both `mattpocock/skills:grill-me` and `mattpocock/skills:grilling`. `grill-me` is only the explicit entrypoint and invokes `grilling`, so installing both is required for the workflow to function.

## What changed

- Added `grill-me` and `grilling` to the public skill allowlist.
- Added allowlist contract assertions for both skill names.
- Kept the existing reconciliation path unchanged. It batches both `--skill` flags for `mattpocock/skills` into one clone, so this change adds no setup path or special-case logic.

This PR changes only the public dotfiles repository. The private repository has no matching subscription and was not modified.

## Validation

Set up the worktree dependencies and hooks.

```shell
make setup
```

Check shell syntax in the installer and its Bats contract tests.

```shell
bash -n install/common/skills.sh tests/install/common/skills.bats
```

Check the installer with ShellCheck.

```shell
shellcheck install/common/skills.sh
```

Check the installer formatting.

```shell
shfmt --indent 4 --space-redirects --diff install/common/skills.sh
```

The static allowlist/source batching contract check passed. Test-first verification confirmed that the new contract check failed before the allowlist entries were added and passed afterward.

Check the patch for whitespace errors.

```shell
git diff --check
```

Bats was not run locally, per repository policy. GitHub Actions provides the Bats validation.
