### PR TITLE
fix(skills): prune renamed skill copies

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -57,6 +57,15 @@ readonly SKILLS_GENERATED_ENTRIES=(
     herdr
 )
 
+readonly SKILLS_RETIRED_NAMES=(
+    shunk031-cgd-dev-identity
+    shunk031-gh-comment-attach-files
+    shunk031-high-impact-journal-publishing
+    shunk031-orchestrate-herdr-workers
+    shunk031-shdoc-shell-docs
+    shunk031-transformers-convert
+)
+
 # Agent skills directories that are fed by symlinks into the pool. Codex is
 # absent on purpose: it reads the pool itself.
 readonly SKILLS_LINKED_AGENT_DIRS=(
@@ -455,11 +464,36 @@ function remove_pool_entry() {
 }
 
 #
+# @description Print managed skill names that may need pruning.
+# @description
+#   The manifest normally identifies removed subscriptions. Retired names are
+#   also included while their old pool directory remains, because an earlier
+#   reconciliation may already have replaced the manifest with the new name.
+# @stdout Newline-separated skill names, sorted and unique.
+#
+function prune_candidate_names() {
+    local name
+
+    {
+        if [ -f "${SKILLS_MANIFEST}" ]; then
+            cat "${SKILLS_MANIFEST}"
+        fi
+
+        for name in "${SKILLS_RETIRED_NAMES[@]}"; do
+            if pool_has_skill "${name}"; then
+                printf '%s\n' "${name}"
+            fi
+        done
+    } | LC_ALL=C sort -u
+}
+
+#
 # @description Remove skills that the previous run installed and the allowlist
 #   no longer declares.
 # @description
-#   Scoped to the manifest on purpose. Pruning "everything in the pool that is
-#   not allowlisted" would delete the generated `herdr` entry and any skill a
+#   Candidates are limited to the previous manifest and the explicit retired
+#   name migration list. Pruning "everything in the pool that is not
+#   allowlisted" would delete the generated `herdr` entry and any skill a
 #   different installer owns.
 #
 #   An absent private allowlist unsubscribes its skills, and that is the
@@ -479,10 +513,6 @@ function remove_pool_entry() {
 function prune_unlisted_skills() {
     local name
 
-    if [ ! -f "${SKILLS_MANIFEST}" ]; then
-        return 0
-    fi
-
     while IFS= read -r name || [ -n "${name}" ]; do
         if [ -z "${name}" ] ||
             allowlist_contains "${name}" ||
@@ -499,7 +529,7 @@ function prune_unlisted_skills() {
         fi
 
         remove_pool_entry "${name}"
-    done < "${SKILLS_MANIFEST}"
+    done < <(prune_candidate_names)
 }
 
 #

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -102,6 +102,15 @@ EOF
     [ -z "${duplicates}" ]
 }
 
+@test "[common] retired skill names do not remain subscribed" {
+    local name
+
+    for name in "${SKILLS_RETIRED_NAMES[@]}"; do
+        run allowlist_contains "${name}"
+        [ "${status}" -eq 1 ]
+    done
+}
+
 @test "[common] prune removes nothing when no manifest exists" {
     write_mise_stub
     mkdir -p "${SKILLS_POOL}/shunk031-retired"
@@ -110,6 +119,19 @@ EOF
 
     [ -d "${SKILLS_POOL}/shunk031-retired" ]
     [ ! -f "${MISE_CALLS_PATH}" ]
+}
+
+@test "[common] prune removes a renamed skill after the manifest records only its replacement" {
+    write_mise_stub
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-gh-comment-attach-files"
+    printf '%s\n' shunk031-github-comment-attach-files > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    [ ! -e "${SKILLS_POOL}/shunk031-gh-comment-attach-files" ]
+    run cat "${MISE_CALLS_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "remove --skill shunk031-gh-comment-attach-files --agent claude-code --agent codex --global --yes" ]
 }
 
 @test "[common] prune removes a manifest skill the allowlist dropped" {


### PR DESCRIPTION
## Why

[PR #683](https://github.com/shunk031/dotfiles/pull/683) renamed six skill subscriptions. Its manifest had already rolled forward to the replacement names while old global pool entries remained. The pinned skills CLI v1.5.20 intentionally skips upstream deletions when `skills update --global --yes` runs, so those retired entries need an explicit migration path.

## What Changed

Add the six old names to an explicit retired-name list. Pruning now considers the previous managed-skills manifest plus that list when a matching old pool directory exists, then reuses the existing scoped `skills remove` call for Claude Code and Codex only.

The code does not scan and prune arbitrary pool entries. It does not touch private skills or skills managed by another installer. The regression test models a manifest that already records `shunk031-github-comment-attach-files` while `shunk031-gh-comment-attach-files` still exists in the pool.

## Validation

Set up the worktree dependencies.

```shell
make setup
```

Run prek against the changed installer and its test.

```shell
prek run --files install/common/skills.sh tests/install/common/skills.bats
```

Check the changed files for whitespace errors.

```shell
git diff --check
```

Check the installer script syntax.

```shell
bash -n install/common/skills.sh
```

Check shell formatting.

```shell
make format
```

Run two isolated shell behavior checks: one confirms a rolled-forward manifest prunes only the retired name, and one confirms a missing manifest preserves an unrelated unmanaged pool entry.

The Bats suite was not run locally per `AGENTS.md`; GitHub Actions is authoritative.
