### PR TITLE
fix(renovate): keep fnox out of day-zero updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,11 @@
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
-  "minimumReleaseAge": "7 days",
+  "description": [
+    "Keep minimumReleaseAge strictly longer than minimum_release_age in home/dot_mise/config.toml.",
+    "Renovate measures age from the release timestamp while mise measures it from the packslip transparency log entry, which is always later, so equal values let Renovate pin a version mise still refuses to install."
+  ],
+  "minimumReleaseAge": "8 days",
   "internalChecksFilter": "strict",
   "mise": {
     "managerFilePatterns": [
@@ -40,8 +44,12 @@
     },
     {
       "matchManagers": ["mise"],
+      "description": [
+        "Tools whose newest release is time-sensitive enough to skip the cooling-off period.",
+        "Every entry must also appear in minimum_release_age_excludes in home/dot_mise/config.toml, or mise refuses to install what Renovate pins here.",
+        "fnox is deliberately absent: it stores credentials, so it keeps the cooling-off period that signature and transparency log verification cannot replace."
+      ],
       "matchDepNames": [
-        "fnox",
         "herdr",
         "aqua:anthropics/claude-code",
         "aqua:google-antigravity/antigravity-cli",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
   "description": [
-    "Keep minimumReleaseAge strictly longer than minimum_release_age in home/dot_mise/config.toml.",
+    "Keep `minimumReleaseAge` strictly longer than `minimum_release_age` in `home/dot_mise/config.toml`.",
     "Renovate measures age from the release timestamp while mise measures it from the packslip transparency log entry, which is always later, so equal values let Renovate pin a version mise still refuses to install."
   ],
   "minimumReleaseAge": "8 days",
@@ -46,8 +46,8 @@
       "matchManagers": ["mise"],
       "description": [
         "Tools whose newest release is time-sensitive enough to skip the cooling-off period.",
-        "Every entry must also appear in minimum_release_age_excludes in home/dot_mise/config.toml, or mise refuses to install what Renovate pins here.",
-        "fnox is deliberately absent: it stores credentials, so it keeps the cooling-off period that signature and transparency log verification cannot replace."
+        "Every entry must also appear in `minimum_release_age_excludes` in `home/dot_mise/config.toml`, or mise refuses to install what Renovate pins here.",
+        "`fnox` is deliberately absent: it stores credentials, so it keeps the cooling-off period that signature and transparency log verification cannot replace."
       ],
       "matchDepNames": [
         "herdr",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,11 +4,7 @@
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
-  "description": [
-    "Keep `minimumReleaseAge` strictly longer than `minimum_release_age` in `home/dot_mise/config.toml`.",
-    "Renovate measures age from the release timestamp while mise measures it from the packslip transparency log entry, which is always later, so equal values let Renovate pin a version mise still refuses to install."
-  ],
-  "minimumReleaseAge": "8 days",
+  "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "mise": {
     "managerFilePatterns": [
@@ -44,11 +40,6 @@
     },
     {
       "matchManagers": ["mise"],
-      "description": [
-        "Tools whose newest release is time-sensitive enough to skip the cooling-off period.",
-        "Every entry must also appear in `minimum_release_age_excludes` in `home/dot_mise/config.toml`, or mise refuses to install what Renovate pins here.",
-        "`fnox` is deliberately absent: it stores credentials, so it keeps the cooling-off period that signature and transparency log verification cannot replace."
-      ],
       "matchDepNames": [
         "herdr",
         "aqua:anthropics/claude-code",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -75,11 +75,8 @@ idiomatic_version_file_enable_tools = ["python"]
 
 # Release policy: wait before adopting new releases, except for fast-moving agent CLIs.
 minimum_release_age = "7d"
-# Keep this list identical to the `agent tooling` group in `.github/renovate.json`:
-# that group pins on release day, so anything Renovate lists there but that is missing
-# here stays refused until the cutoff passes. `fnox` is intentionally absent — it stores
-# credentials, so it keeps the cooling-off period, which signature verification cannot
-# replace.
+# Keep identical to the `agent tooling` group in `.github/renovate.json`, which pins on
+# release day. `fnox` is absent on purpose: it stores credentials, so it keeps the wait.
 minimum_release_age_excludes = [
   "herdr",
   "aqua:anthropics/claude-code",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -77,7 +77,7 @@ idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"
 # Keep this list identical to the `agent tooling` group in `.github/renovate.json`:
 # that group pins on release day, so anything Renovate lists there but that is missing
-# here stays refused until the cutoff passes. fnox is intentionally absent — it stores
+# here stays refused until the cutoff passes. `fnox` is intentionally absent — it stores
 # credentials, so it keeps the cooling-off period, which signature verification cannot
 # replace.
 minimum_release_age_excludes = [

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -75,8 +75,7 @@ idiomatic_version_file_enable_tools = ["python"]
 
 # Release policy: wait before adopting new releases, except for fast-moving agent CLIs.
 minimum_release_age = "7d"
-# Keep identical to the `agent tooling` group in `.github/renovate.json`, which pins on
-# release day. `fnox` is absent on purpose: it stores credentials, so it keeps the wait.
+# Keep identical to the `agent tooling` group in `.github/renovate.json`, which pins on release day.
 minimum_release_age_excludes = [
   "herdr",
   "aqua:anthropics/claude-code",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -73,7 +73,13 @@ sqlite = "3.53.4"
 idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"
 ruby.compile = false
+# Keep this list identical to the `agent tooling` group in `.github/renovate.json`.
+# That group carries `minimumReleaseAge: "0 days"`, so Renovate pins these tools on
+# release day; anything missing here is then refused by `minimum_release_age` until
+# the cutoff passes.
 minimum_release_age_excludes = [
+  "fnox",
+  "herdr",
   "aqua:anthropics/claude-code",
   "aqua:google-antigravity/antigravity-cli",
   "aqua:openai/codex",

--- a/home/dot_mise/config.toml
+++ b/home/dot_mise/config.toml
@@ -16,7 +16,7 @@ rust = "1.98.0"
 # CLI tools
 bun = "1.4.0"
 eza = "0.23.5"
-fnox = "1.35.1"
+fnox = "1.34.1"
 gcloud = "575.0.0"
 herdr = "0.9.0"
 sqlite = "3.53.4"
@@ -74,11 +74,11 @@ idiomatic_version_file_enable_tools = ["python"]
 minimum_release_age = "7d"
 ruby.compile = false
 # Keep this list identical to the `agent tooling` group in `.github/renovate.json`.
-# That group carries `minimumReleaseAge: "0 days"`, so Renovate pins these tools on
+# That group carries `minimumReleaseAge: "0 days"`, so Renovate pins those tools on
 # release day; anything missing here is then refused by `minimum_release_age` until
-# the cutoff passes.
+# the cutoff passes. fnox is intentionally absent: it stores credentials, so it keeps
+# the cooling-off period, which signature verification cannot replace.
 minimum_release_age_excludes = [
-  "fnox",
   "herdr",
   "aqua:anthropics/claude-code",
   "aqua:google-antigravity/antigravity-cli",

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -49,8 +49,7 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-# fnox is deliberately absent: it stores credentials, so it keeps the cooling-off period
-# instead of taking the day-zero updates the rest of the agent tooling gets. mise.bats
+# fnox is absent on purpose: it stores credentials, so it keeps the wait. mise.bats
 # covers that mise still pins it.
 expected_dep_names = [
     "herdr",
@@ -88,7 +87,13 @@ codex_rule = next(
     and rule.get("matchDepNames") == ["aqua:openai/codex"]
     and "extractVersion" in rule
 )
+excludes_match = re.search(
+    r"^minimum_release_age_excludes\s*=\s*\[(?P<body>[^\]]*)\]",
+    mise_text,
+    re.MULTILINE,
+)
 
+assert excludes_match is not None
 assert configured_dep_names == set(expected_dep_names)
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["antigravity-cli"].startswith("aqua:")
@@ -97,6 +102,10 @@ assert agent_rule["matchManagers"] == ["mise"]
 assert agent_rule["matchDepNames"] == expected_dep_names
 assert "fnox" not in agent_rule["matchDepNames"]
 assert agent_rule["minimumReleaseAge"] == "0 days"
+assert re.findall(r'"([^"]+)"', excludes_match.group("body")) == expected_dep_names, (
+    "minimum_release_age_excludes must mirror the day-zero group, or mise refuses to "
+    "install what Renovate pins"
+)
 assert mise_rule_index < agent_rule_index
 
 assert "matchPackageNames" not in agent_rule
@@ -109,64 +118,6 @@ python_pattern = codex_rule["extractVersion"].replace("(?<version>", "(?P<versio
 match = re.fullmatch(python_pattern, "rust-v0.146.0")
 assert match is not None
 assert match.group("version") == "0.146.0"
-PYTHON
-
-    [ "${status}" -eq 0 ]
-}
-
-@test "[common] mise exempts day-zero agent tooling from the release-age policy" {
-    run python3 - "${RENOVATE_CONFIG_PATH}" "${MISE_CONFIG_PATH}" << 'PYTHON'
-import json
-import re
-import sys
-from pathlib import Path
-
-renovate_path, mise_path = map(Path, sys.argv[1:])
-renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
-mise_text = mise_path.read_text(encoding="utf-8")
-
-agent_rule = next(
-    rule
-    for rule in renovate["packageRules"]
-    if rule.get("groupName") == "agent tooling"
-)
-
-excludes_match = re.search(
-    r"^minimum_release_age_excludes\s*=\s*\[(?P<body>[^\]]*)\]",
-    mise_text,
-    re.MULTILINE,
-)
-mise_age_match = re.search(
-    r'^minimum_release_age\s*=\s*"(?P<value>[^"]+)"',
-    mise_text,
-    re.MULTILINE,
-)
-
-
-def to_days(value):
-    match = re.fullmatch(r"(?P<count>\d+)\s*(?P<unit>d|days?|w|weeks?)", value.strip())
-    assert match is not None, f"unsupported release-age duration: {value!r}"
-    count = int(match.group("count"))
-    return count * 7 if match.group("unit").startswith("w") else count
-
-
-assert agent_rule["minimumReleaseAge"] == "0 days"
-assert excludes_match is not None
-assert mise_age_match is not None
-assert re.findall(r'"([^"]+)"', excludes_match.group("body")) == (
-    agent_rule["matchDepNames"]
-), (
-    "minimum_release_age_excludes must mirror the Renovate agent tooling group; "
-    "otherwise mise refuses to install the day-zero versions Renovate pins"
-)
-
-# Renovate measures age from the release timestamp, mise from the packslip
-# transparency log entry, which is always later. Equal waits let Renovate pin a
-# version mise still refuses, so Renovate has to wait strictly longer.
-assert to_days(renovate["minimumReleaseAge"]) > to_days(mise_age_match.group("value")), (
-    "Renovate minimumReleaseAge must be strictly longer than the mise "
-    "minimum_release_age setting"
-)
 PYTHON
 
     [ "${status}" -eq 0 ]

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -100,7 +100,6 @@ assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
 assert agent_rule["matchManagers"] == ["mise"]
 assert agent_rule["matchDepNames"] == expected_dep_names
-assert "fnox" not in agent_rule["matchDepNames"]
 assert agent_rule["minimumReleaseAge"] == "0 days"
 assert re.findall(r'"([^"]+)"', excludes_match.group("body")) == expected_dep_names, (
     "minimum_release_age_excludes must mirror the day-zero group, or mise refuses to "

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -49,8 +49,7 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-# fnox is absent on purpose: it stores credentials, so it keeps the wait. mise.bats
-# covers that mise still pins it.
+# fnox is excluded on purpose; see the mise config. mise.bats covers that it stays pinned.
 expected_dep_names = [
     "herdr",
     "aqua:anthropics/claude-code",

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -112,6 +112,43 @@ PYTHON
     [ "${status}" -eq 0 ]
 }
 
+@test "[common] mise exempts day-zero agent tooling from the release-age policy" {
+    run python3 - "${RENOVATE_CONFIG_PATH}" "${MISE_CONFIG_PATH}" << 'PYTHON'
+import json
+import re
+import sys
+from pathlib import Path
+
+renovate_path, mise_path = map(Path, sys.argv[1:])
+renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
+mise_text = mise_path.read_text(encoding="utf-8")
+
+agent_rule = next(
+    rule
+    for rule in renovate["packageRules"]
+    if rule.get("groupName") == "agent tooling"
+)
+
+excludes_match = re.search(
+    r"^minimum_release_age_excludes\s*=\s*\[(?P<body>[^\]]*)\]",
+    mise_text,
+    re.MULTILINE,
+)
+
+assert re.search(r'^minimum_release_age\s*=\s*"', mise_text, re.MULTILINE)
+assert agent_rule["minimumReleaseAge"] == "0 days"
+assert excludes_match is not None
+assert re.findall(r'"([^"]+)"', excludes_match.group("body")) == (
+    agent_rule["matchDepNames"]
+), (
+    "minimum_release_age_excludes must mirror the Renovate agent tooling group; "
+    "otherwise mise refuses to install the day-zero versions Renovate pins"
+)
+PYTHON
+
+    [ "${status}" -eq 0 ]
+}
+
 @test "[common] Renovate does not raise the minimum compatible mise version" {
     run python3 - "${RENOVATE_CONFIG_PATH}" << 'PYTHON'
 import json

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -67,7 +67,6 @@ configured_dep_names = {
     )
     if match.group("name").split("/")[-1] in logical_names
 }
-configured_agents = {name.split("/")[-1]: name for name in configured_dep_names}
 
 rules = renovate["packageRules"]
 agent_rule_index, agent_rule = next(
@@ -93,11 +92,7 @@ excludes_match = re.search(
     re.MULTILINE,
 )
 
-assert excludes_match is not None
 assert configured_dep_names == set(expected_dep_names)
-assert configured_agents["claude-code"].startswith("aqua:")
-assert configured_agents["antigravity-cli"].startswith("aqua:")
-assert configured_agents["codex"].startswith("aqua:")
 assert agent_rule["matchManagers"] == ["mise"]
 assert agent_rule["matchDepNames"] == expected_dep_names
 assert agent_rule["minimumReleaseAge"] == "0 days"

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -49,25 +49,16 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-# Agent tooling mise pins, and the identifier each one is pinned under. Renovate reads
-# these names from the mise config, so a backend-prefixed rewrite would silently change
-# what its rules match.
-tracked_dep_names = [
-    "fnox",
+# fnox is deliberately absent: it stores credentials, so it keeps the cooling-off period
+# instead of taking the day-zero updates the rest of the agent tooling gets. mise.bats
+# covers that mise still pins it.
+expected_dep_names = [
     "herdr",
     "aqua:anthropics/claude-code",
     "aqua:google-antigravity/antigravity-cli",
     "aqua:openai/codex",
 ]
-# The subset that skips the cooling-off period. fnox stores credentials, so it keeps the
-# wait instead of taking the day-zero updates the rest of the agent tooling gets.
-day_zero_dep_names = [
-    "herdr",
-    "aqua:anthropics/claude-code",
-    "aqua:google-antigravity/antigravity-cli",
-    "aqua:openai/codex",
-]
-logical_names = {name.split("/")[-1] for name in tracked_dep_names}
+logical_names = {name.split("/")[-1] for name in expected_dep_names}
 configured_dep_names = {
     match.group("name")
     for match in re.finditer(
@@ -98,13 +89,12 @@ codex_rule = next(
     and "extractVersion" in rule
 )
 
-assert configured_dep_names == set(tracked_dep_names)
-assert configured_agents["fnox"] == "fnox"
+assert configured_dep_names == set(expected_dep_names)
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
 assert agent_rule["matchManagers"] == ["mise"]
-assert agent_rule["matchDepNames"] == day_zero_dep_names
+assert agent_rule["matchDepNames"] == expected_dep_names
 assert "fnox" not in agent_rule["matchDepNames"]
 assert agent_rule["minimumReleaseAge"] == "0 days"
 assert mise_rule_index < agent_rule_index

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -49,14 +49,22 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-expected_dep_names = [
+tracked_dep_names = [
     "fnox",
     "herdr",
     "aqua:anthropics/claude-code",
     "aqua:google-antigravity/antigravity-cli",
     "aqua:openai/codex",
 ]
-logical_names = {name.split("/")[-1] for name in expected_dep_names}
+# fnox stores credentials, so it keeps the cooling-off period instead of taking the
+# day-zero updates the rest of the agent tooling gets.
+day_zero_dep_names = [
+    "herdr",
+    "aqua:anthropics/claude-code",
+    "aqua:google-antigravity/antigravity-cli",
+    "aqua:openai/codex",
+]
+logical_names = {name.split("/")[-1] for name in tracked_dep_names}
 configured_dep_names = {
     match.group("name")
     for match in re.finditer(
@@ -87,13 +95,14 @@ codex_rule = next(
     and "extractVersion" in rule
 )
 
-assert configured_dep_names == set(expected_dep_names)
+assert configured_dep_names == set(tracked_dep_names)
 assert configured_agents["fnox"] == "fnox"
 assert configured_agents["claude-code"].startswith("aqua:")
 assert configured_agents["antigravity-cli"].startswith("aqua:")
 assert configured_agents["codex"].startswith("aqua:")
 assert agent_rule["matchManagers"] == ["mise"]
-assert agent_rule["matchDepNames"] == expected_dep_names
+assert agent_rule["matchDepNames"] == day_zero_dep_names
+assert "fnox" not in agent_rule["matchDepNames"]
 assert agent_rule["minimumReleaseAge"] == "0 days"
 assert mise_rule_index < agent_rule_index
 
@@ -134,15 +143,36 @@ excludes_match = re.search(
     mise_text,
     re.MULTILINE,
 )
+mise_age_match = re.search(
+    r'^minimum_release_age\s*=\s*"(?P<value>[^"]+)"',
+    mise_text,
+    re.MULTILINE,
+)
 
-assert re.search(r'^minimum_release_age\s*=\s*"', mise_text, re.MULTILINE)
+
+def to_days(value):
+    match = re.fullmatch(r"(?P<count>\d+)\s*(?P<unit>d|days?|w|weeks?)", value.strip())
+    assert match is not None, f"unsupported release-age duration: {value!r}"
+    count = int(match.group("count"))
+    return count * 7 if match.group("unit").startswith("w") else count
+
+
 assert agent_rule["minimumReleaseAge"] == "0 days"
 assert excludes_match is not None
+assert mise_age_match is not None
 assert re.findall(r'"([^"]+)"', excludes_match.group("body")) == (
     agent_rule["matchDepNames"]
 ), (
     "minimum_release_age_excludes must mirror the Renovate agent tooling group; "
     "otherwise mise refuses to install the day-zero versions Renovate pins"
+)
+
+# Renovate measures age from the release timestamp, mise from the packslip
+# transparency log entry, which is always later. Equal waits let Renovate pin a
+# version mise still refuses, so Renovate has to wait strictly longer.
+assert to_days(renovate["minimumReleaseAge"]) > to_days(mise_age_match.group("value")), (
+    "Renovate minimumReleaseAge must be strictly longer than the mise "
+    "minimum_release_age setting"
 )
 PYTHON
 

--- a/tests/install/common/renovate.bats
+++ b/tests/install/common/renovate.bats
@@ -49,7 +49,6 @@ renovate = json.loads(renovate_path.read_text(encoding="utf-8"))
 mise_text = mise_path.read_text(encoding="utf-8")
 renovate_text = json.dumps(renovate)
 
-# fnox is excluded on purpose; see the mise config. mise.bats covers that it stays pinned.
 expected_dep_names = [
     "herdr",
     "aqua:anthropics/claude-code",


### PR DESCRIPTION
## Why

`chezmoi apply` started failing on the mise tool install script:

```
mise ERROR Failed to install packslip:github.com/jdx/fnox@1.35.1: packslip release was
recorded by the transparency log at 2026-09-05T19:21:45Z, after the allowed cutoff
2026-09-05T04:07:20.007429Z; refusing to bypass minimum_release_age
chezmoi: .chezmoiscripts/common/20-install-mise-tools.sh: exit status 1
```

Two configuration files disagreed about how long to wait before adopting a release:

- `.github/renovate.json` put `fnox` in the `agent tooling` package rule, which carries `minimumReleaseAge: "0 days"`. Renovate therefore pinned `fnox` 1.35.1 on its release day.
- `home/dot_mise/config.toml` sets `minimum_release_age = "7d"` and did not exempt `fnox`, so mise refused to install exactly the version Renovate had just pinned.

The obvious fix is to exempt `fnox` in mise. That is the wrong direction. `fnox` is the credential store, and `minimum_release_age` defends against a legitimately signed malicious release from a compromised maintainer account — precisely the case that packslip's signature and transparency-log verification cannot detect. The delay and the signature check are complementary, not interchangeable. This repository already applies the full wait to `aqua:FiloSottile/age`, the crypto protecting the same secrets; day-zero for the store but a week for its crypto has no coherent threat model.

Day-zero was never a recorded choice for `fnox`. https://github.com/shunk031/dotfiles/pull/609 describes its Renovate change only as "Add `fnox` to the existing Renovate coverage for agent tooling" and never mentions release age — `minimumReleaseAge: "0 days"` came along because an existing group was reused.

## What Changed

**`.github/renovate.json`** — `fnox` is removed from the `agent tooling` group's `matchDepNames`, leaving `herdr` plus the three `aqua:` entries. `herdr` deliberately stays day-zero. `fnox` remains fully covered by Renovate through the existing `mise tools` group at the root wait, which is unchanged at `"7 days"`.

**`home/dot_mise/config.toml`** — the `fnox` pin is reverted from `1.35.1` to `1.34.1`. This is the immediate unblock: 1.34.1 sits below the `min_version = "1.35.1"` gate on the packslip backend in mise's `registry/fnox.toml`, so it resolves through `github:jdx/fnox` and installs right away in every environment. This is an unblock, not a lasting pin: `1.35.1` clears mise's 7-day cutoff at 2026-09-12T19:21:45Z, seven days after its transparency-log entry, and Renovate re-proposes it once it clears the same wait. `minimum_release_age = "7d"` is unchanged, and `herdr` joins `minimum_release_age_excludes` so the list mirrors the day-zero group.

**`tests/install/common/renovate.bats`** — one regression guard, folded into the existing `[common] Renovate tracks the configured agent dependencies` rather than added as a separate test: `minimum_release_age_excludes` must mirror the day-zero group, since anything Renovate pins on release day that mise does not exempt reproduces the failure above. Putting `fnox` back in the day-zero group is caught by the same test's existing equality assertion, since its expected list no longer contains `fnox`.

At the reviewer's request, three pre-existing assertions were removed from that test alongside this change, together with the `configured_agents` dict that had no reader left once they were gone. Each checked that a name starts with `aqua:`, which the preceding equality against the literal `expected_dep_names` already fixes, so no input could make them fail. A fourth, `assert excludes_match is not None`, only preempted the `AttributeError` raised two lines later, and produced a bare `AssertionError` where the `AttributeError` names the problem. The test now carries 13 assertions across 21 in the file.

No `min_version` bump is needed. `minimum_release_age_excludes` already works at the pinned floor `2026.8.15`, and the environment that hit the failure runs `2026.9.4`, where `registry/fnox.toml` routes `fnox` 1.35.1 and newer through packslip.

## Validation

The four Python assertion bodies in `tests/install/common/renovate.bats` were extracted and run standalone: all pass.

The guard was confirmed non-vacuous against mutated copies of the configs. Three reversals are each caught, and the assertion that fires was recorded in every case. Putting `fnox` back in the day-zero group alone, and adding `fnox` to both the group and `minimum_release_age_excludes`, both fail on `assert agent_rule["matchDepNames"] == expected_dep_names`. Dropping `herdr` from the excludes list fails on the mirror assertion, with "minimum_release_age_excludes must mirror the day-zero group, or mise refuses to install what Renovate pins".

The removals were checked rather than assumed. Deleting `minimum_release_age_excludes` from the config still fails the test after the removal, with `AttributeError: 'NoneType' object has no attribute 'group'`. An AST scan over all four test bodies reports no unused assigned names remaining.

Check that the Renovate config parses and that `fnox` has left the day-zero group.

```shell
python3 -c "import json, pathlib; c = json.loads(pathlib.Path('.github/renovate.json').read_text()); print(c['minimumReleaseAge']); print(next(r['matchDepNames'] for r in c['packageRules'] if r.get('groupName') == 'agent tooling'))"
```

Check that the mise config parses with the reverted pin and the mirrored excludes list.

```shell
python3 -c "import tomllib, pathlib; c = tomllib.loads(pathlib.Path('home/dot_mise/config.toml').read_text()); print(c['tools']['fnox'], c['settings']['minimum_release_age']); print(c['settings']['minimum_release_age_excludes'])"
```

Run the repository pre-commit hooks over all three changed files.

```shell
prek run --files .github/renovate.json home/dot_mise/config.toml tests/install/common/renovate.bats
```

`bats` was not run locally: repository policy forbids it, so the full suite runs in GitHub Actions on this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


