### PR TITLE
docs(codex): preserve unfinished work across interruptions

### DIFF
--- a/home/dot_config/codex/AGENTS.md
+++ b/home/dot_config/codex/AGENTS.md
@@ -8,4 +8,5 @@
 ## Codex only
 
 - Explicit actors: Codex must state who makes each decision and who performs each action when an explanation or plan would otherwise leave responsibility ambiguous.
+- Interrupted work: When new user input arrives during unfinished work, Codex must decide whether it replaces or extends the active request. Unless it clearly replaces the request, keep the original objective and unresolved acceptance criteria in the active plan, resume them after handling the interruption, and do not report completion until both are complete.
 - Commit attribution: When creating or amending a commit, end the commit message with `Co-authored-by: Codex <noreply@openai.com>` exactly once. Preserve existing trailers and keep one blank line before the trailer block.


### PR DESCRIPTION
## Summary

- keep an unfinished request and its unresolved acceptance criteria active when new user input extends rather than replaces it
- require Codex to resume retained work after handling the interruption
- prevent completion reports until both the interruption and retained work are complete

## Validation

- `git diff --check`
- `mise exec -- prek run --files home/dot_config/codex/AGENTS.md`