### PR TITLE
Remove grill-me skill subscription

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -69,7 +69,6 @@ readonly SKILLS_ALLOWLIST=(
     "anthropics/skills:skill-creator"
     "coji/natural-japanese:natural-japanese"
     "cursor/plugins:unslop"
-    "mattpocock/skills:grill-me"
     "mattpocock/skills:grilling"
     "shunk031/skills:shunk031-codex-worker-prompting"
     "shunk031/skills:shunk031-github-cgd-identity"

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -92,8 +92,8 @@ EOF
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^shunk031/skills:'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^anthropics/skills:'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^cursor/plugins:unslop$'
-    printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^mattpocock/skills:grill-me$'
     printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^mattpocock/skills:grilling$'
+    ! printf '%s\n' "${SKILLS_ALLOWLIST[@]}" | grep -q '^mattpocock/skills:grill-me$'
 }
 
 @test "[common] the allowlist holds no duplicate skill names" {


### PR DESCRIPTION
## Summary

- Remove `mattpocock/skills:grill-me` from the public skills allowlist.
- Keep `mattpocock/skills:grilling`, which is the current skill with the actual grilling workflow.
- Update the allowlist test so `grill-me` is not reintroduced.

## Why

`grill-me` is now only a compatibility entry that delegates to `grilling`:

```md
Call the Skill tool with "grilling".
```

Setup does not need to install both names when only `grilling` contains the real skill behavior.

## Tests

- `bash -n install/common/skills.sh`
- `shellcheck install/common/skills.sh`
- `git diff --check -- install/common/skills.sh tests/install/common/skills.bats`
- Not run: Bats, per repository policy.
