### PR TITLE
feat(gates): route guidance hooks through an override-aware wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,15 @@ repos:
       # rejects, so these two hooks are scoped to `skills/` only.
       - id: shuhari-validate-instructions
         name: validate the user guidance eval schema
-        entry: bash -c 'MISE_CONFIG_FILE=home/dot_mise/config.toml mise exec -- shuhari eval instructions home/dot_config/exact_agents/AGENTS.md --evals home/dot_config/exact_agents/AGENTS.evals.json --validate-only'
+        entry: scripts/shuhari_guidance_gate.sh validate
         language: system
         pass_filenames: false
         files: ^home/dot_config/exact_agents/(AGENTS\.md|AGENTS\.evals\.json)$
 
-      # Live model calls, two arms per case. Skip with
-      # `SKIP=shuhari-eval-instructions` when iterating on wording.
+      # Live model calls, two arms per case.
       - id: shuhari-eval-instructions
         name: evaluate changed user guidance
-        entry: bash -c 'MISE_CONFIG_FILE=home/dot_mise/config.toml mise exec -- shuhari eval instructions home/dot_config/exact_agents/AGENTS.md --evals home/dot_config/exact_agents/AGENTS.evals.json --trials 3 --jobs 2 --timeout 600'
+        entry: scripts/shuhari_guidance_gate.sh eval
         language: system
         pass_filenames: false
         require_serial: true

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,7 @@ setup:
 
 .PHONY: eval-guidance
 eval-guidance:
-	MISE_CONFIG_FILE="$(CURDIR)/home/dot_mise/config.toml" mise exec -- \
-	    shuhari eval instructions home/dot_config/exact_agents/AGENTS.md \
-	    --evals home/dot_config/exact_agents/AGENTS.evals.json \
-	    --trials 3 --jobs 2 --timeout 600
+	./scripts/shuhari_guidance_gate.sh eval
 
 # Reconciliation throttles `skills update` to once a day so that `make watch`
 # does not fetch on every file save. This forces the update now.

--- a/scripts/shuhari_guidance_gate.sh
+++ b/scripts/shuhari_guidance_gate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# @file scripts/shuhari_guidance_gate.sh
+# @brief Run the shared guidance gate with this repository's pinned policy.
+# @description
+#   The two guidance hooks and `make eval-guidance` used to carry their own
+#   copy of the same Shuhari invocation, with every flag written inline. That
+#   left no place to describe the machine a run happens on, so a host whose
+#   kernel refuses Shuhari's default isolated sandbox could not run the gate at
+#   all, and a guidance edit there could only be committed by skipping it.
+#
+#   This wrapper owns target selection and policy; Shuhari owns the evaluation
+#   mechanism, per the Shuhari development architecture contract.
+#
+#   The execution environment can be adjusted with `SHUHARI_SANDBOX` and
+#   `SHUHARI_AGENT_EXECUTABLE`. Each adds its corresponding flag, and an
+#   `unsandboxed` sandbox also adds `--network`, as Shuhari requires. Leaving
+#   both unset preserves the argv the inline entries used byte for byte.
+#
+#   Schema validation is exempt from both. It parses files, starts no agent and
+#   enters no sandbox, and Shuhari reads `SHUHARI_SANDBOX` from the environment
+#   on its own, so an exported `unsandboxed` would fail a `--validate-only` run
+#   over an execution environment that run never establishes.
+#
+#   These are environment-shaped overrides only. Trials, jobs, and the timeout
+#   define measurement and remain pinned below; they are not overridable.
+# @arg $1 mode One of `validate` or `eval`.
+# @exitcode 0 The gate passed.
+# @exitcode 1 The gate failed.
+# @exitcode 2 Invalid usage.
+# @example
+#   scripts/shuhari_guidance_gate.sh validate
+#   SHUHARI_SANDBOX=unsandboxed scripts/shuhari_guidance_gate.sh eval
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+
+# Repository-relative so the argv stays readable in hook output and identical
+# on every machine.
+readonly MISE_CONFIG="home/dot_mise/config.toml"
+readonly GUIDANCE="home/dot_config/exact_agents/AGENTS.md"
+readonly GUIDANCE_EVALS="home/dot_config/exact_agents/AGENTS.evals.json"
+
+# Policy values owned by this repository rather than by Shuhari. Two arms per
+# case at three trials is what makes a guidance verdict trustworthy, so these
+# stay out of reach of the environment.
+readonly TRIALS=3
+readonly JOBS=2
+readonly TIMEOUT=600
+
+# @description Read lines from standard input into a named array.
+# @description
+#   `mapfile` is Bash 4 only, and macOS ships Bash 3.2. This keeps the script
+#   runnable with the system shell.
+# @arg $1 array_name The array to replace with the lines read.
+function read_lines_into() {
+    local array_name="$1"
+    local line
+    eval "${array_name}=()"
+    while IFS= read -r line; do
+        [ -n "${line}" ] || continue
+        eval "${array_name}+=(\"\${line}\")"
+    done
+}
+
+# @description Print flags for execution-environment overrides.
+# @stdout Alternating flag names and values, with `--network` for an
+#   `unsandboxed` sandbox.
+function declared_environment_flags() {
+    if [ -n "${SHUHARI_SANDBOX:-}" ]; then
+        printf -- '--sandbox\n%s\n' "${SHUHARI_SANDBOX}"
+        if [ "${SHUHARI_SANDBOX}" = unsandboxed ]; then
+            printf '%s\n' '--network'
+        fi
+    fi
+
+    if [ -n "${SHUHARI_AGENT_EXECUTABLE:-}" ]; then
+        printf -- '--agent-executable\n%s\n' "${SHUHARI_AGENT_EXECUTABLE}"
+    fi
+}
+
+# @description Validate the guidance eval schema without invoking an agent.
+# @description
+#   Stripped of the execution-environment variables Shuhari reads directly, for
+#   the reason given in this file's description.
+# @exitcode 1 When the schema is invalid.
+function run_validate() {
+    env -u SHUHARI_SANDBOX -u SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY \
+        MISE_CONFIG_FILE="${MISE_CONFIG}" mise exec -- \
+        shuhari eval instructions "${GUIDANCE}" \
+        --evals "${GUIDANCE_EVALS}" \
+        --validate-only
+}
+
+# @description Evaluate the shared guidance with and without the instructions.
+# @exitcode 1 When the evaluation fails.
+function run_eval() {
+    local -a environment_flags=()
+    read_lines_into environment_flags < <(declared_environment_flags)
+
+    # Bash 3.2 treats expanding an empty array as an unbound variable under
+    # `set -u`, so the expansion is guarded.
+    MISE_CONFIG_FILE="${MISE_CONFIG}" mise exec -- \
+        shuhari eval instructions "${GUIDANCE}" \
+        --evals "${GUIDANCE_EVALS}" \
+        ${environment_flags[@]+"${environment_flags[@]}"} \
+        --trials "${TRIALS}" --jobs "${JOBS}" --timeout "${TIMEOUT}"
+}
+
+# @description Dispatch the requested gate.
+# @arg $1 mode One of `validate` or `eval`.
+function main() {
+    local mode="${1:-}"
+
+    case "${mode}" in
+    validate | eval) ;;
+    *)
+        printf 'Usage: %s {validate|eval}\n' "$0" >&2
+        exit 2
+        ;;
+    esac
+
+    # Every path above is repository-relative, including the one mise resolves
+    # its configuration from.
+    cd -- "${REPO_ROOT}"
+    "run_${mode}"
+}
+
+main "$@"

--- a/tests/fixtures/agent_guidance_requirements.json
+++ b/tests/fixtures/agent_guidance_requirements.json
@@ -24,6 +24,7 @@
     "guidance_eval": "home/dot_config/exact_agents/AGENTS.evals.json",
     "wiring_only_paths": [],
     "runner": "shuhari eval instructions",
+    "wrapper": "scripts/shuhari_guidance_gate.sh",
     "validate_hook": "shuhari-validate-instructions",
     "eval_hook": "shuhari-eval-instructions",
     "skip_variable": "SKIP=shuhari-eval-instructions"

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -11,6 +11,7 @@ readonly LEGACY_GH_FIRST_SKILL_PATH="./home/dot_config/exact_agents/skills/gh-fi
 readonly AGENT_GUIDANCE_REQUIREMENTS_PATH="./tests/fixtures/agent_guidance_requirements.json"
 readonly AGENT_GUIDANCE_REQUIREMENTS_TEST_PATH="./tests/python/test_agent_guidance_requirements.py"
 readonly GUIDANCE_EVAL_SCRIPT="./scripts/agent_guidance_eval.py"
+readonly GUIDANCE_GATE_SCRIPT="./scripts/shuhari_guidance_gate.sh"
 readonly PREK_CONFIG_PATH="./.pre-commit-config.yaml"
 readonly SKILL_CREATOR_SHARED_SKILL_PATH="./home/dot_config/exact_agents/skills/skill-creator"
 readonly SKILL_CREATOR_SYMLINK_TEMPLATE="./home/exact_dot_agents/skills/symlink_skill-creator.tmpl"
@@ -434,6 +435,19 @@ readonly GITIGNORE_PATH="./.gitignore"
     [ "${status}" -eq 0 ]
     run grep -F 'pass_filenames: false' "${PREK_CONFIG_PATH}"
     [ "${status}" -eq 0 ]
+
+    # Both hooks reach Shuhari through the wrapper, which is where the
+    # execution environment can be described. An inline entry could not be
+    # told which sandbox a machine can actually provide.
+    run grep -Fc "entry: ${GUIDANCE_GATE_SCRIPT#./} " "${PREK_CONFIG_PATH}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2" ]
+    [ -x "${GUIDANCE_GATE_SCRIPT}" ]
+
+    # Skipping a gate ships unmeasured guidance, so nothing here advertises the
+    # escape hatch.
+    run grep -F 'SKIP=shuhari-eval-instructions' "${PREK_CONFIG_PATH}"
+    [ "${status}" -ne 0 ]
     run grep -F '"aqua:j178/prek" = "0.4.11"' ./home/dot_mise/config.toml
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/common/shuhari_guidance_gate.bats
+++ b/tests/install/common/shuhari_guidance_gate.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+
+# The wrapper reaches Shuhari through `mise exec`, so these tests answer that
+# call with a stub that records the argv it was handed and the two
+# execution-environment variables Shuhari would otherwise read on its own.
+# Nothing here starts an agent or makes a model call.
+
+readonly WRAPPER="./scripts/shuhari_guidance_gate.sh"
+readonly GUIDANCE="home/dot_config/exact_agents/AGENTS.md"
+readonly GUIDANCE_EVALS="home/dot_config/exact_agents/AGENTS.evals.json"
+
+setup() {
+    local stub_bin="${BATS_TEST_TMPDIR}/bin"
+    mkdir -p "${stub_bin}"
+
+    SHUHARI_ARGV_LOG="${BATS_TEST_TMPDIR}/shuhari-argv"
+    SHUHARI_ENV_LOG="${BATS_TEST_TMPDIR}/shuhari-env"
+    export SHUHARI_ARGV_LOG SHUHARI_ENV_LOG
+
+    cat > "${stub_bin}/mise" << 'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "exec" ] && [ "${2:-}" = "--" ]; then
+    shift 2
+    printf '%s\n' "$@" > "${SHUHARI_ARGV_LOG}"
+    {
+        printf 'MISE_CONFIG_FILE=%s\n' "${MISE_CONFIG_FILE-<unset>}"
+        printf 'SHUHARI_SANDBOX=%s\n' "${SHUHARI_SANDBOX-<unset>}"
+        printf 'SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY=%s\n' \
+            "${SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY-<unset>}"
+    } > "${SHUHARI_ENV_LOG}"
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "${stub_bin}/mise"
+    PATH="${stub_bin}:${PATH}"
+    export PATH
+}
+
+# @description Run the wrapper with every override variable removed.
+function run_without_overrides() {
+    run env -u SHUHARI_SANDBOX -u SHUHARI_AGENT_EXECUTABLE \
+        -u SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY "${WRAPPER}" "$@"
+}
+
+@test "[common] guidance gate wrapper is executable" {
+    [ -x "${WRAPPER}" ]
+}
+
+@test "[common] unset overrides preserve the eval argv" {
+    local expected="${BATS_TEST_TMPDIR}/expected"
+    printf '%s\n' \
+        shuhari \
+        eval \
+        instructions \
+        "${GUIDANCE}" \
+        --evals \
+        "${GUIDANCE_EVALS}" \
+        --trials \
+        3 \
+        --jobs \
+        2 \
+        --timeout \
+        600 > "${expected}"
+
+    run_without_overrides eval
+    [ "${status}" -eq 0 ]
+
+    run diff -u "${expected}" "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] unset overrides preserve the validate argv" {
+    local expected="${BATS_TEST_TMPDIR}/expected"
+    printf '%s\n' \
+        shuhari \
+        eval \
+        instructions \
+        "${GUIDANCE}" \
+        --evals \
+        "${GUIDANCE_EVALS}" \
+        --validate-only > "${expected}"
+
+    run_without_overrides validate
+    [ "${status}" -eq 0 ]
+
+    run diff -u "${expected}" "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] both modes pin the mise configuration file" {
+    run_without_overrides validate
+    [ "${status}" -eq 0 ]
+    run grep -Fx 'MISE_CONFIG_FILE=home/dot_mise/config.toml' "${SHUHARI_ENV_LOG}"
+    [ "${status}" -eq 0 ]
+
+    run_without_overrides eval
+    [ "${status}" -eq 0 ]
+    run grep -Fx 'MISE_CONFIG_FILE=home/dot_mise/config.toml' "${SHUHARI_ENV_LOG}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] an unsandboxed sandbox adds the network flag" {
+    run env SHUHARI_SANDBOX=unsandboxed "${WRAPPER}" eval
+    [ "${status}" -eq 0 ]
+
+    run grep -cFx -- '--sandbox' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+    run grep -cFx -- 'unsandboxed' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+    run grep -cFx -- '--network' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+}
+
+@test "[common] a sandboxed level is passed through without the network flag" {
+    run env SHUHARI_SANDBOX=read-only "${WRAPPER}" eval
+    [ "${status}" -eq 0 ]
+
+    run grep -cFx -- 'read-only' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+    run grep -Fx -- '--network' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "[common] an agent executable override reaches the eval run" {
+    run env SHUHARI_AGENT_EXECUTABLE=/usr/local/bin/codex-wrapper \
+        "${WRAPPER}" eval
+    [ "${status}" -eq 0 ]
+
+    run grep -cFx -- '--agent-executable' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+    run grep -cFx -- '/usr/local/bin/codex-wrapper' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" -eq 1 ]
+}
+
+@test "[common] validation is exempt from execution-environment overrides" {
+    # Schema validation starts no agent and enters no sandbox, and Shuhari
+    # reads these two variables from the environment itself, so an exported
+    # `unsandboxed` would fail an offline parse over a sandbox it never enters.
+    run env SHUHARI_SANDBOX=unsandboxed \
+        SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY=1 \
+        SHUHARI_AGENT_EXECUTABLE=/usr/local/bin/codex-wrapper \
+        "${WRAPPER}" validate
+    [ "${status}" -eq 0 ]
+
+    run grep -Fx 'SHUHARI_SANDBOX=<unset>' "${SHUHARI_ENV_LOG}"
+    [ "${status}" -eq 0 ]
+    run grep -Fx 'SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY=<unset>' \
+        "${SHUHARI_ENV_LOG}"
+    [ "${status}" -eq 0 ]
+
+    run grep -Fx -- '--sandbox' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -ne 0 ]
+    run grep -Fx -- '--agent-executable' "${SHUHARI_ARGV_LOG}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "[common] the eval run keeps the sandbox variable Shuhari reads" {
+    # The exemption is scoped to validation. An eval run has an execution
+    # environment, so Shuhari must still see what it was told to use.
+    run env SHUHARI_SANDBOX=unsandboxed "${WRAPPER}" eval
+    [ "${status}" -eq 0 ]
+
+    run grep -Fx 'SHUHARI_SANDBOX=unsandboxed' "${SHUHARI_ENV_LOG}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[common] an unknown mode fails with usage" {
+    run "${WRAPPER}" trigger
+    [ "${status}" -eq 2 ]
+    [[ "${output}" == *"Usage:"* ]]
+
+    run "${WRAPPER}"
+    [ "${status}" -eq 2 ]
+}

--- a/tests/python/test_agent_guidance_requirements.py
+++ b/tests/python/test_agent_guidance_requirements.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import unittest
@@ -269,24 +270,39 @@ class AgentGuidanceRequirementsTest(unittest.TestCase):
 
         # An id proves a hook is listed, not that it runs anything. Both
         # entries could be replaced with `true` and the ids would still be
-        # there, so check what each one actually invokes.
+        # there, so check what each one actually invokes. Both entries, and
+        # `make eval-guidance`, now reach Shuhari through one wrapper: an
+        # inline entry has nowhere to describe the machine a run happens on,
+        # which left a host that cannot provide the default sandbox unable to
+        # run the gate at all.
+        wrapper_path = REPO_ROOT / wiring["wrapper"]
+        self.assertTrue(wrapper_path.is_file(), wiring["wrapper"])
+        self.assertTrue(os.access(wrapper_path, os.X_OK), wiring["wrapper"])
+
         entries = [
             line.strip().removeprefix("entry: ")
             for line in prek.splitlines()
             if line.strip().startswith("entry: ")
         ]
-        guidance_entries = [e for e in entries if wiring["runner"] in e]
+        guidance_entries = [e for e in entries if wiring["wrapper"] in e]
         self.assertEqual(len(guidance_entries), 2, entries)
-        for entry in guidance_entries:
-            self.assertIn(wiring["guidance_source"], entry)
-            self.assertIn(wiring["guidance_eval"], entry)
-        self.assertTrue(
-            any("--validate-only" in entry for entry in guidance_entries),
+        self.assertEqual(
+            {e.removeprefix(wiring["wrapper"]).strip() for e in guidance_entries},
+            {"validate", "eval"},
             guidance_entries,
         )
 
+        # The invocation the entries used to spell out now lives in the
+        # wrapper, so that is where it has to stay truthful.
+        wrapper = wrapper_path.read_text(encoding="utf-8")
+        self.assertIn(wiring["runner"], wrapper)
+        self.assertIn(wiring["guidance_source"], wrapper)
+        self.assertIn(wiring["guidance_eval"], wrapper)
+        self.assertIn("--validate-only", wrapper)
+
         makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
-        self.assertIn(wiring["runner"], makefile)
+        self.assertIn(wiring["wrapper"], makefile)
+        self.assertNotIn(wiring["runner"], makefile)
 
         for key in ("guidance_source", "guidance_eval"):
             self.assertTrue((REPO_ROOT / wiring[key]).is_file(), wiring[key])


### PR DESCRIPTION
## Why

The two guidance hooks and `make eval-guidance` each carried their own copy of the same Shuhari invocation, with every flag inline. That left nowhere to describe the machine a run happens on. On a host whose kernel refuses Shuhari's default isolated sandbox, Codex's preflight fails with `bwrap: No permissions to create a new namespace` and the gate cannot run at all, so a guidance edit there is committable only by skipping the gate. This ports the mechanism shunk031/skills already merged in https://github.com/shunk031/skills/pull/36 and https://github.com/shunk031/skills/pull/39, narrowed to the two fixed targets this repository evaluates.

## What Changed

`scripts/shuhari_guidance_gate.sh` owns the invocation in `validate` and `eval` modes, and both hook entries plus `make eval-guidance` call it. It translates `SHUHARI_SANDBOX` into `--sandbox <level>`, adding `--network` when that level is `unsandboxed` as Shuhari requires, and `SHUHARI_AGENT_EXECUTABLE` into `--agent-executable <path>`. With both unset the argv is byte for byte what the inline entries sent. Trials, jobs, and timeout define measurement and stay pinned in the script.

Validation is exempt from both overrides and runs through `env -u SHUHARI_SANDBOX -u SHUHARI_I_UNDERSTAND_NO_CREDENTIAL_BOUNDARY`, which is the lesson https://github.com/shunk031/skills/pull/41 encoded: Shuhari reads the sandbox variable from the environment itself, so an exported `unsandboxed` fails a `--validate-only` run over a sandbox that run never enters.

The comment advertising `SKIP=shuhari-eval-instructions` is deleted. A skipped gate ships unmeasured guidance, and the standing rule is not to skip these gates.

`tests/install/common/shuhari_guidance_gate.bats` covers the flag translation and the validation exemption with a `mise` stub that records the argv and the environment it was handed; nothing in it starts an agent. The guidance contract test and its fixture followed the invocation into the wrapper, so they still check that the wiring map agrees with the files rather than only with itself.

## Validation

Confirm the guidance wiring contract still agrees with the files.

```shell
python3 -m unittest discover -s tests/python
```

Check the wrapper parses and passes static analysis.

```shell
bash -n scripts/shuhari_guidance_gate.sh && shellcheck scripts/shuhari_guidance_gate.sh
```

Check the formatting CI enforces.

```shell
shfmt -i 4 -sr -d scripts/shuhari_guidance_gate.sh
```

Bats coverage runs in GitHub Actions, per this repository's policy of not running `bats` locally.

This commit touches no `home/dot_config/exact_agents/AGENTS.md` path, so the two guidance hooks reported `no files to check` and skipped legitimately; nothing was bypassed.
