### PR TITLE
feat: support Rocky Linux servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,15 @@ bash -c "$(curl -fsLS http://shunk031.me/dotfiles/setup.sh)"
 
 ![Screenshot of setup on MacOS Client machine](.github/screenshot-macos-client.png)
 
-### 🖥️ `Ubuntu` [![Ubuntu](https://github.com/shunk031/dotfiles/actions/workflows/ubuntu.yaml/badge.svg)](https://github.com/shunk031/dotfiles/actions/workflows/ubuntu.yaml)
+### 🖥️ `Ubuntu / Rocky Linux` [![Ubuntu](https://github.com/shunk031/dotfiles/actions/workflows/ubuntu.yaml/badge.svg)](https://github.com/shunk031/dotfiles/actions/workflows/ubuntu.yaml)
 
-- Configuration snippet of the Ubuntu environment for both client and server machine:
-
-```console
-bash -c "$(wget -qO - http://shunk031.me/dotfiles/setup.sh)"
-```
-
-![Screenshot of setup on Ubuntu Server machine](.github/screenshot-ubuntu-server.png)
-
-### 🪨 `Rocky Linux`
-
-- Configuration snippet for a Rocky Linux server:
+- Configuration snippet for Ubuntu client and server machines, and Rocky Linux server machines:
 
 ```console
 bash -c "$(curl -fsLS https://shunk031.me/dotfiles/setup.sh)"
 ```
+
+![Screenshot of setup on Ubuntu Server machine](.github/screenshot-ubuntu-server.png)
 
 ### Minimal setup
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## 🗿 Overview
 
 This [dotfiles](https://github.com/shunk031/dotfiles) repository is managed with [`chezmoi🏠`](https://www.chezmoi.io/), a great dotfiles manager.
-The setup scripts are aimed for [MacOS](https://www.apple.com/jp/macos), [Ubuntu Desktop](https://ubuntu.com/desktop), and [Ubuntu Server](https://ubuntu.com/server). The first two (MacOS/Ubuntu Desktop) include settings for `client` machines and the latter one (Ubuntu Server) for `server` machines.
+The setup scripts support [macOS](https://www.apple.com/jp/macos), [Ubuntu Desktop](https://ubuntu.com/desktop), [Ubuntu Server](https://ubuntu.com/server), and [Rocky Linux](https://rockylinux.org/). macOS and Ubuntu Desktop use the `client` configuration. Ubuntu Server and Rocky Linux use the `server` configuration.
 
 The actual dotfiles exist under the [`home`](https://github.com/shunk031/dotfiles/tree/main/home) directory specified in the [`.chezmoiroot`](https://github.com/shunk031/dotfiles/blob/main/.chezmoiroot).
 See [.chezmoiroot - chezmoi](https://www.chezmoi.io/reference/special-files-and-directories/chezmoiroot/) more detail on the setting.
@@ -68,6 +68,14 @@ bash -c "$(wget -qO - http://shunk031.me/dotfiles/setup.sh)"
 ```
 
 ![Screenshot of setup on Ubuntu Server machine](.github/screenshot-ubuntu-server.png)
+
+### 🪨 `Rocky Linux`
+
+- Configuration snippet for a Rocky Linux server:
+
+```console
+bash -c "$(curl -fsLS https://shunk031.me/dotfiles/setup.sh)"
+```
 
 ### Minimal setup
 

--- a/home/.chezmoiexternal.yaml.tmpl
+++ b/home/.chezmoiexternal.yaml.tmpl
@@ -1,8 +1,8 @@
 {{ template "chezmoiexternal.d/common.yaml.tmpl" . }}
 {{ if eq .chezmoi.os "darwin" -}}
 {{   template "chezmoiexternal.d/macos.yaml.tmpl" . }}
-{{ else if (and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.idLike "debian")) -}}
+{{ else if (and (eq .chezmoi.os "linux") (or (eq .chezmoi.osRelease.idLike "debian") (eq .chezmoi.osRelease.id "rocky"))) -}}
 {{   template "chezmoiexternal.d/ubuntu.yaml.tmpl" . }}
 {{ else -}}
-{{   fail (printf "Unknown OS for client system: %s" .chezmoi.os) }}
+{{   fail (printf "Unsupported operating system: %s" .chezmoi.os) }}
 {{ end -}}

--- a/home/.chezmoiscripts/rocky/run_once_50-server-configure-ssh-env.sh.tmpl
+++ b/home/.chezmoiscripts/rocky/run_once_50-server-configure-ssh-env.sh.tmpl
@@ -1,0 +1,3 @@
+{{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "rocky") (eq .system "server") -}}
+{{   include "../install/rocky/server/ssh_server.sh" }}
+{{ end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_00-setup-ssh.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_00-setup-ssh.sh.tmpl
@@ -1,6 +1,8 @@
 {{ if eq .chezmoi.os "linux" -}}
 {{   if eq .chezmoi.osRelease.idLike "debian" -}}
 {{     include "../install/ubuntu/common/ssh.sh" }}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     include "../install/rocky/common/ssh.sh" }}
 {{   else -}}
 {{     fail (printf "Invalid linux distribution: %s" .chezmoi.osRelease.id) }}
 {{   end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_08-install-tmux.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_08-install-tmux.sh.tmpl
@@ -1,6 +1,8 @@
 {{ if eq .chezmoi.os "linux" -}}
 {{   if eq .chezmoi.osRelease.idLike "debian" -}}
 {{     include "../install/ubuntu/common/tmux.sh" }}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     include "../install/rocky/common/tmux.sh" }}
 {{   end -}}
 {{   if eq .system "client" -}}
 {{     include "../install/common/tpm.sh" }}

--- a/home/.chezmoiscripts/ubuntu/run_once_10-install-starship.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_10-install-starship.sh.tmpl
@@ -1,7 +1,5 @@
 {{ if eq .chezmoi.os "linux" -}}
-{{   if eq .chezmoi.osRelease.idLike "debian" -}}
-{{     if eq .system "server" -}}
-{{       include "../install/ubuntu/server/starship.sh" }}
-{{     end -}}
+{{   if eq .system "server" -}}
+{{     include "../install/ubuntu/server/starship.sh" }}
 {{   end -}}
 {{ end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_50-server-install-mics.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_50-server-install-mics.sh.tmpl
@@ -3,5 +3,9 @@
 {{     if eq .system "server" -}}
 {{       include "../install/ubuntu/server/misc.sh" }}
 {{     end -}}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     if eq .system "server" -}}
+{{       include "../install/rocky/server/misc.sh" }}
+{{     end -}}
 {{   end -}}
 {{ end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_50-server-setup-locale.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_50-server-setup-locale.sh.tmpl
@@ -3,5 +3,9 @@
 {{     if eq .system "server" -}}
 {{       include "../install/ubuntu/server/setup_locale.sh" }}
 {{     end -}}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     if eq .system "server" -}}
+{{       include "../install/rocky/server/setup_locale.sh" }}
+{{     end -}}
 {{   end -}}
 {{ end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_before_40-setup-timezone.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_before_40-setup-timezone.sh.tmpl
@@ -1,6 +1,8 @@
 {{ if eq .chezmoi.os "linux" -}}
 {{   if eq .chezmoi.osRelease.idLike "debian" -}}
 {{     include "../install/ubuntu/common/setup_timezone.sh" }}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     include "../install/rocky/common/setup_timezone.sh" }}
 {{   else -}}
 {{     fail (printf "Invalid linux distribution: %s" .chezmoi.osRelease.id) }}
 {{   end -}}

--- a/home/.chezmoiscripts/ubuntu/run_once_before_50-common-dependencies.sh.tmpl
+++ b/home/.chezmoiscripts/ubuntu/run_once_before_50-common-dependencies.sh.tmpl
@@ -1,6 +1,8 @@
 {{ if eq .chezmoi.os "linux" -}}
 {{   if eq .chezmoi.osRelease.idLike "debian" -}}
 {{     include "../install/ubuntu/common/dependencies.sh" }}
+{{   else if eq .chezmoi.osRelease.id "rocky" -}}
+{{     include "../install/rocky/common/dependencies.sh" }}
 {{   else -}}
 {{     fail (printf "Invalid linux distribution: %s" .chezmoi.osRelease.id) }}
 {{   end -}}

--- a/home/dot_tmux.conf.tmpl
+++ b/home/dot_tmux.conf.tmpl
@@ -2,8 +2,8 @@
 
     Choices: client and server
 
-    macos, ubuntu (client) -> client 
-    ubuntu (server) -> server
+    macOS, Ubuntu (client) -> client
+    Ubuntu, Rocky Linux (server) -> server
 
 */ -}}
 
@@ -22,7 +22,7 @@
 {{ else if eq .system "server" -}}
 {{   include "dot_tmux.conf.d/system/server.conf" }}
 {{   if eq .chezmoi.os "linux" -}}
-{{     if eq .chezmoi.osRelease.idLike "debian" -}}
+{{     if or (eq .chezmoi.osRelease.idLike "debian") (eq .chezmoi.osRelease.id "rocky") -}}
 {{       include "dot_tmux.conf.d/os/ubuntu_server.conf" }}
 {{     else -}}
 {{       fail (printf "Unknown Linux OS: %s" .chezmoi.osRelease.idLike) }}

--- a/install/rocky/common/dependencies.sh
+++ b/install/rocky/common/dependencies.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/common/dependencies.sh
+# @brief Install essential Rocky Linux packages.
+# @description
+#   Maps required commands to Rocky Linux package names and installs only the
+#   packages whose commands are missing.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly COMMAND_PACKAGES=(
+    "cmake:cmake"
+    "curl:curl"
+    "git:git"
+    "gpg:gnupg2"
+    "htop:htop"
+    "ip:iproute"
+    "ping:iputils"
+    "sudo:sudo"
+    "unzip:unzip"
+    "vim:vim-enhanced"
+    "wget:wget"
+    "zsh:zsh"
+)
+
+#
+# @description Run DNF as root or through sudo while preserving proxy variables.
+# @arg $@ string Arguments passed to DNF.
+#
+function run_dnf() {
+    if [ "${EUID}" -eq 0 ]; then
+        dnf "$@"
+        return
+    fi
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy dnf "$@"
+}
+
+#
+# @description Install packages for commands that are not currently available.
+#
+function install_dnf_packages() {
+    local command_package command_name package_name
+    local missing_packages=()
+
+    for command_package in "${COMMAND_PACKAGES[@]}"; do
+        command_name="${command_package%%:*}"
+        package_name="${command_package#*:}"
+        if ! command -v "${command_name}" > /dev/null 2>&1; then
+            missing_packages+=("${package_name}")
+        fi
+    done
+
+    if [ "${#missing_packages[@]}" -eq 0 ]; then
+        return 0
+    fi
+
+    run_dnf install -y "${missing_packages[@]}"
+}
+
+#
+# @description Install the required Rocky Linux dependencies.
+#
+function main() {
+    install_dnf_packages
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/common/setup_timezone.sh
+++ b/install/rocky/common/setup_timezone.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/common/setup_timezone.sh
+# @brief Configure the Rocky Linux timezone.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly TIMEZONE="${DOTFILES_TIMEZONE:-Asia/Tokyo}"
+
+#
+# @description Apply the repository's preferred timezone with systemd.
+#
+function setup_timezone() {
+    if cmp -s /etc/localtime "/usr/share/zoneinfo/${TIMEZONE}"; then
+        return 0
+    fi
+
+    sudo timedatectl set-timezone "${TIMEZONE}"
+}
+
+#
+# @description Configure the Rocky Linux timezone.
+#
+function main() {
+    setup_timezone
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/common/ssh.sh
+++ b/install/rocky/common/ssh.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/common/ssh.sh
+# @brief Install the OpenSSH client on Rocky Linux.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly PACKAGES=(
+    openssh-clients
+)
+
+#
+# @description Install the Rocky Linux OpenSSH client package.
+#
+function install_openssh() {
+    if command -v ssh > /dev/null 2>&1; then
+        return 0
+    fi
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy dnf install -y "${PACKAGES[@]}"
+}
+
+#
+# @description Run the OpenSSH client installation flow.
+#
+function main() {
+    install_openssh
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/common/tmux.sh
+++ b/install/rocky/common/tmux.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/common/tmux.sh
+# @brief Install tmux on Rocky Linux.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly PACKAGES=(
+    tmux
+)
+
+#
+# @description Install the Rocky Linux tmux package.
+#
+function install_tmux() {
+    if command -v tmux > /dev/null 2>&1; then
+        return 0
+    fi
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy dnf install -y "${PACKAGES[@]}"
+}
+
+#
+# @description Run the Rocky Linux tmux installation flow.
+#
+function main() {
+    install_tmux
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/server/misc.sh
+++ b/install/rocky/server/misc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/server/misc.sh
+# @brief Install optional Rocky Linux server packages.
+# @description
+#   Installs the OpenGL runtime required by OpenCV-based server workloads.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly PACKAGES=(
+    mesa-libGL
+)
+
+#
+# @description Install the OpenGL runtime when it is unavailable.
+#
+function main() {
+    if ldconfig -p 2> /dev/null | grep -F 'libGL.so.1' > /dev/null; then
+        return 0
+    fi
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy dnf install -y "${PACKAGES[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/server/setup_locale.sh
+++ b/install/rocky/server/setup_locale.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/server/setup_locale.sh
+# @brief Ensure the preferred locale exists on Rocky Linux servers.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly TARGET="en_US.UTF-8"
+
+#
+# @description Normalize a locale name for punctuation-insensitive comparison.
+# @arg $1 string Locale name.
+# @stdout Lowercase locale name without punctuation.
+#
+function normalize_locale() {
+    printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '_.-'
+}
+
+#
+# @description Install and select the target locale when it is unavailable.
+#
+function main() {
+    local available_locale target_normalized
+
+    target_normalized="$(normalize_locale "${TARGET}")"
+    while IFS= read -r available_locale; do
+        if [ "$(normalize_locale "${available_locale}")" = "${target_normalized}" ]; then
+            printf '%s already exists.\n' "${TARGET}"
+            return 0
+        fi
+    done < <(locale -a 2> /dev/null)
+
+    sudo --preserve-env=http_proxy,https_proxy,no_proxy dnf install -y glibc-langpack-en
+    sudo localectl set-locale "LANG=${TARGET}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/server/ssh_server.sh
+++ b/install/rocky/server/ssh_server.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# @file install/rocky/server/ssh_server.sh
+# @brief Allow SSH clients to provide proxy environment variables.
+# @description
+#   Merges a narrow proxy-variable allowlist into the global Rocky Linux sshd
+#   configuration, validates a candidate file, and reloads sshd. A failed
+#   reload restores the previous configuration.
+
+set -Eeuo pipefail
+
+if [ "${DOTFILES_DEBUG:-}" ]; then
+    set -x
+fi
+
+readonly SSHD_CONFIG_PATH="${DOTFILES_SSHD_CONFIG_PATH:-/etc/ssh/sshd_config}"
+readonly SSHD_COMMAND="${DOTFILES_SSHD_COMMAND:-/usr/sbin/sshd}"
+readonly SYSTEMCTL_COMMAND="${DOTFILES_SYSTEMCTL_COMMAND:-systemctl}"
+
+#
+# @description Render sshd_config with proxy names merged into global AcceptEnv.
+# @stdout The complete candidate sshd configuration.
+#
+function render_sshd_config() {
+    sudo awk '
+        function add_value(value) {
+            if (!seen[value]++) {
+                values[++value_count] = value
+            }
+        }
+
+        function emit_accept_env() {
+            if (accept_env_emitted) {
+                return
+            }
+
+            add_value("HTTP_PROXY")
+            add_value("HTTPS_PROXY")
+            add_value("NO_PROXY")
+            add_value("http_proxy")
+            add_value("https_proxy")
+            add_value("no_proxy")
+
+            printf "AcceptEnv"
+            for (index = 1; index <= value_count; index++) {
+                printf " %s", values[index]
+            }
+            printf "\n"
+            accept_env_emitted = 1
+        }
+
+        tolower($1) == "match" && !in_match {
+            emit_accept_env()
+            in_match = 1
+        }
+
+        !in_match && tolower($1) == "acceptenv" {
+            for (index = 2; index <= NF; index++) {
+                add_value($index)
+            }
+            next
+        }
+
+        { print }
+
+        END {
+            if (!accept_env_emitted) {
+                emit_accept_env()
+            }
+        }
+    ' "${SSHD_CONFIG_PATH}"
+}
+
+#
+# @description Install, validate, and activate the proxy environment allowlist.
+# @stderr Validation or reload failures from sshd and systemctl.
+# @exitcode 0 When the active configuration contains the allowlist.
+# @exitcode 1 When validation, installation, or reload fails.
+#
+function configure_proxy_accept_env() {
+    local backup_path candidate_path
+
+    candidate_path="$(mktemp)"
+    backup_path="${SSHD_CONFIG_PATH}.backup.$$"
+    render_sshd_config > "${candidate_path}"
+
+    if sudo cmp -s "${candidate_path}" "${SSHD_CONFIG_PATH}"; then
+        rm -f "${candidate_path}"
+        return 0
+    fi
+
+    if ! sudo "${SSHD_COMMAND}" -t -f "${candidate_path}"; then
+        rm -f "${candidate_path}"
+        return 1
+    fi
+
+    sudo cp -p "${SSHD_CONFIG_PATH}" "${backup_path}"
+    if ! sudo cp "${candidate_path}" "${SSHD_CONFIG_PATH}"; then
+        sudo mv "${backup_path}" "${SSHD_CONFIG_PATH}"
+        rm -f "${candidate_path}"
+        return 1
+    fi
+    rm -f "${candidate_path}"
+
+    if ! sudo "${SYSTEMCTL_COMMAND}" reload sshd; then
+        sudo mv "${backup_path}" "${SSHD_CONFIG_PATH}"
+        sudo "${SSHD_COMMAND}" -t && sudo "${SYSTEMCTL_COMMAND}" reload sshd
+        return 1
+    fi
+
+    sudo rm -f "${backup_path}"
+}
+
+#
+# @description Configure sshd to accept proxy variables from SSH clients.
+#
+function main() {
+    configure_proxy_accept_env
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/install/rocky/server/ssh_server.sh
+++ b/install/rocky/server/ssh_server.sh
@@ -42,8 +42,8 @@ function render_sshd_config() {
             add_value("no_proxy")
 
             printf "AcceptEnv"
-            for (index = 1; index <= value_count; index++) {
-                printf " %s", values[index]
+            for (i = 1; i <= value_count; i++) {
+                printf " %s", values[i]
             }
             printf "\n"
             accept_env_emitted = 1
@@ -55,8 +55,8 @@ function render_sshd_config() {
         }
 
         !in_match && tolower($1) == "acceptenv" {
-            for (index = 2; index <= NF; index++) {
-                add_value($index)
+            for (i = 2; i <= NF; i++) {
+                add_value($i)
             }
             next
         }

--- a/install/ubuntu/server/starship.sh
+++ b/install/ubuntu/server/starship.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @file install/ubuntu/server/starship.sh
-# @brief Install the Starship prompt on Ubuntu servers.
+# @brief Install the Starship prompt on Linux servers.
 # @description
 #   Downloads the upstream Starship installer and places the binary in the
 #   user's local bin directory.
@@ -24,7 +24,7 @@ function install_starship() {
 
     mkdir -p "${BIN_DIR}"
 
-    curl -sS "${url}" | dash -s -- \
+    curl -sS "${url}" | sh -s -- \
         --yes \
         --version "${version}" \
         --bin-dir "${BIN_DIR}"

--- a/tests/install/rocky/common/dependencies_unit.bats
+++ b/tests/install/rocky/common/dependencies_unit.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/rocky/common/dependencies.sh"
+
+@test "[rocky-common] install_dnf_packages installs missing command packages" {
+    run bash -c '
+        source "$1"
+
+        function command() {
+            [ "$2" != "tmux" ]
+        }
+        function sudo() {
+            printf "%s\n" "$*"
+        }
+
+        install_dnf_packages
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"dnf install -y tmux"* ]]
+}
+
+@test "[rocky-common] install_dnf_packages skips dnf when commands exist" {
+    run bash -c '
+        source "$1"
+
+        function command() {
+            return 0
+        }
+        function sudo() {
+            return 99
+        }
+
+        install_dnf_packages
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+}
+
+@test "[rocky-common] dependency packages use Rocky names" {
+    run grep -F 'ip:iproute' "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'ping:iputils' "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'gpg:gnupg2' "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_TEMPLATE_DIR="./home/.chezmoiscripts/ubuntu"
+
+@test "[rocky-common] required Linux templates route Rocky Linux to Rocky scripts" {
+    local template
+
+    for template in \
+        run_once_00-setup-ssh.sh.tmpl \
+        run_once_08-install-tmux.sh.tmpl \
+        run_once_before_40-setup-timezone.sh.tmpl \
+        run_once_before_50-common-dependencies.sh.tmpl; do
+        run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${SCRIPT_TEMPLATE_DIR}/${template}"
+        [ "${status}" -eq 0 ]
+        run grep -F '../install/rocky/' "${SCRIPT_TEMPLATE_DIR}/${template}"
+        [ "${status}" -eq 0 ]
+    done
+}
+
+@test "[rocky-server] server templates route Rocky Linux to Rocky scripts" {
+    local template
+
+    for template in \
+        run_once_50-server-install-mics.sh.tmpl \
+        run_once_50-server-setup-locale.sh.tmpl; do
+        run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${SCRIPT_TEMPLATE_DIR}/${template}"
+        [ "${status}" -eq 0 ]
+        run grep -F '../install/rocky/server/' "${SCRIPT_TEMPLATE_DIR}/${template}"
+        [ "${status}" -eq 0 ]
+    done
+}
+
+@test "[rocky-server] Starship installer uses the portable system shell" {
+    run grep -F 'curl -sS "${url}" | sh -s --' ./install/ubuntu/server/starship.sh
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -48,3 +48,12 @@ readonly TMUX_TEMPLATE="./home/dot_tmux.conf.tmpl"
     run grep -F 'include "dot_tmux.conf.d/os/ubuntu_server.conf"' "${TMUX_TEMPLATE}"
     [ "${status}" -eq 0 ]
 }
+
+@test "[rocky-server] SSH environment template configures the Rocky server" {
+    local template="./home/.chezmoiscripts/rocky/run_once_50-server-configure-ssh-env.sh.tmpl"
+
+    run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${template}"
+    [ "${status}" -eq 0 ]
+    run grep -F '../install/rocky/server/ssh_server.sh' "${template}"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 readonly SCRIPT_TEMPLATE_DIR="./home/.chezmoiscripts/ubuntu"
+readonly EXTERNAL_TEMPLATE="./home/.chezmoiexternal.yaml.tmpl"
 
 @test "[rocky-common] required Linux templates route Rocky Linux to Rocky scripts" {
     local template
@@ -32,5 +33,10 @@ readonly SCRIPT_TEMPLATE_DIR="./home/.chezmoiscripts/ubuntu"
 
 @test "[rocky-server] Starship installer uses the portable system shell" {
     run grep -F 'curl -sS "${url}" | sh -s --' ./install/ubuntu/server/starship.sh
+    [ "${status}" -eq 0 ]
+}
+
+@test "[rocky-common] external template accepts Rocky Linux" {
+    run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${EXTERNAL_TEMPLATE}"
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -2,6 +2,7 @@
 
 readonly SCRIPT_TEMPLATE_DIR="./home/.chezmoiscripts/ubuntu"
 readonly EXTERNAL_TEMPLATE="./home/.chezmoiexternal.yaml.tmpl"
+readonly TMUX_TEMPLATE="./home/dot_tmux.conf.tmpl"
 
 @test "[rocky-common] required Linux templates route Rocky Linux to Rocky scripts" {
     local template
@@ -38,5 +39,12 @@ readonly EXTERNAL_TEMPLATE="./home/.chezmoiexternal.yaml.tmpl"
 
 @test "[rocky-common] external template accepts Rocky Linux" {
     run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${EXTERNAL_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "[rocky-server] tmux template accepts Rocky Linux" {
+    run grep -F 'eq .chezmoi.osRelease.id "rocky"' "${TMUX_TEMPLATE}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'include "dot_tmux.conf.d/os/ubuntu_server.conf"' "${TMUX_TEMPLATE}"
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/rocky/server/ssh_server_unit.bats
+++ b/tests/install/rocky/server/ssh_server_unit.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+readonly SCRIPT_PATH="./install/rocky/server/ssh_server.sh"
+
+function setup() {
+    export DOTFILES_SSHD_CONFIG_PATH="${BATS_TEST_TMPDIR}/sshd_config"
+    export DOTFILES_SSHD_COMMAND=true
+    export DOTFILES_SYSTEMCTL_COMMAND=true
+    printf '%s\n' \
+        'Port 22' \
+        'AcceptEnv LANG LC_*' \
+        'Match User nobody' \
+        '    X11Forwarding no' > "${DOTFILES_SSHD_CONFIG_PATH}"
+
+    function sudo() {
+        "$@"
+    }
+    export -f sudo
+}
+
+@test "[rocky-server] configure_proxy_accept_env preserves global names and adds proxies before Match" {
+    run bash -c '
+        source "$1"
+        configure_proxy_accept_env
+        awk "/^AcceptEnv|^Match/ { print }" "${DOTFILES_SSHD_CONFIG_PATH}"
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "AcceptEnv LANG LC_* HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy" ]
+    [ "${lines[1]}" = "Match User nobody" ]
+}
+
+@test "[rocky-server] configure_proxy_accept_env is idempotent" {
+    run bash -c '
+        source "$1"
+        configure_proxy_accept_env
+        first_checksum=$(cksum "${DOTFILES_SSHD_CONFIG_PATH}")
+        configure_proxy_accept_env
+        second_checksum=$(cksum "${DOTFILES_SSHD_CONFIG_PATH}")
+        [ "${first_checksum}" = "${second_checksum}" ]
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+}
+
+@test "[rocky-server] configure_proxy_accept_env leaves the original file when validation fails" {
+    export DOTFILES_SSHD_COMMAND=false
+
+    run bash -c '
+        source "$1"
+        configure_proxy_accept_env || true
+        cat "${DOTFILES_SSHD_CONFIG_PATH}"
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "Port 22" ]
+    [ "${lines[1]}" = "AcceptEnv LANG LC_*" ]
+    [ "${lines[2]}" = "Match User nobody" ]
+}


### PR DESCRIPTION
## Summary

- add DNF-based setup scripts for Rocky Linux servers
- support timezone, SSH, tmux, locale, OpenGL, and Starship setup
- route chezmoi templates based on Rocky Linux OS metadata
- document Rocky Linux server support in README

## Validation

- ShellCheck passed
- shfmt passed
- all affected templates rendered with Rocky Linux 9 server data
- prerequisites checked on a Rocky Linux 9.7 host
- Bats tests added for CI

## References

- Rocky Linux DNF documentation
- Rocky Linux toolbox implementation
- Starship installation guide