### PR TITLE
Add 1Password to the macOS Dock

### DIFF
--- a/install/macos/common/defaults.sh
+++ b/install/macos/common/defaults.sh
@@ -112,7 +112,7 @@ function defaults_dock() {
         "$(dock_item /Applications/Visual\ Studio\ Code.app)" \
         "$(dock_item /Applications/Slack.app)" \
         "$(dock_item /Applications/iTerm.app)" \
-        "$(dock_item /Applications/cmux.app)" \
+        "$(dock_item /Applications/1Password.app)" \
         "$(dock_item "$(get_system_app_path)")"
 }
 

--- a/tests/install/macos/common/defaults.bats
+++ b/tests/install/macos/common/defaults.bats
@@ -62,7 +62,7 @@ function dock_app_path() {
     [ "$(dock_app_path "${dock_plist}" 1)" = "/Applications/Visual Studio Code.app" ]
     [ "$(dock_app_path "${dock_plist}" 2)" = "/Applications/Slack.app" ]
     [ "$(dock_app_path "${dock_plist}" 3)" = "/Applications/iTerm.app" ]
-    [ "$(dock_app_path "${dock_plist}" 4)" = "/Applications/cmux.app" ]
+    [ "$(dock_app_path "${dock_plist}" 4)" = "/Applications/1Password.app" ]
     [ "$(dock_app_path "${dock_plist}" 5)" = "$(get_system_app_path)" ]
 
     rm -f "${dock_plist}"


### PR DESCRIPTION
## Why

The managed macOS Dock should include 1Password instead of cmux.

## What Changed

- Replace `/Applications/cmux.app` with `/Applications/1Password.app` in the Dock defaults.
- Update the Dock order test to expect 1Password at position 4.

## Validation

Check the changed files for whitespace errors.

```shell
git diff --check origin/main...HEAD
```

Confirm the pull request contains only the Dock defaults and its test.

```shell
git diff --name-only origin/main...HEAD
```

GitHub Actions runs the Bats suite according to repository policy.
