### PR TITLE
docs(agents): require unambiguous issue and PR references

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.evals.json
+++ b/home/dot_config/exact_agents/AGENTS.evals.json
@@ -47,6 +47,15 @@
         "The response directly provides the requested function and example.",
         "The response does not add irrelevant ceremony or discuss respectful-language guidance instead of solving the technical task."
       ]
+    },
+    {
+      "id": "unambiguous-issue-pr-reference",
+      "prompt": "The fix for the cache invalidation bug landed as pull request 247 in the shunk031/dotfiles repository. Write a short status note for the owner telling them where to review the change.",
+      "expected_output": "A short status note tells the owner where to review pull request 247 in shunk031/dotfiles using a reference that remains usable outside that repository. It stays focused on the landed fix.",
+      "assertions": [
+        "The note identifies pull request 247 in shunk031/dotfiles.",
+        "The note gives a reference that remains usable outside that repository."
+      ]
     }
   ]
 }

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -48,6 +48,7 @@
 - Use respectful, professional language. Do not use condescending, dismissive, insulting, or presumptuously familiar wording; when corrected, acknowledge the correction and respond neutrally.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 - Before writing or editing any prose deliverable (documentation, README, PR/issue text, or reports), first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
+- When referring to a GitHub issue or pull request in any reader-facing text (reports, chat replies, issue and pull-request bodies, comments), write the full URL, or `owner/repo#number` at minimum; never a bare `#123`, which is repository-relative, unclickable in chat, and ambiguous when paired changes span repositories.
 - Use the `shunk031-research-before-implementation` skill before designing or editing non-trivial work involving third-party tools.
 - Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
 - Write tests before behavior-changing implementation, verify them, and then refactor.


### PR DESCRIPTION
## Why
Reader-facing references to GitHub issues and pull requests need to remain clear outside their repository.
A bare issue or pull-request number is repository-relative and can be unclear when changes span repositories.
## What Changed
The shared agent guidance now requires a full GitHub URL or an owner/repository number reference.
The eval register adds one natural pull-request review scenario without prescribing the expected reference form.
The new case measures whether the generated status note points to a reference usable outside the repository.
## Validation
The required offline checks passed.
```shell
python3 -m unittest discover -s tests/python
prek run shuhari-validate-instructions --files home/dot_config/exact_agents/AGENTS.md home/dot_config/exact_agents/AGENTS.evals.json
prek run textlint-markdown --files home/dot_config/exact_agents/AGENTS.md
```
The live guidance gate ran on this commit and all hooks passed.
Context: https://github.com/shunk031/skills/issues/38
No merge is requested.
