### PR TITLE
fix(starship): run installer in POSIX mode

### DIFF
--- a/install/ubuntu/server/starship.sh
+++ b/install/ubuntu/server/starship.sh
@@ -24,7 +24,7 @@ function install_starship() {
 
     mkdir -p "${BIN_DIR}"
 
-    curl -sS "${url}" | sh -s -- \
+    curl -sS "${url}" | POSIXLY_CORRECT=1 sh -s -- \
         --yes \
         --version "${version}" \
         --bin-dir "${BIN_DIR}"

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -33,7 +33,7 @@ readonly TMUX_TEMPLATE="./home/dot_tmux.conf.tmpl"
 }
 
 @test "[rocky-server] Starship installer uses the portable system shell" {
-    run grep -F 'curl -sS "${url}" | sh -s --' ./install/ubuntu/server/starship.sh
+    run grep -F 'curl -sS "${url}" | POSIXLY_CORRECT=1 sh -s --' ./install/ubuntu/server/starship.sh
     [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## Why

The downloaded Starship installer runs through the system shell. Explicitly setting `POSIXLY_CORRECT=1` for that installer process selects the portable POSIX option-parsing behavior expected by this installation path and avoids shell-specific parsing failures.

This follows Starship's documented installation flow and official installer source: [installation documentation](https://starship.rs/installing/) and [installer source](https://github.com/starship/starship/blob/master/install/install.sh).

## What Changed

- Updated `install/ubuntu/server/starship.sh` to pipe the downloaded installer through `POSIXLY_CORRECT=1 sh -s --`.
- Updated the exact expected command assertion in `tests/install/rocky/common/templates.bats`.
- The scope is exactly two files and exactly two line replacements. There is no wrapper, branching, configuration change, new feature, broad rewrite, or unrelated cleanup.

## Validation

- `make setup`
- `git diff --check`
- `bash -n install/ubuntu/server/starship.sh`
- `grep -F 'curl -sS "${url}" | POSIXLY_CORRECT=1 sh -s --' install/ubuntu/server/starship.sh`
- `prek run --files install/ubuntu/server/starship.sh tests/install/rocky/common/templates.bats`

The host `/bin/sh` POSIX guard probe also passed. Bats was not run locally because repository policy delegates it to GitHub Actions.