### PR TITLE
feat(claude): default gh-workflow-manager subagent to Sonnet

### DIFF
--- a/home/dot_config/claude/agents/gh-workflow-manager.md
+++ b/home/dot_config/claude/agents/gh-workflow-manager.md
@@ -1,6 +1,7 @@
 ---
 name: gh-workflow-manager
 description: GitHub and pull request workflow agent.
+model: sonnet
 ---
 
 Before doing anything else, read ~/.agents/agents/gh-workflow-manager.md and follow it as your primary instructions.


### PR DESCRIPTION
## Why

The owner decided execution/work subagents should default to Claude Sonnet 5. This persists that decision as configuration in the public dotfiles.

## What Changed

Added `model: sonnet` to the frontmatter of `home/dot_config/claude/agents/gh-workflow-manager.md`, the Claude Code wrapper for the `gh-workflow-manager` subagent.

Enumeration of Claude Code custom agent definitions found under `home/dot_config/claude/agents/`:

| Agent | Role | Touched |
| --- | --- | --- |
| `gh-workflow-manager` | Mechanical GitHub/PR execution (branch, commit, push, PR, CI) | Yes: added `model: sonnet` |

No other Claude Code agent definitions exist in this repository or in `chezmoi-private`, so no research/review-oriented agent was left untouched by choice — none exist to leave untouched. The private source (`~/.local/share/chezmoi-private`) holds no Claude agent definitions or model configuration; this repository is the sole owner of the changed setting.

The global `model` key in `home/dot_config/claude/settings.json` is a separate, session-level default and was left untouched (it also currently has an unrelated pending local change that this branch does not include).

## Validation

Run the guidance/agent bats suite covering the Claude wrapper contract.

```shell
bats tests/install/common/agents_guidance.bats
```

Run the Python agent-guidance requirements tests.

```shell
uv run --with pytest pytest tests/python/test_agent_guidance_requirements.py -q
```

Pre-commit hooks ran on commit: `shuhari-validate-instructions` and `shuhari-eval-instructions` were skipped (no matching files changed), and `textlint-markdown` passed.
