### PR TITLE
fix(skills): unregister entries after pool removal

### DIFF
--- a/install/common/skills.sh
+++ b/install/common/skills.sh
@@ -505,6 +505,9 @@ function prune_candidate_names() {
 #   only way to reach this case is for the private source to be gone or to have
 #   failed to apply, and then removal is the correct answer.
 #
+#   Remove the pool entry before `skills remove` so the CLI sees no remaining
+#   universal-agent install path and clears the skill from its registry.
+#
 function prune_unlisted_skills() {
     local name
 
@@ -515,6 +518,8 @@ function prune_unlisted_skills() {
             continue
         fi
 
+        remove_pool_entry "${name}"
+
         if ! skills_cli remove \
             --skill "${name}" \
             "${SKILLS_AGENT_FLAGS[@]}" \
@@ -522,8 +527,6 @@ function prune_unlisted_skills() {
             --yes; then
             echo "skills: could not unregister ${name}" >&2
         fi
-
-        remove_pool_entry "${name}"
     done < <(prune_candidate_names)
 }
 

--- a/tests/install/common/skills.bats
+++ b/tests/install/common/skills.bats
@@ -135,6 +135,30 @@ EOF
     [ "${output}" = "remove --skill shunk031-gh-comment-attach-files --agent claude-code --agent codex --global --yes" ]
 }
 
+@test "[common] prune removes the pool entry before unregistering the skill" {
+    write_mise_stub
+    local pool_state_path="${BATS_TEST_TMPDIR}/pool-state.txt"
+    export pool_state_path
+    cat > "${BATS_TEST_TMPDIR}/bin/skills" << EOF
+#!/usr/bin/env bash
+if [ -d "${SKILLS_POOL}/shunk031-retired" ]; then
+    printf '%s\n' present > "\${pool_state_path}"
+else
+    printf '%s\n' absent > "\${pool_state_path}"
+fi
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/skills"
+
+    mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"
+    printf '%s\n' shunk031-retired > "${SKILLS_MANIFEST}"
+
+    prune_unlisted_skills
+
+    run cat "${pool_state_path}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = absent ]
+}
+
 @test "[common] prune removes a manifest skill the allowlist dropped" {
     write_mise_stub
     mkdir -p "${SKILLS_STATE_DIR}" "${SKILLS_POOL}/shunk031-retired"


### PR DESCRIPTION
`skills update` prints: `appear to have been deleted upstream ... Skipping deletion in non-interactive mode`.

`prune_unlisted_skills` called `skills remove` before deleting the shared pool directory.
The CLI treats the universal agent's pool path as an active install, so it retained the registry entry after the directory was deleted.

The function now removes the pool directory first, then invokes the same scoped `skills remove` command.