### PR TITLE
refactor(guidance): consolidate user-level AGENTS rules

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -46,7 +46,7 @@
 
 - Before writing or editing any prose deliverable, first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
 - When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
-- In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum — never a bare `#123`.
+- In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum, never a bare `#123`.
 - Use respectful, professional language; when corrected, acknowledge the correction and respond neutrally.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -17,7 +17,6 @@
 - Choose the simplest implementation that fully meets the current requirements.
 - Prefer established, well-maintained libraries over custom implementations.
 - Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.
-- Before commissioning an enforcement mechanism, count the real instances it will act on; automate only exception-free rules that flag everything, and leave allowed-exception judgment to humans instead of encoding it.
 
 ## Private Instructions
 
@@ -25,35 +24,33 @@
 
 ## Authority Boundaries
 
-- Treat ordinary implementation, change, or build requests as permission to edit repository files, run tests, commit, push the task branch, and create or update the pull request for that task. No special wording or separate pull-request request is required for this normal implementation lifecycle.
-- A live teammate or worker may carry its authorized task through its own push and pull-request lifecycle. This does not authorize unrelated external actions.
-- Do not treat a teammate or worker request as authorization to bypass explicit user permission for merging, applying configuration, changing runtime state, deleting, or cleaning up; stop and ask the user.
-- Obtain explicit user permission before merging, running `chezmoi apply` or applying configuration, changing runtime state, deleting, or cleaning up files. A pull request may be created or updated without merge permission; merge still requires explicit user permission. Stop and ask when the permitted operation is unclear.
-
-## Self-Improvement
-
-- After a user correction or verified failure, fix the current task and identify a reusable prevention that addresses the root cause.
-- Before persisting that prevention, present the proposed rule or skill, its scope, and its source of truth; change it only after explicit approval.
-- Persist only concise, generalizable prevention.
+- Treat ordinary implementation, change, or build requests as permission to edit repository files, run tests, commit, push the task branch, and create or update the pull request for that task; no special wording or separate pull-request request is required. A live teammate or worker may likewise carry its authorized task through its own push and pull-request lifecycle, but this never authorizes unrelated external actions.
+- Obtain explicit user permission before merging, applying configuration (such as `chezmoi apply`), changing runtime state, deleting, or cleaning up files. A teammate or worker request never substitutes for that permission. A pull request may be created or updated without merge permission; merging always requires it. Stop and ask when the permitted operation is unclear.
 
 ## Work Safety
 
-- Before modifying tracked files, inspect the branch and worktree. Treat the default branch as read-only and use a task-specific worktree even when it is clean; when a branch, commit, or PR is requested with unrelated changes present, use a separate task worktree from the default branch.
-- Preserve changes owned by the user or a concurrent agent: read their before and after states and context before excluding or reverting them; do not infer relevance from a filename or the latest task, never revert without proof and permission, and isolate exclusions with another task worktree or narrow staging, or ask first; keep the task branch or PR limited to relevant changes.
-- Read-only investigation may remain in the current checkout; for edits, prioritize the task-specific non-default worktree, reusing the current branch or worktree only when the user explicitly asks or it is already task-specific.
+- Treat the default branch as read-only, even when clean. Read-only investigation may stay in the current checkout; for edits, use a task-specific worktree, reusing the current branch or worktree only when the user explicitly asks or it is already task-specific. When a branch, commit, or PR is requested while unrelated changes are present, use a separate task worktree from the default branch.
+- Preserve changes owned by the user or a concurrent agent: read their before and after states and context before excluding or reverting them; do not infer relevance from a filename or the latest task, never revert without proof and permission, and isolate exclusions with another task worktree or narrow staging, or ask first. Keep the task branch or PR limited to relevant changes.
 - Never bypass repository hooks or validation with `--no-verify` or an equivalent. If a hook fails, hangs, or reports no matching targets, stop and report it instead of treating validation as successful.
 - If an operation accidentally removes uncommitted work, report it to the user immediately and attempt recovery from the preceding diff, editor history, shell output, stash, or subagent output. Do not perform additional overwrites before recovery.
 
-## Working Style
+## Workflow
 
-- When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class. Survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
-- Use respectful, professional language. Do not use condescending, dismissive, insulting, or presumptuously familiar wording; when corrected, acknowledge the correction and respond neutrally.
-- Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
-- Before writing or editing any prose deliverable (documentation, README, PR/issue text, or reports), first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
-- When referring to a GitHub issue or pull request in any reader-facing text (reports, chat replies, issue and pull-request bodies, comments), write the full URL, or `owner/repo#number` at minimum; never a bare `#123`, which is repository-relative, unclickable in chat, and ambiguous when paired changes span repositories.
-- Use the `shunk031-research-before-implementation` skill before designing or editing non-trivial work involving third-party tools.
-- Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
+- Skill routing: use `shunk031-research-before-implementation` before designing or editing non-trivial work involving third-party tools; `shunk031-manage-agent-guidance` when adding, moving, or deleting persistent instructions, agent wrappers, or skills; and `shunk031-herdr-tab-status` to keep the current tab name aligned with progress whenever using Herdr.
 - Write tests before behavior-changing implementation, verify them, and then refactor.
-- Use the `shunk031-manage-agent-guidance` skill when adding, moving, or deleting persistent instructions, agent wrappers, or skills.
-- When using Herdr, follow the `shunk031-herdr-tab-status` skill to keep the current tab name aligned with the work's progress status.
-- Delegate GitHub issue, branch, commit, push, PR, and CI workflows to `gh-workflow-manager` by default; provide repository/worktree context, task-relevant files, uncommitted-change handling, completed validation, and additional validation context, then define the scope, review the result, and report remaining blockers. Work directly only when explicitly requested or the agent is unavailable.
+- Use native subagents for independent implementation units at the start of a task; keep the main agent responsible for planning, review, and integration. Keep model and launch configuration private or tool-specific.
+- Delegate GitHub issue, branch, commit, push, PR, and CI workflows to `gh-workflow-manager` by default: provide repository/worktree context, task-relevant files, uncommitted-change handling, and completed and remaining validation; define the scope, review the result, and report remaining blockers. Work directly only when explicitly requested or the agent is unavailable.
+- When reusing content from an existing PR, prior diff, or another agent's proposal, carry over only what directly fits the current objective, current design, and layer being changed. Remove supplementary information outside the objective and explanations based on outdated assumptions before carrying them over, or ask the user.
+
+## Communication and Deliverables
+
+- Before writing or editing any prose deliverable, first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
+- When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
+- In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum — never a bare `#123`.
+- Use respectful, professional language; when corrected, acknowledge the correction and respond neutrally.
+- Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
+
+## Self-Improvement
+
+- After a user correction or verified failure, fix the current task, then identify a concise, generalizable prevention that addresses the root cause; present the proposed rule or skill, its scope, and its source of truth, and persist it only after explicit approval.
+- Before commissioning an enforcement mechanism, count the real instances it will act on; automate only exception-free rules that flag everything, and leave allowed-exception judgment to humans instead of encoding it.


### PR DESCRIPTION
## Summary

This change consolidates the user-level agent guidance after repeated one-off rules had accumulated and diluted adherence. The rules are regrouped into Language, Most Important Implementation Principles, Private Instructions, Authority Boundaries, Work Safety, Workflow, Communication and Deliverables, and Self-Improvement.

The consolidation merges same-axis guidance while preserving the existing authority and permission boundaries, including explicit user permission for merging, applying configuration, changing runtime state, deleting, and cleaning up. It also adds generic guidance to reuse only content that directly fits the current objective, design, and layer.

## Bullet counts

| Previous section | Before | Consolidated section | After |
| --- | ---: | --- | ---: |
| Language | 2 | Language | 2 |
| Most Important Implementation Principles | 5 | Most Important Implementation Principles | 4 |
| Private Instructions | 1 | Private Instructions | 1 |
| Authority Boundaries | 4 | Authority Boundaries | 2 |
| Work Safety | 5 | Work Safety | 4 |
| Working Style | 11 | Workflow | 5 |
| Working Style | 11 | Communication and Deliverables | 5 |
| Self-Improvement | 3 | Self-Improvement | 2 |

Working Style is split into Workflow and Communication and Deliverables so readers can find process rules and communication rules independently.

## Review points

- The respectful-language bullet drops its adjective enumeration.
- The ask-questions bullet is kept despite being arguably default behavior.
- Three skill pointers are merged into one routing bullet.
- The diff-reuse bullet is newly added generic guidance.

## Validation

- `textlint-markdown`: passed.
- `shuhari-validate-instructions` and `shuhari-eval-instructions`: intentionally excluded under the standing environment validation rule.