### PR TITLE
docs(codex): clarify explicit actors

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -7,4 +7,5 @@
 
 ## Codex only
 
+- Explicit actors: Codex must state who makes each decision and who performs each action when an explanation or plan would otherwise leave responsibility ambiguous.
 - Commit attribution: When creating or amending a commit, end the commit message with `Co-authored-by: Codex <noreply@openai.com>` exactly once. Preserve existing trailers and keep one blank line before the trailer block.


### PR DESCRIPTION
## Why

Codex guidance should make decision and action ownership clear whenever a plan or explanation could otherwise be ambiguous.

## What Changed

- Add an explicit-actors rule to the Codex-only guidance entrypoint.

## Validation

Check the updated guidance diff for whitespace errors.

```shell
git diff --check
```

Lint the updated Codex guidance prose.

```shell
MISE_CONFIG_FILE="$PWD/home/dot_mise/config.toml" mise exec -- prek run --files home/dot_config/codex/AGENTS.md
```

The two shared-guidance evaluation hooks skipped because their file filter does not include the Codex-only entrypoint.
