### PR TITLE
feat(macos): install ChatGPT app

### DIFF
--- a/install/macos/common/misc.sh
+++ b/install/macos/common/misc.sh
@@ -25,6 +25,7 @@ readonly BREW_TAPS=(
 
 readonly CASK_PACKAGES=(
     adobe-acrobat-reader
+    chatgpt
     clop
     cmux
     cyberduck


### PR DESCRIPTION
Adds the `chatgpt` Homebrew Cask to the macOS common setup script, so the existing setup flow installs the ChatGPT app.