### PR TITLE
fix(mise): require v2026.8.15 for npm install repair

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -1,7 +1,7 @@
 # Minimum mise version compatible with this dotfiles configuration.
 # Raise this only when a configuration or tool change requires newer mise behavior.
-# Declarative system bootstrap requires mise 2026.8.2 or newer.
-min_version = "2026.8.2"
+# Declarative system bootstrap and automatic dangling npm install repair require mise 2026.8.15 or newer.
+min_version = "2026.8.15"
 
 [tools]
 # Keep each group sorted by package name, ignoring backend prefixes and leading `@`.

--- a/tests/install/common/mise.bats
+++ b/tests/install/common/mise.bats
@@ -216,18 +216,18 @@ function run_mise_bash_startup() {
     [[ "${output}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
 }
 
-@test "[common] mise version supports declarative system bootstrap" {
+@test "[common] mise version supports declarative system bootstrap and dangling npm install repair" {
     local min_version
 
     min_version="$(get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}")"
-    run is_mise_version_at_least "${min_version}" "2026.8.2"
+    run is_mise_version_at_least "${min_version}" "2026.8.15"
     [ "${status}" -eq 0 ]
 }
 
 @test "[common] mise config pins fnox for command-backed authentication" {
     run get_mise_min_version_from_config "${MISE_CONFIG_SOURCE}"
     [ "${status}" -eq 0 ]
-    [ "${output}" = "2026.8.2" ]
+    [ "${output}" = "2026.8.15" ]
 
     run awk '
         /^\[tools\]$/ { in_tools = 1; next }


### PR DESCRIPTION
## Why

`chezmoi apply` can fail when mise encounters a dangling embedded-aube npm installation. mise v2026.8.15 includes the automatic repair for this state ([jdx/mise#12570](https://github.com/jdx/mise/pull/12570)), so the dotfiles minimum must move to that release.

## What Changed

- Raise `home/dot_mise/config.toml` `min_version` from `2026.8.2` to `2026.8.15`.
- Document that the minimum includes automatic repair for dangling npm installs.
- Update `tests/install/common/mise.bats` to require and assert `2026.8.15`.

The minimum mise requirement for this repository is now v2026.8.15 or newer.

## Validation

The repository setup completed successfully before the edits.

Inspect the committed diff for formatting issues.

```shell
git diff HEAD^ HEAD --check
```

The existing repository helper reads `min_version = "2026.8.15"` from the updated config.

The Bats suite is delegated to GitHub Actions per repository policy and was not run locally.
