### PR TITLE
docs(codex): separate Codex-only guidance

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -4,4 +4,7 @@
 > After reading this `AGENTS.md`, say: `🤖 I read ~/.codex/AGENTS.md.`
 
 - Shared instructions: Read `~/.agents/AGENTS.md` first, then apply it together with this Codex-specific entrypoint.
+
+## Codex only
+
 - Commit attribution: When creating or amending a commit, end the commit message with `Co-authored-by: Codex <noreply@openai.com>` exactly once. Preserve existing trailers and keep one blank line before the trailer block.


### PR DESCRIPTION
## Why

The shared-guidance bridge applies to Codex and other agents, while the commit-attribution rule applies only to Codex. A dedicated heading makes that boundary explicit.

## What Changed

- Added a `Codex only` section above the existing Codex commit-attribution rule.
- Kept the shared-guidance bridge unchanged.

## Validation

Check the rebased diff for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Run all hooks that apply to the rebased change.

```shell
mise exec -- prek run --from-ref origin/main --to-ref HEAD
```
