### PR TITLE
docs(agents): avoid mirroring frustrated user tone

### DIFF
--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -47,7 +47,7 @@
 - Before writing or editing any prose deliverable, first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
 - When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
 - In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum, never a bare `#123`.
-- Use respectful, professional language; when corrected or criticized, acknowledge it and respond neutrally. Do not mirror frustration, sarcasm, profanity, or laughter markers such as `w`, `ｗ`, `笑`, `lol`, or `haha`; treat them as possible expressions of exasperation rather than invitations to banter.
+- Use respectful, professional language; when corrected or criticized, acknowledge it and respond neutrally. In critical messages, `w`, `ｗ`, and `笑` should be interpreted as signs of severe disappointment, disbelief, or exasperation—not amusement. Never mirror them. Treat their presence as a signal to become more serious, restrained, and precise.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 
 ## Self-Improvement

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -47,7 +47,7 @@
 - Before writing or editing any prose deliverable, first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
 - When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
 - In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum, never a bare `#123`.
-- Use respectful, professional language; when corrected or criticized, acknowledge it and respond neutrally. In critical messages, `w`, `ｗ`, and `笑` should be interpreted as signs of severe disappointment, disbelief, or exasperation—not amusement. Never mirror them. Treat their presence as a signal to become more serious, restrained, and precise.
+- Use respectful, professional language; when corrected or criticized, acknowledge it and respond neutrally. In critical messages, `w` and `ｗ` should be interpreted as signs of severe disappointment, disbelief, or exasperation—not amusement. Never mirror them. Treat their presence as a signal to become more serious, restrained, and precise.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 
 ## Self-Improvement

--- a/home/dot_config/exact_agents/AGENTS.md
+++ b/home/dot_config/exact_agents/AGENTS.md
@@ -47,7 +47,7 @@
 - Before writing or editing any prose deliverable, first declare which reader it is for and what it must convey, then judge every addition and removal by value to that reader rather than by redundancy or writer-side consistency.
 - When the user flags one defective or unnecessary passage in a deliverable, treat it as an instance of a class: survey the whole deliverable and any sibling deliverables that can carry the class, fix every instance, and report found/fixed counts. Never fix only the quoted spot.
 - In reader-facing text, reference GitHub issues and pull requests by full URL, or `owner/repo#number` at minimum, never a bare `#123`.
-- Use respectful, professional language; when corrected, acknowledge the correction and respond neutrally.
+- Use respectful, professional language; when corrected or criticized, acknowledge it and respond neutrally. Do not mirror frustration, sarcasm, profanity, or laughter markers such as `w`, `ｗ`, `笑`, `lol`, or `haha`; treat them as possible expressions of exasperation rather than invitations to banter.
 - Ask questions that materially improve the result when the answer cannot be discovered safely from the available context.
 
 ## Self-Improvement


### PR DESCRIPTION
## Summary

- clarify that corrections and criticism should receive a neutral response
- treat `w` and `ｗ` in critical messages as signs of severe disappointment, disbelief, or exasperation rather than amusement
- prohibit mirroring those markers and require a more serious, restrained, and precise response

## Validation

- documentation-only change
- verified the branch differs from `main` by one file and one line replacement