### PR TITLE
feat(herdr): install Codex integration

### DIFF
--- a/install/common/herdr.sh
+++ b/install/common/herdr.sh
@@ -17,6 +17,7 @@ readonly HERDR_SKILL_PATH="${HOME}/.agents/skills/herdr/SKILL.md"
 
 readonly HERDR_INTEGRATIONS=(
     claude
+    codex
 )
 
 #

--- a/tests/install/common/herdr.bats
+++ b/tests/install/common/herdr.bats
@@ -100,6 +100,7 @@ EOF
     run cat "${BATS_TEST_TMPDIR}/mise_args.txt"
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "exec -- herdr integration install claude" ]
+    [ "${lines[1]}" = "exec -- herdr integration install codex" ]
 }
 
 @test "[common] sync_herdr_skill writes the shared skill from Herdr" {
@@ -166,12 +167,14 @@ EOF
     [ "${lines[0]}" = "activate bash" ]
     [ "${lines[1]}" = "install herdr" ]
     [ "${lines[2]}" = "exec -- herdr integration install claude" ]
-    [ "${lines[3]}" = "exec -- herdr --skill" ]
+    [ "${lines[3]}" = "exec -- herdr integration install codex" ]
+    [ "${lines[4]}" = "exec -- herdr --skill" ]
 
     run cat "${BATS_TEST_TMPDIR}/herdr_args.txt"
     [ "${status}" -eq 0 ]
     [ "${lines[0]}" = "integration install claude" ]
-    [ "${lines[1]}" = "--skill" ]
+    [ "${lines[1]}" = "integration install codex" ]
+    [ "${lines[2]}" = "--skill" ]
 
     run cat "${HOME}/.agents/skills/herdr/SKILL.md"
     [ "${status}" -eq 0 ]


### PR DESCRIPTION
## Summary

- install the Herdr Codex integration alongside the existing Claude integration
- extend the Herdr setup tests to cover both integrations and their execution order

## Why

`install/common/herdr.sh` only listed `claude`, so setup never ran `herdr integration install codex`. Herdr manages Claude and Codex integrations independently, which left Claude current while Codex remained uninstalled.

Herdr documents the separate Codex install command and its managed files in the [integration guide](https://herdr.dev/docs/integrations/). The [Herdr v0.8.0 Codex installer](https://github.com/herdrdev/herdr/blob/v0.8.0/src/integration/targets.rs#L147-L207) updates the Codex hook, `hooks.json`, and `config.toml` idempotently. This repository therefore only adds `codex` to the existing integration list instead of duplicating Herdr-owned configuration.

## Validation

- `shellcheck install/common/herdr.sh`
- `shfmt --indent 4 --space-redirects --diff install/common/herdr.sh tests/install/common/herdr.bats`
- sourced `install/common/herdr.sh` and verified `HERDR_INTEGRATIONS` resolves to `claude` and `codex`
- `git diff --check`

Bats was not run locally per repository policy. GitHub Actions will run it.