### PR TITLE
fix: install Rocky Linux pinentry

### DIFF
--- a/home/private_dot_gnupg/gpg-agent.conf.tmpl
+++ b/home/private_dot_gnupg/gpg-agent.conf.tmpl
@@ -4,6 +4,8 @@ pinentry-program /opt/homebrew/bin/pinentry-mac
 {{-   else -}}
 pinentry-program /usr/local/bin/pinentry-mac
 {{-   end -}}
+{{- else if eq .chezmoi.osRelease.id "rocky" }}
+pinentry-program /usr/bin/pinentry-curses
 {{- end }}
 max-cache-ttl 60480000
 default-cache-ttl 60480000

--- a/install/rocky/common/dependencies.sh
+++ b/install/rocky/common/dependencies.sh
@@ -17,6 +17,7 @@ readonly COMMAND_PACKAGES=(
     "curl:curl"
     "git:git"
     "gpg:gnupg2"
+    "pinentry-curses:pinentry"
     "htop:htop"
     "ip:iproute"
     "ping:iputils"

--- a/tests/install/rocky/common/dependencies_unit.bats
+++ b/tests/install/rocky/common/dependencies_unit.bats
@@ -38,6 +38,24 @@ readonly SCRIPT_PATH="./install/rocky/common/dependencies.sh"
     [ -z "${output}" ]
 }
 
+@test "[rocky-common] install_dnf_packages installs the terminal pinentry package when missing" {
+    run bash -c '
+        source "$1"
+
+        function command() {
+            [ "$2" != "pinentry-curses" ]
+        }
+        function sudo() {
+            printf "%s\n" "$*"
+        }
+
+        install_dnf_packages
+    ' _ "${SCRIPT_PATH}"
+
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"dnf install -y pinentry"* ]]
+}
+
 @test "[rocky-common] dependency packages use Rocky names" {
     run grep -F 'ip:iproute' "${SCRIPT_PATH}"
     [ "${status}" -eq 0 ]
@@ -46,5 +64,8 @@ readonly SCRIPT_PATH="./install/rocky/common/dependencies.sh"
     [ "${status}" -eq 0 ]
 
     run grep -F 'gpg:gnupg2' "${SCRIPT_PATH}"
+    [ "${status}" -eq 0 ]
+
+    run grep -F 'pinentry-curses:pinentry' "${SCRIPT_PATH}"
     [ "${status}" -eq 0 ]
 }

--- a/tests/install/rocky/common/templates.bats
+++ b/tests/install/rocky/common/templates.bats
@@ -57,3 +57,12 @@ readonly TMUX_TEMPLATE="./home/dot_tmux.conf.tmpl"
     run grep -F '../install/rocky/server/ssh_server.sh' "${template}"
     [ "${status}" -eq 0 ]
 }
+
+@test "[rocky-common] GPG agent template selects the Rocky terminal pinentry" {
+    local template="./home/private_dot_gnupg/gpg-agent.conf.tmpl"
+
+    run grep -F 'else if eq .chezmoi.osRelease.id "rocky"' "${template}"
+    [ "${status}" -eq 0 ]
+    run grep -F 'pinentry-program /usr/bin/pinentry-curses' "${template}"
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Install Rocky Linux's `pinentry` package when `pinentry-curses` is missing.
- Configure Rocky Linux `gpg-agent` to use `/usr/bin/pinentry-curses`.
- Add regression coverage for the dependency mapping and template branch.

## Validation

- `make setup` (with temporary `MISE_TRUSTED_CONFIG_PATHS=/home/ly-2027476`)
- `bash -n install/rocky/common/dependencies.sh`
- `shellcheck install/rocky/common/dependencies.sh`
- `shfmt --diff --indent 4 --space-redirects install/rocky/common/dependencies.sh`
- Rocky template render via `chezmoi execute-template`
- `git diff --check`
- `prek run --files ...`

Bats was not run locally because the repository policy requires GitHub Actions for Bats.