### PR TITLE
Cap Ubuntu build jobs at 15 minutes

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -39,6 +39,7 @@ jobs:
     # Dependabot PRs and forked PRs do not receive required repository secrets.
     # Skip this job early instead of failing at the SSH key setup step.
     if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    timeout-minutes: 15
     strategy:
       matrix:
         system: [server, client]


### PR DESCRIPTION
Normal Ubuntu matrix jobs finish in about three minutes, but both jobs in [shunk031/dotfiles#596](https://github.com/shunk031/dotfiles/pull/596) remained in Setup dotfiles for more than 30 minutes. Set `jobs.build.timeout-minutes` to 15 so a future hang cannot run indefinitely.