### PR TITLE
Add git up alias

### DIFF
--- a/home/dot_config/exact_git/config.tmpl
+++ b/home/dot_config/exact_git/config.tmpl
@@ -22,3 +22,5 @@
 	autoStash = true
 [credential]
     helper = !gh auth git-credential
+[alias]
+	up = "!git fetch origin && git rebase \"@{u}\""


### PR DESCRIPTION
Adds the global Git alias `up` for fetching `origin` and rebasing onto the tracked upstream ref.

Using `@{u}` avoids rebasing against shared `FETCH_HEAD`, which can contain multiple branches when concurrent worktree agents fetch into the same repository.

Validation: rendered the chezmoi template and verified the alias through Git config parsing and an include-path check.