### PR TITLE
docs(agents): require class-wide deliverable sweeps

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -45,6 +45,7 @@
 
 ## Working Style
 
+- When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable, and sibling deliverables that can carry the class, fix every instance, and report found/fixed counts — never fix only the quoted spot.
 - Use respectful, professional language. Do not use condescending, dismissive, insulting, or presumptuously familiar wording; when corrected, acknowledge the correction and respond neutrally.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 - Before writing or editing any prose deliverable (documentation, README, PR/issue text, or reports), first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -45,7 +45,7 @@
 
 ## Working Style
 
-- When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable, and sibling deliverables that can carry the class, fix every instance, and report found/fixed counts — never fix only the quoted spot.
+- When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class. Survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
 - Use respectful, professional language. Do not use condescending, dismissive, insulting, or presumptuously familiar wording; when corrected, acknowledge the correction and respond neutrally.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 - Before writing or editing any prose deliverable (documentation, README, PR/issue text, or reports), first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.


### PR DESCRIPTION
## Why

When a user flags one defective or unnecessary passage, the issue may be a repeated class of problem rather than an isolated spot. This change makes the expected user-level response explicit and auditable.

## What changed

Added one bullet to the user-level `~/.agents/AGENTS.md` Working Style section. The rule requires surveying the whole deliverable and sibling deliverables that can carry the same class, fixing every instance, and reporting found/fixed counts. Its scope is cross-repository deliverable work; no other guidance or adapter was changed.

## Validation

The guidance eval schema validator passed.

```shell
MISE_CONFIG_FILE=home/dot_mise/config.toml mise exec -- prek run shuhari-validate-instructions --files home/dot_config/exact_agents/AGENTS.md
```

The Markdown textlint hook passed.

```shell
MISE_CONFIG_FILE=home/dot_mise/config.toml mise exec -- prek run textlint-markdown --files home/dot_config/exact_agents/AGENTS.md
```

The `shuhari-eval-instructions` hook was skipped for this commit under a Gateway budget outage with explicit user authorization; it will be re-run on the standard path after the reset before merge.

```shell
SKIP=shuhari-eval-instructions git commit -m "docs(agents): require class-wide deliverable sweeps"
```
