### PR TITLE
docs(agent-guidance): map adapter paths to canonical sources

### DIFF
--- a/home/dot_claude/README.md
+++ b/home/dot_claude/README.md
@@ -1,6 +1,32 @@
+# ~/.claude
+
 - This directory is applied as `~/.claude`.
-- Chezmoi maps it to the canonical source in [home/dot_config/claude/](../dot_config/claude/).
-- Chezmoi maps `~/.claude/agents` to Claude wrapper agents in [home/dot_config/claude/agents/](../dot_config/claude/agents/). Those wrappers tell Claude to read shared instructions from `~/.agents/agents`.
-- `skills/` only carries a `.keep` marker so chezmoi creates `~/.claude/skills` as a real, Claude-only directory. It is not populated from this repo: the `skills` CLI links each skill it installs into `~/.claude/skills` when `home/.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl` reconciles the shared pool at `~/.agents/skills`, and skill installers may also write real skill directories there directly.
+
+## Linked paths
+
+### Public dotfiles
+
+| Applied path | Canonical source |
+| --- | --- |
+| `~/.claude/CLAUDE.md` | [dotfiles/home/dot_config/claude/CLAUDE.md](../dot_config/claude/CLAUDE.md) |
+| `~/.claude/agents` | [dotfiles/home/dot_config/claude/agents/](../dot_config/claude/agents/) |
+| `~/.claude/commands` | [dotfiles/home/dot_config/claude/commands/](../dot_config/claude/commands/) |
+| `~/.claude/hooks` | [dotfiles/home/dot_config/claude/hooks/](../dot_config/claude/hooks/) |
+| `~/.claude/rules` | [dotfiles/home/dot_config/claude/rules/](../dot_config/claude/rules/) |
+| `~/.claude/settings.json` | [dotfiles/home/dot_config/claude/settings.json](../dot_config/claude/settings.json) |
+
+## Skills
+
+- `skills/` only carries a `.keep` marker.
+  - Chezmoi creates `~/.claude/skills` as a real, Claude-only directory; this repository does not populate it.
+  - The `skills` CLI links each installed skill into it when [run_after_30-reconcile-agent-skills.sh.tmpl](../.chezmoiscripts/common/run_after_30-reconcile-agent-skills.sh.tmpl) reconciles the shared pool at `~/.agents/skills`.
+  - Skill installers can also write real skill directories there directly.
+
+## Shared instructions
+
+- Claude wrapper agents read shared instructions from `~/.agents/agents`.
+
+## Editing
+
 - The design keeps the home-facing path stable while the real files live in one git-friendly source tree.
 - Edit the canonical source, not this adapter directory.

--- a/home/dot_codex/README.md
+++ b/home/dot_codex/README.md
@@ -1,5 +1,32 @@
+# ~/.codex
+
 - This directory is applied as `~/.codex`.
-- Chezmoi maps `~/.codex/AGENTS.md` to [home/dot_config/codex/AGENTS.md](../dot_config/codex/AGENTS.md).
-- Chezmoi maps `~/.codex/agents` to Codex custom-agent adapters in [home/dot_config/codex/agents/](../dot_config/codex/agents/), which reference shared instructions under `~/.agents/agents`.
-- Private dotfiles manage `~/.codex/config.toml` and private profiles separately.
+
+## Linked paths
+
+### Public dotfiles
+
+| Applied path | Canonical source |
+| --- | --- |
+| `~/.codex/AGENTS.md` | [dotfiles/home/dot_config/codex/AGENTS.md](../dot_config/codex/AGENTS.md) |
+| `~/.codex/agents` | [dotfiles/home/dot_config/codex/agents/](../dot_config/codex/agents/) |
+
+### Private dotfiles
+
+| Applied path | Canonical source |
+| --- | --- |
+| `~/.codex/config.toml` | [dotfiles-private/home/dot_config/codex/config.toml](https://github.com/shunk031/dotfiles-private/blob/main/home/dot_config/codex/config.toml) |
+| `~/.codex/hooks.json` | [dotfiles-private/home/dot_codex/hooks.json](https://github.com/shunk031/dotfiles-private/blob/main/home/dot_codex/hooks.json) |
+| `~/.codex/hooks` | [dotfiles-private/home/dot_codex/hooks/](https://github.com/shunk031/dotfiles-private/tree/main/home/dot_codex/hooks) |
+
+## Skills
+
+- `~/.agents/skills` is shared rather than mapped from this adapter; see [the shared skill pool](../exact_dot_agents/README.md#shared-skill-pool).
+
+## Shared instructions
+
+- Codex custom-agent adapters read shared instructions from `~/.agents/agents`.
+
+## Editing
+
 - Edit the canonical source, not this adapter directory.

--- a/home/exact_dot_agents/README.md
+++ b/home/exact_dot_agents/README.md
@@ -1,6 +1,26 @@
+# ~/.agents
+
 - This directory is applied as `~/.agents`.
-- Chezmoi maps it to the canonical source in [home/dot_config/exact_agents/](../dot_config/exact_agents/).
-- Chezmoi maps `~/.agents/agents` to shared agent instructions in [home/dot_config/exact_agents/agents/](../dot_config/exact_agents/agents/).
-- `~/.agents/skills`, the shared skills pool, is not mapped from here. It is a real directory the `skills` CLI installs into, reconciled against the allowlist in [install/common/skills.sh](../../install/common/skills.sh) on every apply, and listed in [chezmoiignore.d/common](../.chezmoitemplates/chezmoiignore.d/common) so chezmoi leaves it alone.
+
+## Linked paths
+
+| Applied path | Canonical source |
+| --- | --- |
+| `~/.agents/AGENTS.md` | [dotfiles/home/dot_config/exact_agents/AGENTS.md](../dot_config/exact_agents/AGENTS.md) |
+| `~/.agents/AGENTS-private.md` | [dotfiles-private/home/dot_config/codex/AGENTS-private.md](https://github.com/shunk031/dotfiles-private/blob/main/home/dot_config/codex/AGENTS-private.md) |
+| `~/.agents/agents` | [dotfiles/home/dot_config/exact_agents/agents/](../dot_config/exact_agents/agents/) |
+
+## Skills
+
+- `~/.agents/skills`, the shared skills pool, is not mapped from here.
+  - It is a real directory the `skills` CLI installs into, reconciled against the allowlist in [install/common/skills.sh](../../install/common/skills.sh) on every apply.
+  - It is listed in [chezmoiignore.d/common](../.chezmoitemplates/chezmoiignore.d/common) so chezmoi leaves it alone.
+
+## Shared instructions
+
+- `~/.agents/agents` supplies shared instructions to Codex and Claude wrapper agents.
+
+## Editing
+
 - The design keeps the home-facing path stable while the real files live in one git-friendly source tree.
 - Edit the canonical source, not this adapter directory.


### PR DESCRIPTION
## Why

The adapter READMEs did not list every home-facing symlink and its canonical source, which made ownership harder to verify.

## What Changed

- Added headings and compact linked-path tables for Claude, Codex, and shared agent adapters.
- Organized all three adapter READMEs into linked paths, skills, shared instructions, and editing sections.
- Split the Claude skills wiring into a marker bullet and three nested implementation details.
- Separated public and private Codex mappings, including the private `config.toml` and hook sources, and identified Claude mappings as public dotfiles.
- Qualified each canonical source label with its owning repository and linked private guidance and Codex sources to `dotfiles-private`.
- Documented the shared skill pool and shared instructions under `~/.agents`, and linked the Codex README to the shared skill details.
- Kept behavior and guidance in their canonical source files instead of duplicating it in the adapter documentation.

## Validation

Check the README diff for whitespace errors.

```shell
git diff --check main...HEAD
```

Run all applicable repository hooks for the changed READMEs.

```shell
MISE_CONFIG_FILE=home/dot_mise/config.toml mise exec -- prek run --files home/dot_claude/README.md home/dot_codex/README.md home/exact_dot_agents/README.md
```
