### PR TITLE
Update private Codex guidance symlink

### DIFF
--- a/home/exact_dot_agents/symlink_AGENTS-private.md.tmpl
+++ b/home/exact_dot_agents/symlink_AGENTS-private.md.tmpl
@@ -1,1 +1,1 @@
-{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/.agents/AGENTS-private.md
+{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/home/dot_config/codex/AGENTS-private.md

--- a/home/exact_dot_agents/symlink_AGENTS-private.md.tmpl
+++ b/home/exact_dot_agents/symlink_AGENTS-private.md.tmpl
@@ -1,1 +1,1 @@
-{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/home/dot_config/codex/AGENTS-private.md
+{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/.agents/AGENTS-private.md

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -15,7 +15,6 @@ readonly PREK_CONFIG_PATH="./.pre-commit-config.yaml"
 readonly SKILL_CREATOR_SHARED_SKILL_PATH="./home/dot_config/exact_agents/skills/skill-creator"
 readonly SKILL_CREATOR_SYMLINK_TEMPLATE="./home/exact_dot_agents/skills/symlink_skill-creator.tmpl"
 readonly AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS.md.tmpl"
-readonly PRIVATE_AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS-private.md.tmpl"
 readonly SHARED_AGENT_DIR_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_agents.tmpl"
 readonly CLAUDE_MD_PATH="./home/dot_config/claude/CLAUDE.md"
 readonly CLAUDE_SYMLINK_TEMPLATE="./home/dot_claude/symlink_CLAUDE.md.tmpl"
@@ -221,7 +220,6 @@ readonly GITIGNORE_PATH="./.gitignore"
 
 @test "[common] agent guidance adapters point to the canonical files" {
     [ "$(< "${AGENTS_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/AGENTS.md" ]
-    [ "$(< "${PRIVATE_AGENTS_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/home/dot_config/codex/AGENTS-private.md" ]
     [ "$(< "${SHARED_AGENT_DIR_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/agents" ]
     run grep -F '@~/.agents/AGENTS.md' "${CLAUDE_MD_PATH}"
     [ "${status}" -eq 0 ]

--- a/tests/install/common/agents_guidance.bats
+++ b/tests/install/common/agents_guidance.bats
@@ -15,6 +15,7 @@ readonly PREK_CONFIG_PATH="./.pre-commit-config.yaml"
 readonly SKILL_CREATOR_SHARED_SKILL_PATH="./home/dot_config/exact_agents/skills/skill-creator"
 readonly SKILL_CREATOR_SYMLINK_TEMPLATE="./home/exact_dot_agents/skills/symlink_skill-creator.tmpl"
 readonly AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS.md.tmpl"
+readonly PRIVATE_AGENTS_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_AGENTS-private.md.tmpl"
 readonly SHARED_AGENT_DIR_SYMLINK_TEMPLATE="./home/exact_dot_agents/symlink_agents.tmpl"
 readonly CLAUDE_MD_PATH="./home/dot_config/claude/CLAUDE.md"
 readonly CLAUDE_SYMLINK_TEMPLATE="./home/dot_claude/symlink_CLAUDE.md.tmpl"
@@ -220,6 +221,7 @@ readonly GITIGNORE_PATH="./.gitignore"
 
 @test "[common] agent guidance adapters point to the canonical files" {
     [ "$(< "${AGENTS_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/AGENTS.md" ]
+    [ "$(< "${PRIVATE_AGENTS_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.homeDir }}/.local/share/chezmoi-private/home/dot_config/codex/AGENTS-private.md" ]
     [ "$(< "${SHARED_AGENT_DIR_SYMLINK_TEMPLATE}")" = "{{ .chezmoi.sourceDir }}/dot_config/exact_agents/agents" ]
     run grep -F '@~/.agents/AGENTS.md' "${CLAUDE_MD_PATH}"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Why

The stable `~/.agents/AGENTS-private.md` adapter must follow the private guidance source moved by shunk031/dotfiles-private#184.

## What Changed

- Retarget the existing public symlink template to the private Codex source directory.
- Add a Bats assertion that locks the adapter to the canonical private source path.

## Dependency

Merge shunk031/dotfiles-private#184 before this pull request. Merge shunk031/skills#48 after both dotfiles changes.

## Validation

Check the branch diff for whitespace errors.

```shell
git diff --check main...HEAD
```

Bats was not run locally, per repository policy. GitHub Actions provides Bats coverage.
