### PR TITLE
fix(mise): install Python from precompiled binaries only

### DIFF
--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -72,6 +72,7 @@ sqlite = "3.53.4"
 [settings]
 idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"
+python.compile = false
 ruby.compile = false
 minimum_release_age_excludes = [
   "aqua:anthropics/claude-code",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -70,12 +70,20 @@ sqlite = "3.53.4"
 "npm:textlint-rule-ja-space-between-half-and-full-width" = "3.0.3"
 
 [settings]
+# Version files: honor idiomatic files such as `.python-version`.
 idiomatic_version_file_enable_tools = ["python"]
+
+# Release policy: wait before adopting new releases, except for fast-moving agent CLIs.
 minimum_release_age = "7d"
-python.compile = false
-ruby.compile = false
 minimum_release_age_excludes = [
   "aqua:anthropics/claude-code",
   "aqua:google-antigravity/antigravity-cli",
   "aqua:openai/codex",
 ]
+
+# Language runtimes: install precompiled binaries only; never build from source.
+[settings.python]
+compile = false
+
+[settings.ruby]
+compile = false


### PR DESCRIPTION
## Summary

Set `python.compile = false` in `home/dot_mise/config.toml` so mise installs Python from python-build-standalone precompiled binaries only.

With the setting unset, mise uses a precompiled binary when one is available and otherwise falls back to compiling from source with `python-build`. That fallback is silent, and on a host without the `python-build` dependency set it yields a Python that imports but is missing most stdlib extension modules.

Setting it to `false` makes mise fail loudly when no precompiled binary exists for the requested version, instead of producing a broken interpreter. This mirrors `ruby.compile = false`, added in https://github.com/shunk031/dotfiles/pull/562.

Installing the full `python-build` dependency set was considered and rejected. It requires `libssl-dev` plus roughly a dozen more `-dev` packages on both Ubuntu and Rocky, and a source build can still silently drop a module when one of them is absent.

A second commit then regroups the `[settings]` block into three commented sections, version files, release policy, and language runtimes, moving the compile toggles into `[settings.python]` and `[settings.ruby]` sub-tables without changing any value.

## Root cause

On an Ubuntu 24.04 host without Python build dependencies, `mise install python@3.12.14` (pulled in by a project's `.python-version`) compiled from source and produced an interpreter with no `_ssl`, `zlib`, `bz2`, `lzma`, `sqlite3`, `readline`, `_ctypes`, `_curses`, `_uuid`, `_gdbm`, or `tkinter`.

Any `python3` invoked in that project directory then failed on every HTTPS request with `unknown url type: https`. In the Codex `SessionStart` hook this surfaced as a misleading `GenAI Gateway connection failed` message, which pointed at the network rather than at the interpreter.

## Validation

Reinstall the affected version with compilation disabled and confirm a precompiled binary is used.

```shell
mise uninstall python@3.12.14 && MISE_PYTHON_COMPILE=false mise install python@3.12.14
```

The install completed in 2.3 s from `cpython-3.12.14+20260901-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz`.

Confirm the previously missing stdlib extension modules now import.

```shell
python3 -c 'import ssl, zlib, bz2, lzma, sqlite3, readline, ctypes; print(ssl.OPENSSL_VERSION)'
```

All imports succeed and the interpreter reports OpenSSL 3.5.8.

Confirm the regrouping is a pure reformat by parsing the `[settings]` table before and after and comparing the results.

```shell
python3 -c 'import tomllib; print(tomllib.load(open("home/dot_mise/config.toml","rb"))["settings"])'
```

The parsed table is identical across both commits.

The Codex `SessionStart` Gateway hook, run from the affected project directory with the Codex process environment, now completes normally in 1.1 s instead of reporting both Gateway URLs as unreachable.

`bats` coverage runs in GitHub Actions on this pull request, per the repository test policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BYGxLCyBodua2WczGJcnr
